### PR TITLE
Special cases of refs to data

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -366,15 +366,6 @@ fn gather_vars<'a>(
     gather_loop_vars(expr, parent_scopes, scope)
 }
 
-fn get_rule_prefix(expr: &Expr) -> Result<&str> {
-    match expr {
-        Expr::Var(v) => Ok(*v.text()),
-        Expr::RefDot { refr, .. } => get_rule_prefix(refr),
-        Expr::RefBrack { refr, .. } => get_rule_prefix(refr),
-        _ => bail!("internal error: analyzer: could not get rule prefix"),
-    }
-}
-
 pub struct Analyzer<'a> {
     packages: BTreeMap<String, Scope<'a>>,
     locals: BTreeMap<Ref<'a, Query>, Scope<'a>>,
@@ -447,7 +438,7 @@ impl<'a> Analyzer<'a> {
                             | RuleHead::Set { refr, .. }
                             | RuleHead::Func { refr, .. },
                         ..
-                    } => get_rule_prefix(refr)?,
+                    } => get_root_var(refr)?,
                 };
                 scope.locals.insert(var);
             }

--- a/src/value.rs
+++ b/src/value.rs
@@ -331,6 +331,9 @@ impl Value {
     }
 
     pub fn merge(&mut self, mut new: Value) -> Result<()> {
+        if self == &new {
+            return Ok(());
+        }
         match (self, &mut new) {
             (v @ Value::Undefined, _) => *v = new,
             (Value::Set(ref mut set), Value::Set(new)) => {
@@ -351,7 +354,7 @@ impl Value {
                     };
                 }
             }
-            _ => bail!("internal error: could not merge value"),
+            _ => bail!("error: could not merge value"),
         };
         Ok(())
     }

--- a/tests/interpreter/cases/data/tests.yaml
+++ b/tests/interpreter/cases/data/tests.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: numbers are converted to string as needed when indexing data
+    data:
+      "1": "hello"
+      "1.2": "world"
+      test:
+        "2": 100
+        "2.2": 200
+      play:
+        "2": 100
+    modules:
+      - |
+        package test
+
+        p = v {
+          q = data.play
+          # 2 is not converted to "2" since refr doesn't being with `data`
+          v = q[2]
+        }
+
+        a = [
+          data[1],
+          data[1.2],
+          data.test[2],
+          data.test[2.2]
+        ]
+    query: data.test
+    want_result:
+      "2": 100
+      "2.2": 200
+      a:
+        - "hello"
+        - "world"
+        - 100
+        - 200
+        
+  - note: overriding refs in data produces error
+    data:
+      test:
+        rule1: 0
+    modules:
+      - |
+        package test
+
+        rule1 = 6
+    query: data.test
+    error: value for rule has already been specified
+      
+  - note: rule named data
+    data:
+      test:
+        rule1: 8
+    modules:
+      - |
+        package test
+
+        data.test.rule1 = 9
+        data.test.rule1 = 9
+    query: data.test
+    want_result:
+      rule1: 8
+      data:
+        test:
+          rule1: 9
+    
+    

--- a/tests/opa/mod.rs
+++ b/tests/opa/mod.rs
@@ -133,7 +133,7 @@ fn run_opa_tests() -> Result<()> {
                         } else {
                             for (i, m) in modules.iter().enumerate() {
                                 std::fs::write(
-                                    path.join(format!("rego{n}_{i}.json")),
+                                    path.join(format!("rego{n}_{i}.rego")),
                                     m.as_bytes(),
                                 )?;
                             }


### PR DESCRIPTION
1. Numeric indices will be converted to strings for refs beginning with `data` if there is not valid numeric key
2. Error out if input document already contains value for a ref