### PR TITLE
Release preparation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/microsoft/regorus/releases/tag/v0.1.0) - 2024-01-12
+
+### Fixed
+- fix bitwise.and and add tests ([#19](https://github.com/microsoft/regorus/pull/19))
+
+### Other
+- Add Release-plz GitHub workflow file
+- Update `Cargo.toml`
+- Update READEME.md with current status, grammar etc. ([#102](https://github.com/microsoft/regorus/pull/102))
+- Implement builtin `time.parse_duration_ns` method ([#100](https://github.com/microsoft/regorus/pull/100))
+- Implement import keyword ([#101](https://github.com/microsoft/regorus/pull/101))
+- OPA conformance: Pass refheads test suite ([#90](https://github.com/microsoft/regorus/pull/90))
+- OPA conformance: Ensure that `withkeyword` OPA tests pass ([#88](https://github.com/microsoft/regorus/pull/88))
+- Handle walk builtin as a loop expression ([#86](https://github.com/microsoft/regorus/pull/86))
+- Implement most of the builtin `time` module ([#82](https://github.com/microsoft/regorus/pull/82))
+- OPA Conformance
+- OPA conformance ([#81](https://github.com/microsoft/regorus/pull/81))
+- More OPA conformance ([#77](https://github.com/microsoft/regorus/pull/77))
+- OPA conformance ([#71](https://github.com/microsoft/regorus/pull/71))
+- Builtin UUID module ([#68](https://github.com/microsoft/regorus/pull/68))
+- Add tests for builtin `string::format_int` method ([#65](https://github.com/microsoft/regorus/pull/65))
+- More builtins and semantic improvements ([#66](https://github.com/microsoft/regorus/pull/66))
+- More OPA conformance; in-progress: ability to trace interpreter ([#63](https://github.com/microsoft/regorus/pull/63))
+- More OPA conformant semantics ([#62](https://github.com/microsoft/regorus/pull/62))
+- Updated readme. Added bundle support. ([#61](https://github.com/microsoft/regorus/pull/61))
+- crypto builtins ([#57](https://github.com/microsoft/regorus/pull/57))
+- Regex and Glob builtins ([#56](https://github.com/microsoft/regorus/pull/56))
+- Formalize concept of a Number ([#55](https://github.com/microsoft/regorus/pull/55))
+- Lock down ACI tests and more OPA test folders ([#54](https://github.com/microsoft/regorus/pull/54))
+- Fix scheduling regression ([#53](https://github.com/microsoft/regorus/pull/53))
+- add full api to engine ([#50](https://github.com/microsoft/regorus/pull/50))
+- Use Rc<str> instead of string. ([#52](https://github.com/microsoft/regorus/pull/52))
+- More library functions ([#51](https://github.com/microsoft/regorus/pull/51))
+- Added semver.is_valid and semver.compare ([#49](https://github.com/microsoft/regorus/pull/49))
+- OPA conformance tests ([#45](https://github.com/microsoft/regorus/pull/45))
+- Avoid dependency on `source lifetime. ([#43](https://github.com/microsoft/regorus/pull/43))
+- Allow with modifier for builtin and user functions ([#42](https://github.com/microsoft/regorus/pull/42))
+- Special cases of refs to data ([#41](https://github.com/microsoft/regorus/pull/41))
+- Fix scheduling statements that don't create bindings ([#40](https://github.com/microsoft/regorus/pull/40))
+- Ability to run the OPA testsuite ([#39](https://github.com/microsoft/regorus/pull/39))
+- Engine ([#38](https://github.com/microsoft/regorus/pull/38))
+- Use Ref for storing ast nodes in collections. ([#37](https://github.com/microsoft/regorus/pull/37))
+- all, any deprecated functions ([#35](https://github.com/microsoft/regorus/pull/35))
+- all, any deprecated functions ([#34](https://github.com/microsoft/regorus/pull/34))
+- Improvements ([#33](https://github.com/microsoft/regorus/pull/33))
+- Order query expression results ([#32](https://github.com/microsoft/regorus/pull/32))
+- Scheduling of statements in user queries ([#31](https://github.com/microsoft/regorus/pull/31))
+- eval, lex, parse commands ([#30](https://github.com/microsoft/regorus/pull/30))
+- eval_user_query for OPA style results ([#29](https://github.com/microsoft/regorus/pull/29))
+- Arity for builtins ([#28](https://github.com/microsoft/regorus/pull/28))
+- Handle chained _ ([#27](https://github.com/microsoft/regorus/pull/27))
+- Minimize PR 22  ([#26](https://github.com/microsoft/regorus/pull/26))
+- improve errors location ([#23](https://github.com/microsoft/regorus/pull/23))
+- Fix clippy warning ([#25](https://github.com/microsoft/regorus/pull/25))
+- negation of an undefined value should return true ([#21](https://github.com/microsoft/regorus/pull/21))
+- Ensure that scopes are cleaned up correctly upon error. ([#20](https://github.com/microsoft/regorus/pull/20))
+- support of or-functions ([#18](https://github.com/microsoft/regorus/pull/18))
+- Statement Scheduler Implementation
+- Remove unnecessary lifetime
+- json.filter, object.filter, object.get, object.keys, object.remove
+- :to_number builtin
+- :trace builtin
+- bitwise builtins
+- :print builtin
+- Partial sprintf implementation.
+- All string functions except sprintf. TODO: Add tests
+- More string functions without tests
+- More string functions
+- concat and contains
+- string concat (WIP)
+- Support build on non Linux platforms
+- Prepare for upstreaming
+- Test for multi-assign
+- Support dependencies between vars defined in same statement
+- Statement scheduler (WIP)
+- Print small-form table of files without 100% coverage.
+- Code tweaks to improve coverage
+- Tests for aggregates builtins
+- Tests for numbers builtins
+- Tests for arrays builtins
+- Tests for types functions
+- Destructuring of arrays and objects in some-in expressions
+- `some .. in` implementation
+- Fix key, value in membership and some-in
+- refactor
+- Arrays and Aggregates
+- Implement `every` statement ([#4](https://github.com/microsoft/regorus/pull/4))
+- Set loop index variable if not "_" ([#3](https://github.com/microsoft/regorus/pull/3))
+- Allow comprehensions in default value. ([#2](https://github.com/microsoft/regorus/pull/2))
+- Lock down numbers
+- mod function
+- Builtin functions for numbers (WIP)
+- Implement comparison operators. Formalize semantics.
+- Rework assign operations ([#6](https://github.com/microsoft/regorus/pull/6))
+- Locked down supported values in default rule.
+- Improvements to github workflow ([#4](https://github.com/microsoft/regorus/pull/4))
+- Update name to regorus
+- Update rust.yml
+- Add simple git action
+- Add missing config.toml
+- Update license to MIT
+- Code from github.com/anakrish/rego-rs
+- SUPPORT.md committed
+- SECURITY.md committed
+- README.md committed
+- LICENSE committed
+- CODE_OF_CONDUCT.md committed
+- Initial commit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "regorus"
+description = "A fast, lightweight Rego (OPA policy language) interpreter"
 version = "0.1.0"
 edition = "2021"
+license-file = "LICENSE"
+repository = "https://github.com/microsoft/regorus"
+keywords = ["interpreter", "opa", "policy-as-code", "rego", "confidential-computing"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Updated `Cargo.toml` with the necessary fields, created [release-plz](https://github.com/MarcoIeni/release-plz) workflow file, and ran `release-plz update` to generate `CHANGELOG` file.

Release-plz GitHub Action quickstart guide (that also contains generating a token for crates.io) must be followed to complete the release automation: https://release-plz.ieni.dev/docs/github/quickstart.

Afterward, release-plz will create a rolling PR (example: https://github.com/MarcoIeni/release-plz/pull/1171) that will be updated with every change. Whenever we want to make a new release we will simply merge that PR and that will trigger GitHub workflow and run `release-plz release` which is going to detect the new version and then going to publish a release tag on GitHub and a new version on crates.io.

For the first release, we might need to run `release-plz release` manually.