### PR TITLE
Use Rc<str> instead of string.

### DIFF
--- a/src/builtins/encoding.rs
+++ b/src/builtins/encoding.rs
@@ -29,7 +29,7 @@ fn base64_decode(span: &Span, params: &[Ref<Expr>], args: &[Value]) -> Result<Va
     let encoded_str = ensure_string(name, &params[0], &args[0])?;
     let decoded_bytes = BASE64.decode(encoded_str.as_bytes())?;
     Ok(Value::String(
-        String::from_utf8_lossy(&decoded_bytes).to_string(),
+        String::from_utf8_lossy(&decoded_bytes).into(),
     ))
 }
 
@@ -46,7 +46,8 @@ fn yaml_marshal(span: &Span, params: &[Ref<Expr>], args: &[Value]) -> Result<Val
     ensure_args_count(span, name, params, args, 1)?;
     Ok(Value::String(
         serde_yaml::to_string(&args[0])
-            .with_context(|| span.error("could not serialize to yaml"))?,
+            .with_context(|| span.error("could not serialize to yaml"))?
+            .into(),
     ))
 }
 
@@ -70,7 +71,8 @@ fn json_marshal(span: &Span, params: &[Ref<Expr>], args: &[Value]) -> Result<Val
     ensure_args_count(span, name, params, args, 1)?;
     Ok(Value::String(
         serde_json::to_string(&args[0])
-            .with_context(|| span.error("could not serialize to json"))?,
+            .with_context(|| span.error("could not serialize to json"))?
+            .into(),
     ))
 }
 

--- a/src/builtins/types.rs
+++ b/src/builtins/types.rs
@@ -72,5 +72,5 @@ pub fn get_type(value: &Value) -> &str {
 
 pub fn type_name(span: &Span, params: &[Ref<Expr>], args: &[Value]) -> Result<Value> {
     ensure_args_count(span, "type_name", params, args, 1)?;
-    Ok(Value::String(get_type(&args[0]).to_string()))
+    Ok(Value::String(get_type(&args[0]).into()))
 }

--- a/src/builtins/units.rs
+++ b/src/builtins/units.rs
@@ -21,7 +21,7 @@ fn parse(span: &Span, params: &[Ref<Expr>], args: &[Value]) -> Result<Value> {
     let name = "units.parse";
     ensure_args_count(span, name, params, args, 1)?;
     let string = ensure_string(name, &params[0], &args[0])?;
-    let string = string.as_str();
+    let string = string.as_ref();
 
     // Remove quotes.
     let string = if string.starts_with('"') && string.ends_with('"') && string.len() >= 2 {
@@ -101,7 +101,7 @@ fn parse_bytes(span: &Span, params: &[Ref<Expr>], args: &[Value]) -> Result<Valu
     let name = "units.parse_bytes";
     ensure_args_count(span, name, params, args, 1)?;
     let string = ensure_string(name, &params[0], &args[0])?;
-    let string = string.as_str();
+    let string = string.as_ref();
 
     // Remove quotes.
     let string = if string.starts_with('"') && string.ends_with('"') && string.len() >= 2 {

--- a/src/builtins/utils.rs
+++ b/src/builtins/utils.rs
@@ -43,7 +43,7 @@ pub fn ensure_numeric(fcn: &str, arg: &Expr, v: &Value) -> Result<Float> {
     })
 }
 
-pub fn ensure_string(fcn: &str, arg: &Expr, v: &Value) -> Result<String> {
+pub fn ensure_string(fcn: &str, arg: &Expr, v: &Value) -> Result<Rc<str>> {
     Ok(match &v {
         Value::String(s) => s.clone(),
         _ => {
@@ -60,7 +60,7 @@ pub fn ensure_string_element<'a>(
     idx: usize,
 ) -> Result<&'a str> {
     Ok(match &v {
-        Value::String(s) => s.as_str(),
+        Value::String(s) => s.as_ref(),
         _ => {
             let span = arg.span();
             bail!(span.error(

--- a/src/value.rs
+++ b/src/value.rs
@@ -90,7 +90,7 @@ pub enum Value {
     Null,
     Bool(bool),
     Number(Number),
-    String(String),
+    String(Rc<str>),
     Array(Rc<Vec<Value>>),
     Object(Rc<BTreeMap<Value, Value>>),
 
@@ -110,7 +110,7 @@ impl Serialize for Value {
         match self {
             Value::Null => serializer.serialize_none(),
             Value::Bool(b) => serializer.serialize_bool(*b),
-            Value::String(s) => serializer.serialize_str(s.as_str()),
+            Value::String(s) => serializer.serialize_str(s.as_ref()),
             Value::Number(n) => n.serialize(serializer),
             Value::Array(a) => a.serialize(serializer),
             Value::Object(fields) => {
@@ -233,14 +233,14 @@ impl Value {
         }
     }
 
-    pub fn as_string(&self) -> Result<&String> {
+    pub fn as_string(&self) -> Result<&Rc<str>> {
         match self {
             Value::String(s) => Ok(s),
             _ => Err(anyhow!("not a string")),
         }
     }
 
-    pub fn as_string_mut(&mut self) -> Result<&mut String> {
+    pub fn as_string_mut(&mut self) -> Result<&mut Rc<str>> {
         match self {
             Value::String(s) => Ok(s),
             _ => Err(anyhow!("not a string")),
@@ -310,7 +310,7 @@ impl Value {
             return Ok(self);
         }
 
-        let key = Value::String(paths[0].to_owned());
+        let key = Value::String(paths[0].into());
         if self == &Value::Undefined {
             *self = Value::new_object();
         }
@@ -379,7 +379,7 @@ impl ops::Index<&str> for Value {
     type Output = Value;
 
     fn index(&self, key: &str) -> &Self::Output {
-        &self[&Value::String(key.to_owned())]
+        &self[&Value::String(key.into())]
     }
 }
 
@@ -387,7 +387,7 @@ impl ops::Index<&String> for Value {
     type Output = Value;
 
     fn index(&self, key: &String) -> &Self::Output {
-        &self[&Value::String(key.clone())]
+        &self[&Value::String(key.clone().into())]
     }
 }
 

--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -12,7 +12,7 @@ use test_generator::test_resources;
 pub fn process_value(v: &Value) -> Result<Value> {
     match v {
         // Handle Undefined encoded as a string "#undefined"
-        Value::String(s) if s == "#undefined" => Ok(Value::Undefined),
+        Value::String(s) if s.as_ref() == "#undefined" => Ok(Value::Undefined),
 
         // Handle set encoded as an object
         // set! :

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -20,7 +20,7 @@ macro_rules! my_assert_eq {
 }
 
 fn skip_value(v: &Value) -> bool {
-    matches!(v, Value::String(s) if s == "--skip--")
+    matches!(v, Value::String(s) if s.as_ref() == "--skip--")
 }
 
 fn match_span(s: &Span, v: &Value) -> Result<()> {
@@ -28,7 +28,7 @@ fn match_span(s: &Span, v: &Value) -> Result<()> {
         Value::String(vs) => {
             my_assert_eq!(
                 *s.text(),
-                vs,
+                vs.as_ref(),
                 "{}",
                 s.source
                     .message(s.line, s.col, "match-error", "mismatch happened here.")
@@ -151,7 +151,7 @@ fn match_expr_impl(e: &Expr, v: &Value) -> Result<()> {
         Expr::UnaryExpr { span, expr } => {
             match_span_opt(span, &v["span"])?;
             my_assert_eq!(
-                &Value::String("-".to_owned()),
+                &Value::String("-".into()),
                 &v["op"],
                 "{}",
                 span.source.message(
@@ -324,8 +324,8 @@ fn match_expr_opt(s: &Span, e: &Option<Ref<Expr>>, v: &Value) -> Result<()> {
 
 fn match_bin_op(s: &Span, op: &BinOp, v: &Value) -> Result<()> {
     match (op, v) {
-        (BinOp::And, Value::String(s)) if s == "&" => Ok(()),
-        (BinOp::Or, Value::String(s)) if s == "|" => Ok(()),
+        (BinOp::And, Value::String(s)) if s.as_ref() == "&" => Ok(()),
+        (BinOp::Or, Value::String(s)) if s.as_ref() == "|" => Ok(()),
         _ => bail!(
             "{}",
             s.source.message(
@@ -340,10 +340,10 @@ fn match_bin_op(s: &Span, op: &BinOp, v: &Value) -> Result<()> {
 
 fn match_arith_op(s: &Span, op: &ArithOp, v: &Value) -> Result<()> {
     match (op, v) {
-        (ArithOp::Add, Value::String(s)) if s == "+" => Ok(()),
-        (ArithOp::Sub, Value::String(s)) if s == "-" => Ok(()),
-        (ArithOp::Mul, Value::String(s)) if s == "*" => Ok(()),
-        (ArithOp::Div, Value::String(s)) if s == "/" => Ok(()),
+        (ArithOp::Add, Value::String(s)) if s.as_ref() == "+" => Ok(()),
+        (ArithOp::Sub, Value::String(s)) if s.as_ref() == "-" => Ok(()),
+        (ArithOp::Mul, Value::String(s)) if s.as_ref() == "*" => Ok(()),
+        (ArithOp::Div, Value::String(s)) if s.as_ref() == "/" => Ok(()),
         _ => bail!(
             "{}",
             s.source.message(
@@ -358,11 +358,11 @@ fn match_arith_op(s: &Span, op: &ArithOp, v: &Value) -> Result<()> {
 
 fn match_bool_op(s: &Span, op: &BoolOp, v: &Value) -> Result<()> {
     match (op, v) {
-        (BoolOp::Lt, Value::String(s)) if s == "<" => Ok(()),
-        (BoolOp::Le, Value::String(s)) if s == "<=" => Ok(()),
-        (BoolOp::Eq, Value::String(s)) if s == "==" => Ok(()),
-        (BoolOp::Ge, Value::String(s)) if s == ">=" => Ok(()),
-        (BoolOp::Gt, Value::String(s)) if s == ">" => Ok(()),
+        (BoolOp::Lt, Value::String(s)) if s.as_ref() == "<" => Ok(()),
+        (BoolOp::Le, Value::String(s)) if s.as_ref() == "<=" => Ok(()),
+        (BoolOp::Eq, Value::String(s)) if s.as_ref() == "==" => Ok(()),
+        (BoolOp::Ge, Value::String(s)) if s.as_ref() == ">=" => Ok(()),
+        (BoolOp::Gt, Value::String(s)) if s.as_ref() == ">" => Ok(()),
         _ => bail!(
             "{}",
             s.source.message(
@@ -377,8 +377,8 @@ fn match_bool_op(s: &Span, op: &BoolOp, v: &Value) -> Result<()> {
 
 fn match_assign_op(s: &Span, op: &AssignOp, v: &Value) -> Result<()> {
     match (op, v) {
-        (AssignOp::Eq, Value::String(s)) if s == "=" => Ok(()),
-        (AssignOp::ColEq, Value::String(s)) if s == ":=" => Ok(()),
+        (AssignOp::Eq, Value::String(s)) if s.as_ref() == "=" => Ok(()),
+        (AssignOp::ColEq, Value::String(s)) if s.as_ref() == ":=" => Ok(()),
         _ => bail!(
             "{}",
             s.source.message(
@@ -470,7 +470,7 @@ fn match_literal(l: &Literal, v: &Value) -> Result<()> {
         Literal::NotExpr { expr, span } => {
             let v = &v["notexpr"];
             match &v["op"] {
-                Value::String(s) if s == "not" => (),
+                Value::String(s) if s.as_ref() == "not" => (),
                 _ => {
                     bail!(
                         "{}",

--- a/tests/value/mod.rs
+++ b/tests/value/mod.rs
@@ -86,7 +86,7 @@ fn display_number() {
 #[test]
 fn serialize_string() -> Result<()> {
     assert_eq!(
-        Value::String("Hello, World\n".to_owned()).to_json_str()?,
+        Value::String("Hello, World\n".into()).to_json_str()?,
         "\"Hello, World\\n\""
     );
     Ok(())
@@ -122,7 +122,7 @@ fn value_as_index() -> Result<()> {
     assert_eq!(&Value::Undefined[&idx], &Value::Undefined);
     assert_eq!(&Value::Null[&idx], &Value::Undefined);
     assert_eq!(&Value::Bool(true)[&idx], &Value::Undefined);
-    assert_eq!(&Value::String("Hello".to_owned())[&idx], &Value::Undefined);
+    assert_eq!(&Value::String("Hello".into())[&idx], &Value::Undefined);
     assert_eq!(&Value::new_set()[&idx], &Value::Undefined);
 
     Ok(())
@@ -151,7 +151,7 @@ fn api() -> Result<()> {
     assert!(&Value::from_json_str("{}")?.as_object()?.is_empty());
     let mut v = Value::new_object();
     v.as_object_mut()?
-        .insert(Value::String("a".to_owned()), Value::from_float(3.145));
+        .insert(Value::String("a".into()), Value::from_float(3.145));
     assert_eq!(v["a"], Value::from_float(3.145));
     assert_eq!(v.as_object()?.len(), 1);
 
@@ -168,8 +168,8 @@ fn api() -> Result<()> {
     assert!(Value::Null.as_set().is_err());
     assert!(Value::Null.as_set_mut().is_err());
 
-    assert!(Value::String("anc".to_owned()).as_array().is_err());
-    assert!(Value::String("anc".to_owned()).as_array_mut().is_err());
+    assert!(Value::String("anc".into()).as_array().is_err());
+    assert!(Value::String("anc".into()).as_array_mut().is_err());
 
     assert!(Value::new_object().as_number().is_err());
     assert!(Value::new_object().as_number_mut().is_err());


### PR DESCRIPTION
This reduces std::mem::size_of::<Value>() to 16 bytes. String values are also efficiently copied like Objects, arrays, sets etc.

When multiple function rules are evaluated, ensure that constant argument values match before running the rule. If actual parameter does not match the constant parameter, then the rule is skipped.