### PR TITLE
Rework assign operations

### DIFF
--- a/tests/interpreter/cases/assign/basic.yaml
+++ b/tests/interpreter/cases/assign/basic.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: basic
+    data: {}
+    modules:
+      - |
+        package test
+
+        default x = 5
+
+        y := "string"
+
+        assign_rule_forward = v {
+          v = [1, 2, 3]
+        }
+
+        assign_rule_reverse = w {
+          {9, 8, 7} = w
+        }
+
+        assign_rule_shadowing = x {
+          x := 10
+        }
+
+        assign_comparison_true {
+          x = 100
+        }
+
+        assign_comparison_reverse_true {
+          100 = x
+        }
+
+        assign_comparison_false {
+          x = 20
+        }
+  
+        assign_comparison_reverse_false {
+          20 = x
+        }
+
+        x = 100
+
+    query: data.test
+    want_result:
+      x: 100
+      y: "string"
+      assign_rule_forward: [1, 2, 3]
+      assign_rule_reverse:
+        set!: [9, 8, 7]
+      assign_rule_shadowing: 10
+      assign_comparison_true: true
+      assign_comparison_reverse_true: true

--- a/tests/interpreter/cases/default/basic.yaml
+++ b/tests/interpreter/cases/default/basic.yaml
@@ -24,6 +24,14 @@ cases:
           x == 4
         }
 
+        default y = 10
+
+        z = y {
+          y
+        }
+
+        y = 20
+
         default d = "has_default"
 
         default object["key"] = "string"
@@ -51,6 +59,8 @@ cases:
       x: 5
       a: -6
       b: -6
+      y: 20
+      z: 20
       c: "has_default"
       d: "has_default"
       object:


### PR DESCRIPTION
Details of the PR
- Support "var = value", "value = var", and "var = var"
- Fall back the '=' to comparison when both operators are defined
- Correctly support variable shadowing with "var := value"

Also, remove the unused Variable struct

Signed-off-by: Ming-Wei Shih <mishih@microsoft.com>