### PR TITLE
OPA conformance

### DIFF
--- a/examples/regorus.rs
+++ b/examples/regorus.rs
@@ -10,9 +10,12 @@ fn rego_eval(
     input: Option<String>,
     query: String,
     enable_tracing: bool,
+    non_strict: bool,
 ) -> Result<()> {
     // Create engine.
     let mut engine = regorus::Engine::new();
+
+    engine.set_strict_builtin_errors(!non_strict);
 
     // Load files from given bundles.
     for dir in bundles.iter() {
@@ -130,6 +133,10 @@ enum RegorusCommand {
         /// Enable tracing.
         #[arg(long, short)]
         trace: bool,
+
+        // Non strict execution
+        #[arg(long, short)]
+        non_strict: bool,
     },
 
     /// Tokenize a Rego policy.
@@ -171,7 +178,8 @@ fn main() -> Result<()> {
             input,
             query,
             trace,
-        } => rego_eval(&bundles, &data, input, query, trace),
+            non_strict,
+        } => rego_eval(&bundles, &data, input, query, trace, non_strict),
         RegorusCommand::Lex { file, verbose } => rego_lex(file, verbose),
         RegorusCommand::Parse { file } => rego_parse(file),
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -186,8 +186,8 @@ pub struct Span {
 }
 
 impl Span {
-    pub fn text(&self) -> std::rc::Rc<&str> {
-        std::rc::Rc::new(&self.source.contents()[self.start as usize..self.end as usize])
+    pub fn text(&self) -> &str {
+        &self.source.contents()[self.start as usize..self.end as usize]
     }
 
     pub fn source_str(&self) -> SourceStr {
@@ -619,7 +619,7 @@ impl<'source> Lexer<'source> {
 	    _ if chr.is_ascii_digit() => self.read_number(),
 	    _ if chr.is_ascii_alphabetic() || chr == '_' => {
 		let mut ident = self.read_ident()?;
-		if *ident.1.text() == "set" && self.peek().1 == '(' {
+		if ident.1.text() == "set" && self.peek().1 == '(' {
 		    // set immediately followed by ( is treated as set( if
 		    // the next token is ).
 		    let state = (self.iter.clone(), self.line, self.col);
@@ -627,7 +627,7 @@ impl<'source> Lexer<'source> {
 
 		    // Check it next token is ).
 		    let next_tok = self.next_token()?;
-		    let is_setp = *next_tok.1.text() == ")";
+		    let is_setp = next_tok.1.text() == ")";
 
 		    // Restore state
 		    (self.iter, self.line, self.col) = state;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -298,7 +298,7 @@ fn gather_assigned_vars(
 ) -> Result<()> {
     traverse(expr, &mut |e| match e.as_ref() {
         // Ignore _, input, data.
-        Var(v) if matches!(*v.text(), "_" | "input" | "data") => Ok(false),
+        Var(v) if matches!(v.text(), "_" | "input" | "data") => Ok(false),
 
         // Record local var that can shadow input var.
         Var(v) if can_shadow => {
@@ -623,7 +623,7 @@ impl Analyzer {
         let mut used_vars = vec![];
         let mut comprs = vec![];
         traverse(expr, &mut |e| match e.as_ref() {
-            Var(v) if !matches!(*v.text(), "_" | "input" | "data") => {
+            Var(v) if !matches!(v.text(), "_" | "input" | "data") => {
                 let name = v.source_str();
                 let is_extra_arg = match assigned_vars {
                     Some(vars) => vars.contains(&v.source_str()),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,17 +86,17 @@ pub fn get_path_string(refr: &Expr, document: Option<&str>) -> Result<String> {
     while expr.is_some() {
         match expr {
             Some(Expr::RefDot { refr, field, .. }) => {
-                comps.push(&field.text());
+                comps.push(field.text());
                 expr = Some(refr);
             }
             Some(Expr::RefBrack { refr, index, .. }) => {
                 if let Expr::String(s) = index.as_ref() {
-                    comps.push(&s.text());
+                    comps.push(s.text());
                 }
                 expr = Some(refr);
             }
             Some(Expr::Var(v)) => {
-                comps.push(&v.text());
+                comps.push(v.text());
                 expr = None;
             }
             _ => bail!("internal error: not a simple ref {expr:?}"),

--- a/tests/interpreter/cases/data/tests.yaml
+++ b/tests/interpreter/cases/data/tests.yaml
@@ -37,7 +37,7 @@ cases:
         - 100
         - 200
         
-  - note: overriding refs in data produces error
+  - note: overriding refs in data produces no error
     data:
       test:
         rule1: 0
@@ -46,8 +46,8 @@ cases:
         package test
 
         rule1 = 6
-    query: data.test
-    error: value for rule has already been specified
+    query: data.test.rule1
+    want_result: 0
       
   - note: rule named data
     data:

--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -50,6 +50,9 @@ intersection
 invalidkeyerror
 jsonfilter
 jsonfilteridempotent
+jsonremove
+jsonremoveidempotent
+jsonschema
 jwtencodesignheadererrors
 jwtencodesignpayloaderrors
 negation
@@ -96,5 +99,6 @@ typenamebuiltin
 undos
 union
 units
+uuid
 varreferences
 virtualdocs

--- a/tests/opa.rs
+++ b/tests/opa.rs
@@ -169,7 +169,8 @@ fn run_opa_tests(opa_tests_dir: String, folders: &[String]) -> Result<()> {
                 {
                     entry.0 += 1;
                 }
-                (Err(_), None) if case.want_error.is_some() => {
+                // TODO: Handle tests that specify both want_result and strict_error
+                (Err(_), _) if case.want_error.is_some() => {
                     // Expected failure.
                     entry.0 += 1;
                 }

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -27,7 +27,7 @@ fn match_span(s: &Span, v: &Value) -> Result<()> {
     match &v {
         Value::String(vs) => {
             my_assert_eq!(
-                *s.text(),
+                s.text(),
                 vs.as_ref(),
                 "{}",
                 s.source


### PR DESCRIPTION
- Remove unnecessary memory allocations
- Add --non-strict flag
- Ensure that only empty modules (ones without rules) are initialzed prior to evaluating rules.
- Record rule as entry for each of its prefixes. For example, for a rule a.b.c =... in package test, record it in rules["data.test.a"], rules["data.test.a.b"] and rules["data.test.a.b.c"]

  This allows evaluating the correct list of rules based on expessions a.b.c, a.b, a, data.test.a.b.c, data.test.a.b, data.test.a

Closes #69
Closes #70