### PR TITLE
Handle walk builtin as a loop expression

### DIFF
--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -76,6 +76,7 @@ partialobjectdoc
 partialsetdoc
 planner-ir
 rand
+reachable
 regexfind
 regexfindallstringsubmatch
 regexisvalid
@@ -109,3 +110,4 @@ urlbuiltins
 uuid
 varreferences
 virtualdocs
+walkbuiltin


### PR DESCRIPTION
The walk builtin generates values and implicitly creates a loop over the values. Hoist walk calls as loops and handle them. Also handle cases where return value is bound to an extra parameter.

Closes #83