### PR TITLE
OPA conformance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,14 @@ md-5 = {version = "0.10.6", optional = true}
 
 data-encoding = { version = "2.4.0", optional = true }
 jsonschema = { version = "0.17.1", optional = true }
+scientific = { version = "0.5.2" }
 
 regex = {version = "1.10.2", optional = true}
 semver = {version = "1.0.20", optional = true}
 wax = { version = "0.6.0", features = [], default-features = false, optional = true }
 url = { version = "2.5.0", optional = true }
-dashu-float = { version = "0.4.1", features = ["num-traits"] }
-num-traits = "0.2.17"
-dashu-base = "0.4.0"
 uuid = { version = "1.6.1", features = ["v4", "fast-rng"], optional = true }
+
 
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,14 @@
 // Licensed under the MIT License.
 
 use anyhow::Result;
+use std::path::Path;
 
 fn main() -> Result<()> {
     // Copy hooks to appropriate location so that git will run them.
-    std::fs::copy("./scripts/pre-commit", "./.git/hooks/pre-commit")?;
-    std::fs::copy("./scripts/pre-push", "./.git/hooks/pre-push")?;
+    // In git worktrees, .git is a symlink and the following commands fail.
+    if Path::new(".git").is_dir() {
+        std::fs::copy("./scripts/pre-commit", "./.git/hooks/pre-commit")?;
+        std::fs::copy("./scripts/pre-push", "./.git/hooks/pre-push")?;
+    }
     Ok(())
 }

--- a/src/builtins/units.rs
+++ b/src/builtins/units.rs
@@ -102,10 +102,10 @@ fn parse(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Re
     };
 
     if let Some(e) = ten_exp(suffix) {
-        n.mul_assign(&Number::ten_pow(e))?;
+        n.mul_assign(&Number::ten_pow(e)?)?;
         Ok(Value::from(n))
     } else if let Some(e) = two_exp(suffix) {
-        n.mul_assign(&Number::two_pow(e))?;
+        n.mul_assign(&Number::two_pow(e)?)?;
         Ok(Value::from(n))
     } else {
         return Ok(Value::Undefined);
@@ -182,10 +182,10 @@ fn parse_bytes(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) 
     };
 
     if let Some(e) = twob_exp(suffix) {
-        n.mul_assign(&Number::two_pow(e))?;
+        n.mul_assign(&Number::two_pow(e)?)?;
         Ok(Value::from(n.round()))
     } else if let Some(e) = tenb_exp(suffix) {
-        n.mul_assign(&Number::ten_pow(e))?;
+        n.mul_assign(&Number::ten_pow(e)?)?;
         Ok(Value::from(n.round()))
     } else {
         Ok(Value::Undefined)

--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -88,6 +88,7 @@ semvercompare
 semverisvalid
 sets
 sprintf
+strings
 subset
 toarray
 topdowndynamicdispatch
@@ -104,6 +105,7 @@ typenamebuiltin
 undos
 union
 units
+urlbuiltins
 uuid
 varreferences
 virtualdocs


### PR DESCRIPTION
- Switch to scientific crate. Large values are printed in scientific notations. Regular values are printed as u64, i64 or f64.
- Skip copying commit hooks in git worktrees
- urlquery.decode, urlquery.encode, urlquery.encode_object
- substring, indexof_n string builtins
- Make sprintf more OPA conformant

Closes #78 
Closes #79
Closes #80