### PR TITLE
Ensure that scopes are cleaned up correctly upon error.

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -39,7 +39,6 @@ pub enum SortResult {
 }
 
 pub fn schedule<'a>(infos: &mut [StmtInfo<'a>]) -> Result<SortResult> {
-    println!("infos: {infos:?}");
     let num_statements = infos.len();
 
     // Mapping from each var to the list of statements that define it.

--- a/tests/interpreter/cases/call/or.yaml
+++ b/tests/interpreter/cases/call/or.yaml
@@ -130,10 +130,8 @@ cases:
         a2 = fcn(5)
     query: data.test
     want_result:
-      a1: 
-        set!: [hello world]
-      a2: 
-        set!: [6]
+      a1: "hello world"
+      a2: 6
 
   - note: or-all-error
     data: {}


### PR DESCRIPTION
When evaluating rules, upon error the last pushed scope wasn't being popped from the stack of scopes. This causes incorrect behavior when there are multiple definitions for the same rule name.

The fix is to make sure that the scopes are popped manually upon encountering errors.

Once the interpreter logic is locked down, then we need to clean up scope management using Drop functions so that the cleanup happens even during short circuited return.