### PR TITLE
OPA conformance: Ensure that `withkeyword` OPA tests pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # vscode files
 .vscode/
+
+# worktrees
+worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ base64url = ["dep:data-encoding"]
 crypto = ["dep:constant_time_eq", "dep:hmac", "dep:hex", "dep:md-5", "dep:sha1", "dep:sha2"]
 deprecated = []
 hex = ["dep:data-encoding"]
+http = []
+jwt = []
 glob = ["dep:wax"]
 graph = []
 jsonschema = ["dep:jsonschema"]
+opa-runtime = []
 regex = ["dep:regex"]
 semver = ["dep:semver"]
 uuid = ["dep:uuid"]
@@ -30,12 +33,15 @@ full-opa = [
     "glob",
     "graph",
     "hex",
+    "http",
+    "jwt",
     "jsonschema",
+    "opa-runtime",
     "regex",
     "semver",
+    "time",
     "uuid",
     "urlquery",
-    "time",
     "yaml"
 ]
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use std::path::Path;
+use std::process::Command;
 
 fn main() -> Result<()> {
     // Copy hooks to appropriate location so that git will run them.
@@ -11,5 +12,14 @@ fn main() -> Result<()> {
         std::fs::copy("./scripts/pre-commit", "./.git/hooks/pre-commit")?;
         std::fs::copy("./scripts/pre-push", "./.git/hooks/pre-push")?;
     }
+
+    // Supply information as compile-time environment variables.
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
     Ok(())
 }

--- a/src/builtins/aggregates.rs
+++ b/src/builtins/aggregates.rs
@@ -21,7 +21,7 @@ pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("sum", (sum, 1));
 }
 
-fn count(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn count(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     ensure_args_count(span, "count", params, args, 1)?;
 
     Ok(Value::from(Number::from(match &args[0] {
@@ -29,12 +29,13 @@ fn count(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Re
         Value::Set(a) => a.len(),
         Value::Object(a) => a.len(),
         Value::String(a) => a.encode_utf16().count(),
-        a => {
+        a if strict => {
             let span = params[0].span();
             bail!(span.error(
                 format!("`count` requires array/object/set/string argument. Got `{a}`.").as_str()
             ))
         }
+        _ => return Ok(Value::Undefined),
     })))
 }
 

--- a/src/builtins/http.rs
+++ b/src/builtins/http.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ast::{Expr, Ref};
+use crate::builtins;
+use crate::builtins::utils::ensure_args_count;
+
+use crate::lexer::Span;
+use crate::value::Value;
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+    m.insert("http.send", (send, 1));
+}
+
+fn send(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    let name = "http.send";
+    ensure_args_count(span, name, params, args, 1)?;
+    Ok(Value::Undefined)
+}

--- a/src/builtins/jwt.rs
+++ b/src/builtins/jwt.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ast::{Expr, Ref};
+use crate::builtins;
+use crate::builtins::utils::ensure_args_count;
+
+use crate::lexer::Span;
+use crate::value::Value;
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+    m.insert("io.jwt.decode_verify", (jwt_decode_verify, 2));
+}
+
+fn jwt_decode_verify(
+    span: &Span,
+    params: &[Ref<Expr>],
+    args: &[Value],
+    _strict: bool,
+) -> Result<Value> {
+    let name = "io.jwt.decode_verify";
+    ensure_args_count(span, name, params, args, 2)?;
+    Ok(Value::Undefined)
+}

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -17,14 +17,21 @@ mod encoding;
 mod glob;
 #[cfg(feature = "graph")]
 mod graph;
+#[cfg(feature = "http")]
+mod http;
+#[cfg(feature = "jwt")]
+mod jwt;
 pub mod numbers;
 mod objects;
+#[cfg(feature = "opa-runtime")]
+mod opa;
 #[cfg(feature = "regex")]
 mod regex;
 #[cfg(feature = "semver")]
 mod semver;
 pub mod sets;
 mod strings;
+#[cfg(feature = "time")]
 mod time;
 mod tracing;
 pub mod types;
@@ -77,22 +84,24 @@ lazy_static! {
 	//units::register(&mut m);
 	types::register(&mut m);
 	encoding::register(&mut m);
-	//token_signing::register(&mut m);
-	//token_verification::register(&mut m);
+	#[cfg(feature = "jwt")]
+	jwt::register(&mut m);
 	#[cfg(feature = "time")]
 	time::register(&mut m);
 
 	#[cfg(feature = "crypto")]
 	crypto::register(&mut m);
 	//graphql::register(&mut m);
-	//http::register(&mut m);
+	#[cfg(feature = "http")]
+	http::register(&mut m);
 	//net::register(&mut m);
 	#[cfg(feature = "uuid")]
 	uuid::register(&mut m);
 	#[cfg(feature = "semver")]
 	semver::register(&mut m);
 	//rego::register(&mut m);
-	//opa::register(&mut m);
+	#[cfg(feature = "opa-runtime")]
+	opa::register(&mut m);
 	debugging::register(&mut m);
 	tracing::register(&mut m);
 	units::register(&mut m);
@@ -106,9 +115,10 @@ lazy_static! {
 
 pub fn must_cache(path: &str) -> Option<&'static str> {
     match path {
+        "opa.runtime" => Some("opa.runtime"),
         "rand.intn" => Some("rand.intn"),
-        "uuid.rfc4122" => Some("uuid.rfc4122"),
         "time.now_ns" => Some("time.now_ns"),
+        "uuid.rfc4122" => Some("uuid.rfc4122"),
         _ => None,
     }
 }

--- a/src/builtins/opa.rs
+++ b/src/builtins/opa.rs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ast::{Expr, Ref};
+use crate::builtins;
+use crate::builtins::utils::ensure_args_count;
+
+use crate::lexer::Span;
+use crate::value::Value;
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Result;
+
+pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+    m.insert("opa.runtime", (opa_runtime, 0));
+}
+
+fn opa_runtime(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    let name = "opa.runtime";
+    ensure_args_count(span, name, params, args, 0)?;
+    let mut obj = BTreeMap::new();
+
+    obj.insert(
+        Value::String("commit".into()),
+        Value::String(env!("GIT_HASH").into()),
+    );
+
+    obj.insert(
+        Value::String("regorus-version".into()),
+        Value::String(env!("CARGO_PKG_VERSION").into()),
+    );
+
+    obj.insert(
+        Value::String("version".into()),
+        Value::String("0.60.0".into()),
+    );
+
+    // Emitting environment variables could lead to confidential data being leaked.
+    if false {
+        obj.insert(
+            Value::String("env".into()),
+            Value::from_map(
+                std::env::vars()
+                    .map(|(k, v)| (Value::String(k.into()), Value::String(v.into())))
+                    .collect(),
+            ),
+        );
+    }
+
+    let features = [
+        #[cfg(feature = "base64")]
+        "base64",
+        #[cfg(feature = "base64url")]
+        "base64url",
+        #[cfg(feature = "crypto")]
+        "crypto",
+        #[cfg(feature = "deprecated")]
+        "deprecated",
+        #[cfg(feature = "glob")]
+        "glob",
+        #[cfg(feature = "graph")]
+        "graph",
+        #[cfg(feature = "hex")]
+        "hex",
+        #[cfg(feature = "http")]
+        "http",
+        #[cfg(feature = "jwt")]
+        "jwt",
+        #[cfg(feature = "jsonschema")]
+        "jsonschema",
+        #[cfg(feature = "opa-runtime")]
+        "opa-runtime",
+        #[cfg(feature = "regex")]
+        "regex",
+        #[cfg(feature = "semver")]
+        "semver",
+        #[cfg(feature = "time")]
+        "time",
+        #[cfg(feature = "uuid")]
+        "uuid",
+        #[cfg(feature = "urlquery")]
+        "urlquery",
+        #[cfg(feature = "yaml")]
+        "yaml",
+        "",
+    ];
+
+    let features = &features[..features.len() - 1];
+    obj.insert(
+        Value::String("features".into()),
+        Value::from_array(
+            features
+                .iter()
+                .map(|f| Value::String(f.to_string().into()))
+                .collect(),
+        ),
+    );
+
+    let mut builtins: Vec<&&str> = builtins::BUILTINS.keys().collect();
+    builtins.sort();
+
+    obj.insert(
+        Value::String("builtins".into()),
+        Value::from_array(
+            builtins
+                .iter()
+                .map(|f| Value::String(f.to_string().into()))
+                .collect(),
+        ),
+    );
+
+    #[cfg(feature = "deprecated")]
+    {
+        let mut deprecated: Vec<&&str> = builtins::deprecated::DEPRECATED.keys().collect();
+        deprecated.sort();
+
+        obj.insert(
+            Value::String("deprecated".into()),
+            Value::from_array(
+                deprecated
+                    .iter()
+                    .map(|f| Value::String(f.to_string().into()))
+                    .collect(),
+            ),
+        );
+    }
+
+    Ok(Value::from_map(obj))
+}

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -10,6 +10,7 @@ use crate::value::Value;
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail, Result};
+
 use chrono::{
     DateTime, Datelike, Days, FixedOffset, Local, Months, NaiveDateTime, SecondsFormat, TimeZone,
     Timelike, Utc, Weekday,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -84,7 +84,6 @@ impl Engine {
             let analyzer = Analyzer::new();
             let schedule = analyzer.analyze(&self.modules)?;
 
-            self.interpreter.init_with_document()?;
             self.interpreter.set_schedule(Some(schedule));
             self.interpreter.set_modules(&self.modules);
 
@@ -93,6 +92,10 @@ impl Engine {
             // the data will be reset to init_data each time clean_internal_evaluation_state is called
             let init_data = self.interpreter.get_data_mut().clone();
             self.interpreter.set_init_data(init_data);
+
+            // Initialize the with-document with initial data values.
+            // with-modifiers will be applied to this document.
+            self.interpreter.init_with_document()?;
 
             self.interpreter
                 .set_functions(gather_functions(&self.modules)?);

--- a/tests/interpreter/cases/call/or.yaml
+++ b/tests/interpreter/cases/call/or.yaml
@@ -132,6 +132,7 @@ cases:
     want_result:
       a1: "hello world"
       a2: 6
+    strict: false
 
   - note: or-all-error
     data: {}

--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -138,8 +138,10 @@ pub fn eval_file(
     input_opt: Option<ValueOrVec>,
     query: &str,
     enable_tracing: bool,
+    strict: bool,
 ) -> Result<Vec<Value>> {
     let mut engine: Engine = engine::Engine::new();
+    engine.set_strict_builtin_errors(strict);
 
     let mut results = vec![];
     let mut files = vec![];
@@ -237,6 +239,12 @@ struct TestCase {
     traces: Option<bool>,
     want_error: Option<String>,
     want_error_code: Option<String>,
+    #[serde(default = "default_strict")]
+    strict: bool,
+}
+
+fn default_strict() -> bool {
+    true
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -270,6 +278,7 @@ fn yaml_test_impl(file: &str) -> Result<()> {
             case.input,
             case.query.as_str(),
             enable_tracing,
+            case.strict,
         ) {
             Ok(results) => match case.want_result {
                 Some(want_result) => {

--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -6,6 +6,7 @@ array
 assignments
 base64builtins
 base64urlbuiltins
+baseandvirtualdocs
 bitsand
 bitsnegate
 bitsor
@@ -47,7 +48,6 @@ indexing
 indirectreferences
 inputvalues
 intersection
-invalidkeyerror
 jsonbuiltins
 jsonfilter
 jsonfilteridempotent
@@ -111,3 +111,4 @@ uuid
 varreferences
 virtualdocs
 walkbuiltin
+withkeyword


### PR DESCRIPTION
- ignore worktrees
- feature guard time module
- Apply with modifiers before evaluating loop expressions
- Support value modifier for functions
- stubs for http.send and io.jwt.decode_verify
- Initialize with-document after initializing init data
- In case of conflict, with modifier override init-data values.
- In case of conflict, subsequent with modifier overrides earlier ones.
- Ensure that zero parameter functions are evaluated and added to document
- opa.runtime builtin returns:
   - git commit hash
   - environment vars
   - regorus features enabled
   - builtins available
   - deprecated builtins available
- If `sort_bindings` is specified, sort the bindings in OPA tests
- gather inputs, used vars and comprehensions in with modifiers
- For refs starting with `data`, ensure that modules are evaluated before looking up value of the expression. Thie ensures that modules that have only been partly populated (E.g via with mods) are completely evaluated before the value is looked up
- Mark rules overridden using with modifiers are evaluated.
- Exclude env vars in opa.runtime.
- Include regorus version in OPA runtime
- update to opa v0.60.0
- scheduler: Handle function refs in with modifers. Error out only if a truly undefined ref.
- Handle undefined params, parameter expression evaluation errors before applying with modifiers.
- When applying with modifiers, first determine whether the target is a function. If so, handle cleanly.
- concat: raise error only in strict mode
- In strict mode, propagate errors raised by function rule execution in case of multiple function definitions for same rule
- skip "withkeyword/builtin-builtin: arity 0" test which can never pass.
- When a mock has is being applied, clear with_function so that other mocks won't be applied during the evaluation of the mock.
- Ability to specify strictness in tests

Closes #87 