### PR TITLE
negation of an undefined value should return true

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -760,7 +760,10 @@ impl<'source> Interpreter<'source> {
                 value,
                 collection,
             } => self.eval_some_in(span, key, value, collection, stmts)?,
-            Literal::NotExpr { expr, .. } => matches!(self.eval_expr(expr)?, Value::Bool(false)),
+            Literal::NotExpr { expr, .. } => {
+                // https://github.com/open-policy-agent/opa/issues/1622#issuecomment-520547385
+                matches!(self.eval_expr(expr)?, Value::Bool(false) | Value::Undefined)
+            }
             Literal::Every {
                 span,
                 key,

--- a/tests/interpreter/cases/negation/tests.yaml
+++ b/tests/interpreter/cases/negation/tests.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: not-false
+    data: {}
+    modules:
+      - |
+        package test
+
+        x[a] {
+          not 1 == 2
+          a := "hello"
+        }
+    query: data.test
+    want_result:
+      x: 
+        set!: [hello]
+
+  - note: not-undefined
+    data: {}
+    modules:
+      - |
+        package test
+
+        myequal(t) {
+          t == 2
+        }
+
+        x[a] {
+          not myequal(1)
+          a := "hello"
+        }
+    query: data.test
+    want_result:
+      x: 
+        set!: [hello]
+
+  # https://github.com/open-policy-agent/opa/issues/1877
+  - note: not-more-undefined-OPA-INCOMPATIBLE
+    data: {}
+    modules:
+      - |
+        package test
+
+        import future.keywords.if
+
+        p if false # undefined value
+
+        q1 {
+          not p # `not undefined` evaluates to true
+        }
+        
+        q2 = [p] # q2 = [undefined] = undefined
+        
+        q3 {
+          not [p] # `not undefined` evaluates to true
+        }
+
+        q4 {
+          not q3 # `not true` making it undefined
+        }
+    query: data.test
+    want_result:
+      q1: true
+      q3: true


### PR DESCRIPTION
When I read this discussion https://github.com/open-policy-agent/opa/issues/1622#issuecomment-520547385
It's not clear for me what should be the value of a negated undefined value

But currently, on rego playground, `not undefined` returns `true`