### PR TITLE
Engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.66"
 ordered-float = "3.4.0"
 serde = {version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
+serde_yaml = "0.9.16"
 log = "0.4.17"
 env_logger="0.10.0"
 lazy_static = "1.4.0"
@@ -18,7 +19,6 @@ data-encoding = "2.4.0"
 
 [dev-dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
-serde_yaml = "0.9.16"
 test-generator = "0.3.1"
 walkdir = "2.3.2"
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -35,115 +35,115 @@ pub enum AssignOp {
 }
 
 #[derive(Debug, Clone)]
-pub enum Expr<'source> {
+pub enum Expr {
     // Simple items that only have a span as content.
-    String(Span<'source>),
-    RawString(Span<'source>),
-    Number(Span<'source>),
-    True(Span<'source>),
-    False(Span<'source>),
-    Null(Span<'source>),
-    Var(Span<'source>),
+    String(Span),
+    RawString(Span),
+    Number(Span),
+    True(Span),
+    False(Span),
+    Null(Span),
+    Var(Span),
 
     // array
     Array {
-        span: Span<'source>,
-        items: Vec<Expr<'source>>,
+        span: Span,
+        items: Vec<Expr>,
     },
 
     // set
     Set {
-        span: Span<'source>,
-        items: Vec<Expr<'source>>,
+        span: Span,
+        items: Vec<Expr>,
     },
 
     Object {
-        span: Span<'source>,
-        fields: Vec<(Span<'source>, Expr<'source>, Expr<'source>)>,
+        span: Span,
+        fields: Vec<(Span, Expr, Expr)>,
     },
 
     // Comprehensions
     ArrayCompr {
-        span: Span<'source>,
-        term: Box<Expr<'source>>,
-        query: Query<'source>,
+        span: Span,
+        term: Box<Expr>,
+        query: Query,
     },
 
     SetCompr {
-        span: Span<'source>,
-        term: Box<Expr<'source>>,
-        query: Query<'source>,
+        span: Span,
+        term: Box<Expr>,
+        query: Query,
     },
 
     ObjectCompr {
-        span: Span<'source>,
-        key: Box<Expr<'source>>,
-        value: Box<Expr<'source>>,
-        query: Query<'source>,
+        span: Span,
+        key: Box<Expr>,
+        value: Box<Expr>,
+        query: Query,
     },
 
     Call {
-        span: Span<'source>,
-        fcn: Box<Expr<'source>>,
-        params: Vec<Expr<'source>>,
+        span: Span,
+        fcn: Box<Expr>,
+        params: Vec<Expr>,
     },
 
     UnaryExpr {
-        span: Span<'source>,
-        expr: Box<Expr<'source>>,
+        span: Span,
+        expr: Box<Expr>,
     },
 
     // ref
     RefDot {
-        span: Span<'source>,
-        refr: Box<Expr<'source>>,
-        field: Span<'source>,
+        span: Span,
+        refr: Box<Expr>,
+        field: Span,
     },
 
     RefBrack {
-        span: Span<'source>,
-        refr: Box<Expr<'source>>,
-        index: Box<Expr<'source>>,
+        span: Span,
+        refr: Box<Expr>,
+        index: Box<Expr>,
     },
 
     // Infix expressions
     BinExpr {
-        span: Span<'source>,
+        span: Span,
         op: BinOp,
-        lhs: Box<Expr<'source>>,
-        rhs: Box<Expr<'source>>,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
     },
     BoolExpr {
-        span: Span<'source>,
+        span: Span,
         op: BoolOp,
-        lhs: Box<Expr<'source>>,
-        rhs: Box<Expr<'source>>,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
     },
 
     ArithExpr {
-        span: Span<'source>,
+        span: Span,
         op: ArithOp,
-        lhs: Box<Expr<'source>>,
-        rhs: Box<Expr<'source>>,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
     },
 
     AssignExpr {
-        span: Span<'source>,
+        span: Span,
         op: AssignOp,
-        lhs: Box<Expr<'source>>,
-        rhs: Box<Expr<'source>>,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
     },
 
     Membership {
-        span: Span<'source>,
-        key: Box<Option<Expr<'source>>>,
-        value: Box<Expr<'source>>,
-        collection: Box<Expr<'source>>,
+        span: Span,
+        key: Box<Option<Expr>>,
+        value: Box<Expr>,
+        collection: Box<Expr>,
     },
 }
 
-impl<'source> Expr<'source> {
-    pub fn span(&self) -> &Span<'source> {
+impl Expr {
+    pub fn span(&self) -> &Span {
         use Expr::*;
         match self {
             String(s) | RawString(s) | Number(s) | True(s) | False(s) | Null(s) | Var(s) => s,
@@ -167,121 +167,121 @@ impl<'source> Expr<'source> {
 }
 
 #[derive(Debug, Clone)]
-pub enum Literal<'source> {
+pub enum Literal {
     SomeVars {
-        span: Span<'source>,
-        vars: Vec<Span<'source>>,
+        span: Span,
+        vars: Vec<Span>,
     },
     SomeIn {
-        span: Span<'source>,
-        key: Option<Expr<'source>>,
-        value: Expr<'source>,
-        collection: Expr<'source>,
+        span: Span,
+        key: Option<Expr>,
+        value: Expr,
+        collection: Expr,
     },
     Expr {
-        span: Span<'source>,
-        expr: Expr<'source>,
+        span: Span,
+        expr: Expr,
     },
     NotExpr {
-        span: Span<'source>,
-        expr: Expr<'source>,
+        span: Span,
+        expr: Expr,
     },
     Every {
-        span: Span<'source>,
-        key: Option<Span<'source>>,
-        value: Span<'source>,
-        domain: Expr<'source>,
-        query: Query<'source>,
+        span: Span,
+        key: Option<Span>,
+        value: Span,
+        domain: Expr,
+        query: Query,
     },
 }
 
 #[derive(Debug, Clone)]
-pub struct WithModifier<'source> {
-    pub span: Span<'source>,
-    pub refr: Expr<'source>,
-    pub r#as: Expr<'source>,
+pub struct WithModifier {
+    pub span: Span,
+    pub refr: Expr,
+    pub r#as: Expr,
 }
 
 #[derive(Debug, Clone)]
-pub struct LiteralStmt<'source> {
-    pub span: Span<'source>,
-    pub literal: Literal<'source>,
-    pub with_mods: Vec<WithModifier<'source>>,
+pub struct LiteralStmt {
+    pub span: Span,
+    pub literal: Literal,
+    pub with_mods: Vec<WithModifier>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Query<'source> {
-    pub span: Span<'source>,
-    pub stmts: Vec<LiteralStmt<'source>>,
+pub struct Query {
+    pub span: Span,
+    pub stmts: Vec<LiteralStmt>,
 }
 
 #[derive(Debug, Clone)]
-pub struct RuleAssign<'source> {
-    pub span: Span<'source>,
+pub struct RuleAssign {
+    pub span: Span,
     pub op: AssignOp,
-    pub value: Expr<'source>,
+    pub value: Expr,
 }
 
 #[derive(Debug, Clone)]
-pub struct RuleBody<'source> {
-    pub span: Span<'source>,
-    pub assign: Option<RuleAssign<'source>>,
-    pub query: Query<'source>,
+pub struct RuleBody {
+    pub span: Span,
+    pub assign: Option<RuleAssign>,
+    pub query: Query,
 }
 
 #[derive(Debug, Clone)]
-pub enum RuleHead<'source> {
+pub enum RuleHead {
     Compr {
-        span: Span<'source>,
-        refr: Expr<'source>,
-        assign: Option<RuleAssign<'source>>,
+        span: Span,
+        refr: Expr,
+        assign: Option<RuleAssign>,
     },
     Set {
-        span: Span<'source>,
-        refr: Expr<'source>,
-        key: Option<Expr<'source>>,
+        span: Span,
+        refr: Expr,
+        key: Option<Expr>,
     },
     Func {
-        span: Span<'source>,
-        refr: Expr<'source>,
-        args: Vec<Expr<'source>>,
-        assign: Option<RuleAssign<'source>>,
+        span: Span,
+        refr: Expr,
+        args: Vec<Expr>,
+        assign: Option<RuleAssign>,
     },
 }
 
 #[derive(Debug, Clone)]
-pub enum Rule<'source> {
+pub enum Rule {
     Spec {
-        span: Span<'source>,
-        head: RuleHead<'source>,
-        bodies: Vec<RuleBody<'source>>,
+        span: Span,
+        head: RuleHead,
+        bodies: Vec<RuleBody>,
     },
     Default {
-        span: Span<'source>,
-        refr: Expr<'source>,
+        span: Span,
+        refr: Expr,
         op: AssignOp,
-        value: Expr<'source>,
+        value: Expr,
     },
 }
 
 #[derive(Debug, Clone)]
-pub struct Package<'source> {
-    pub span: Span<'source>,
-    pub refr: Expr<'source>,
+pub struct Package {
+    pub span: Span,
+    pub refr: Expr,
 }
 
 #[derive(Debug, Clone)]
-pub struct Import<'source> {
-    pub span: Span<'source>,
-    pub refr: Expr<'source>,
-    pub r#as: Option<Span<'source>>,
+pub struct Import {
+    pub span: Span,
+    pub refr: Expr,
+    pub r#as: Option<Span>,
 }
 
 #[derive(Debug, Clone)]
-pub struct Module<'source> {
-    pub package: Package<'source>,
-    pub imports: Vec<Import<'source>>,
-    pub policy: Vec<Rule<'source>>,
+pub struct Module {
+    pub package: Package,
+    pub imports: Vec<Import>,
+    pub policy: Vec<Rule>,
 }
 
 #[derive(Debug, Clone)]
@@ -315,7 +315,6 @@ impl<'a, T> PartialOrd for Ref<'a, T> {
 
 impl<'a, T> Ord for Ref<'a, T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        //std::ptr::from_ref(self.r).partial_cmp(std::ptr::from_ref(other.r))
         (self.r as *const T).cmp(&(other.r as *const T))
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ast::*;
+use crate::interpreter::*;
+use crate::lexer::*;
+use crate::parser::*;
+use crate::scheduler::*;
+use crate::value::*;
+
+use anyhow::Result;
+
+#[derive(Clone)]
+pub struct Engine {
+    modules: Vec<std::rc::Rc<Module>>,
+    input: Value,
+    data: Value,
+}
+
+impl Default for Engine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Engine {
+    pub fn new() -> Self {
+        Self {
+            modules: vec![],
+            input: Value::new_object(),
+            data: Value::new_object(),
+        }
+    }
+
+    pub fn add_policy(&mut self, path: String, rego: String) -> Result<()> {
+        let source = Source::new(path, rego);
+        let mut parser = Parser::new(&source)?;
+        self.modules.push(std::rc::Rc::new(parser.parse()?));
+        Ok(())
+    }
+
+    pub fn add_policy_from_file(&mut self, path: String) -> Result<()> {
+        let source = Source::from_file(path)?;
+        let mut parser = Parser::new(&source)?;
+        self.modules.push(std::rc::Rc::new(parser.parse()?));
+        Ok(())
+    }
+
+    pub fn set_input(&mut self, input: Value) {
+        self.input = input;
+    }
+
+    pub fn clear_data(&mut self) {
+        self.data = Value::new_object();
+    }
+
+    pub fn add_data(&mut self, data: Value) -> Result<()> {
+        self.data.merge(data)
+    }
+
+    pub fn eval_query(&self, query: String, enable_tracing: bool) -> Result<QueryResults> {
+        let modules_ref: Vec<&Module> = self.modules.iter().map(|m| &**m).collect();
+
+        // Analyze the modules and determine how statements must be scheduled.
+        let analyzer = Analyzer::new();
+        let schedule = analyzer.analyze(&modules_ref)?;
+
+        // Create interpreter object.
+        let mut interpreter = Interpreter::new(&modules_ref)?;
+
+        // Evaluate all the modules.
+        interpreter.eval(
+            &Some(self.data.clone()),
+            &Some(self.input.clone()),
+            false,
+            Some(schedule),
+        )?;
+
+        // Parse the query.
+        let query_len = query.len();
+        let query_source = Source::new("<query.rego>".to_string(), query);
+        let query_span = Span {
+            source: query_source.clone(),
+            line: 1,
+            col: 1,
+            start: 0,
+            end: query_len as u16,
+        };
+        let mut parser = Parser::new(&query_source)?;
+        let query_node = parser.parse_query(query_span, "")?;
+        let query_schedule = Analyzer::new().analyze_query_snippet(&modules_ref, &query_node)?;
+
+        let results = interpreter.eval_user_query(&query_node, &query_schedule, enable_tracing)?;
+        Ok(results)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod ast;
 pub mod builtins;
+pub mod engine;
 pub mod interpreter;
 pub mod lexer;
 pub mod parser;
@@ -11,6 +12,7 @@ mod utils;
 pub mod value;
 
 pub use ast::*;
+pub use engine::*;
 pub use interpreter::*;
 pub use lexer::*;
 pub use parser::*;

--- a/src/value.rs
+++ b/src/value.rs
@@ -165,6 +165,24 @@ impl Value {
     pub fn to_json_str(&self) -> Result<String> {
         Ok(serde_json::to_string_pretty(self)?)
     }
+
+    pub fn from_json_file(path: &String) -> Result<Value> {
+        match std::fs::read_to_string(path) {
+            Ok(c) => Self::from_json_str(c.as_str()),
+            Err(e) => bail!("Failed to read {path}. {e}"),
+        }
+    }
+
+    pub fn from_yaml_str(yaml: &str) -> Result<Value> {
+        Ok(serde_yaml::from_str(yaml)?)
+    }
+
+    pub fn from_yaml_file(path: &String) -> Result<Value> {
+        match std::fs::read_to_string(path) {
+            Ok(c) => Self::from_yaml_str(c.as_str()),
+            Err(e) => bail!("Failed to read {path}. {e}"),
+        }
+    }
 }
 
 impl Value {

--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -210,11 +210,7 @@ pub fn eval_file_first_rule(
 
     for (idx, file) in files.iter().enumerate() {
         let contents = regos[idx].as_str();
-        sources.push(Source {
-            file,
-            contents,
-            lines: contents.split('\n').collect(),
-        });
+        sources.push(Source::new(file.to_string(), contents.to_string()));
     }
 
     for source in &sources {
@@ -226,13 +222,9 @@ pub fn eval_file_first_rule(
         modules_ref.push(m);
     }
 
-    let query_source = regorus::Source {
-        file: "<query.rego>",
-        contents: query,
-        lines: query.split('\n').collect(),
-    };
+    let query_source = regorus::Source::new("<query.rego>".to_string(), query.to_string());
     let query_span = regorus::Span {
-        source: &query_source,
+        source: query_source.clone(),
         line: 1,
         col: 1,
         start: 0,
@@ -303,11 +295,7 @@ pub fn eval_file(
 
     for (idx, file) in files.iter().enumerate() {
         let contents = regos[idx].as_str();
-        sources.push(Source {
-            file,
-            contents,
-            lines: contents.split('\n').collect(),
-        });
+        sources.push(Source::new(file.to_string(), contents.to_string()));
     }
 
     for source in &sources {
@@ -319,13 +307,9 @@ pub fn eval_file(
         modules_ref.push(m);
     }
 
-    let query_source = regorus::Source {
-        file: "<query.rego>",
-        contents: query,
-        lines: query.split('\n').collect(),
-    };
+    let query_source = regorus::Source::new("<query.rego".to_string(), query.to_string());
     let query_span = regorus::Span {
-        source: &query_source,
+        source: query_source.clone(),
         line: 1,
         col: 1,
         start: 0,

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -28,7 +28,7 @@ fn match_span(s: &Span, v: &Value) -> Result<()> {
     match &v {
         Value::String(vs) => {
             my_assert_eq!(
-                s.text(),
+                *s.text(),
                 vs,
                 "{}",
                 s.source
@@ -37,7 +37,7 @@ fn match_span(s: &Span, v: &Value) -> Result<()> {
         }
         _ => {
             my_assert_eq!(
-                s.text(),
+                *s.text(),
                 serde_json::to_string_pretty(v)?,
                 "{}",
                 s.source
@@ -629,11 +629,7 @@ fn yaml_test_impl(file: &str) -> Result<()> {
 
     for case in &test.cases {
         print!("\ncase {} ", case.note);
-        let source = Source {
-            file: "case.rego",
-            contents: case.rego.as_str(),
-            lines: case.rego.split('\n').collect(),
-        };
+        let source = Source::new("case.rego".to_string(), case.rego.clone());
         let mut parser = Parser::new(&source)?;
         match parser.parse() {
             Ok(module) => {

--- a/tests/scheduler/analyzer/mod.rs
+++ b/tests/scheduler/analyzer/mod.rs
@@ -32,20 +32,10 @@ fn to_string_set(s: &BTreeSet<&str>) -> BTreeSet<String> {
 }
 
 fn analyze_file(regos: &[String], expected_scopes: &[Scope]) -> Result<()> {
-    let mut files = vec![];
     let mut sources = vec![];
     let mut modules = vec![];
     for (idx, _) in regos.iter().enumerate() {
-        files.push(format!("rego_{idx}"));
-    }
-
-    for (idx, file) in files.iter().enumerate() {
-        let contents = regos[idx].as_str();
-        sources.push(Source {
-            file,
-            contents,
-            lines: contents.split('\n').collect(),
-        });
+        sources.push(Source::new(format!("rego_{idx}"), regos[idx].clone()));
     }
 
     for source in &sources {


### PR DESCRIPTION
- Avoid lifetime parameter for Source, Span. Use Rc instead.
- Engine for simplified API

fixes #36 