### PR TITLE
Support build on non Linux platforms

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,14 @@
 [build]
-target = "x86_64-unknown-linux-musl"
+#target = "x86_64-unknown-linux-musl"
 
 # Flags to enable code-coverage for all builds.
 # These can be removed later.
-rustflags = ["-Cinstrument-coverage"]
+#rustflags = ["-Cinstrument-coverage"]
 incremental = true
 
 [env]
 # Name of coverage instrumentation log file.
 LLVM_PROFILE_FILE="target/cargo-test-%p-%m.profraw"
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Cinstrument-coverage"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,3 +28,7 @@ jobs:
       run: cargo clippy --all-targets --no-deps -- -Dwarnings
     - name: Run tests
       run: cargo test --verbose
+    - name: Build (MUSL)
+      run: cargo build --verbose --all-targets --target x86_64-unknown-linux-musl
+    - name: Run tests (MUSL)
+      run: cargo test --verbose --target x86_64-unknown-linux-musl

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -32,7 +32,7 @@ echo "Running tests"
 cargo test
 
 # Generate html
-grcov target/ --binary-path ./target/x86_64-unknown-linux-musl/debug/deps -s src/ -t html \
+grcov target/ --binary-path ./target/debug/deps -s src/ -t html \
 --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html
 
 if [ "$1" == "--show" ]; then
@@ -42,7 +42,7 @@ if [ "$1" == "--show" ]; then
 fi
 
 # Generate markdown
-grcov target/ --binary-path ./target/x86_64-unknown-linux-musl/debug/deps -s src/ -t markdown \
+grcov target/ --binary-path ./target/debug/deps -s src/ -t markdown \
 --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/markdown
 
 cat target/coverage/markdown

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -6,7 +6,7 @@ set -eo pipefail
 
 if [ -f Cargo.toml ]; then
     # Ensure that all targets can be built.
-    scripts/coverage --no-run
+    cargo build --all-targets
 
     #Ensure that code is correctly formatted.
     cargo fmt --check || (echo "Run cargo fmt to fix formatting" && exit 1)

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -11,5 +11,7 @@ if [ -f Cargo.toml ]; then
 
    # Ensure that all tests pass
    # Also generate coverage information.
-   scripts/coverage
+   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+       scripts/coverage
+   fi
 fi


### PR DESCRIPTION
cargo config
1. MUSL is no longer the default target. This allows building on Mac and Windows.
2. On Linux, code coverage compiler options are supplied by default.

pre-commit, pre-push
- Coverage is turned on only on Linux
- clippy is run on all platforms

github
- MUSL build is tested to ensure that stand alone executables can be created

fixes #9 