### PR TITLE
OPA conformance: Pass refheads test suite

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -327,6 +327,14 @@ pub enum Rule {
     },
 }
 
+impl Rule {
+    pub fn span(&self) -> &Span {
+        match self {
+            Self::Spec { span, .. } | Self::Default { span, .. } => span,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Package {
     pub span: Span,

--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -77,6 +77,7 @@ partialsetdoc
 planner-ir
 rand
 reachable
+refheads
 regexfind
 regexfindallstringsubmatch
 regexisvalid


### PR DESCRIPTION
- parser: allow non-string index at any position; not just last
- impl Default for Context
- Fix width of OPA test results table
- Allow non string compoenent anywhere in rule ref; not just as last item.
- Normalize want_result before comparison.
- Ensure that object rules are created even if no definition succeed,
- Sort want_result values for "refheads/general, multiple result-set entries" The entries are in reverse order of how OPA and regorus produce.
- Emit PASS status for each OPA testpoint
- Detect rule conflicts
- 
closes #89 