### PR TITLE
Conform to OPA 0.61.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ uuid = { version = "1.6.1", features = ["v4", "fast-rng"], optional = true }
 jsonschema = { version = "0.17.1", default-features = false, optional = true }
 chrono = { version = "0.4.31", optional = true }
 chrono-tz = { version = "0.8.5", optional = true }
-document-features = "0.2.8"
 
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ $ cargo build -r --example regorus --features "yaml" --no-default-features; stri
 ```
 
 
-Regorus passes the [OPA v0.60.0 test-suite](https://www.openpolicyagent.org/docs/latest/ir/#test-suite) barring a few
+Regorus passes the [OPA v0.61.0 test-suite](https://www.openpolicyagent.org/docs/latest/ir/#test-suite) barring a few
 builtins. See [OPA Conformance](#opa-conformance) below.
 
 ## Bindings
 
 Regorus can be used from a variety of languages:
 
-- Javascript: Via npm package `regorusjs`. This package is Regorus compiled into WASM.
-- Python: Via `regorus` package.
+- Javascript: To compile Regorus to WASM and use it in Javascript, see [bindings/wasm](bindings/wasm)
+- Python: To use Regorus from Python, see [bindings/python](bindings/python)
 
 ## Getting Started
 
@@ -199,7 +199,7 @@ Benchmark 1: opa eval -b tests/aci -d tests/aci/data.json -i tests/aci/input.jso
 ```
 ## OPA Conformance
 
-Regorus has been verified to be compliant with [OPA v0.60.0](https://github.com/open-policy-agent/opa/releases/tag/v0.60.0)
+Regorus has been verified to be compliant with [OPA v0.61.0](https://github.com/open-policy-agent/opa/releases/tag/v0.61.0)
 using a [test driver](https://github.com/microsoft/regorus/blob/main/tests/opa.rs) that loads and runs the OPA testsuite using Regorus, and verifies that expected outputs
 are produced.
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -353,6 +353,7 @@ pub struct Module {
     pub package: Package,
     pub imports: Vec<Import>,
     pub policy: Vec<Ref<Rule>>,
+    pub rego_v1: bool,
 }
 
 pub type ExprRef = Ref<Expr>;

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -84,7 +84,6 @@ fn match_values(computed: &Value, expected: &Value) -> Result<()> {
 
 pub fn check_output(computed_results: &[Value], expected_results: &[Value]) -> Result<()> {
     if computed_results.len() != expected_results.len() {
-        dbg!((&computed_results, &expected_results));
         bail!(
             "the number of computed results ({}) and expected results ({}) is not equal",
             computed_results.len(),

--- a/tests/interpreter/cases/rego.v1/tests.yaml
+++ b/tests/interpreter/cases/rego.v1/tests.yaml
@@ -1,0 +1,481 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+cases:
+  - note: conflict future after rego.v1
+    data: {}
+    modules:
+      - |
+        package test
+
+        import rego.v1
+        import future.keywords.in
+
+    query: data
+    error: "this import shadows previous import"
+
+  - note: conflict rego after future
+    data: {}
+    modules:
+      - |
+        package test
+
+        import future.keywords.in
+        import rego.v1
+
+    query: data
+    error: "this import shadows previous import"
+
+  - note: conflict rego after rego
+    data: {}
+    modules:
+      - |
+        package test
+
+        import rego.v1
+        import rego.v1
+
+    query: data
+    error: "this import shadows previous import"
+
+  - note: allowed future after future
+    data: {}
+    modules:
+      - |
+        package test
+
+        import future.keywords
+        import future.keywords
+
+    query: data.test
+    want_result: {}
+
+  - note: if-required-before-body
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        allow {
+          1 > 2
+        }
+    query: data
+    error: "`if` keyword is required before rule body"
+
+  - note: ok-if-before-body
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        allow if {
+          1 < 2
+        }
+    query: data.test
+    want_result:
+        allow: true
+
+  - note: if-required-before-else-body
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        allow if {
+          1 > 2
+        } else = 5 {
+          1 < 2
+        }
+    query: data
+    error: "`if` keyword is required before rule body"
+
+  - note: ok-if-before-else-body
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        allow if {
+          1 > 2
+        } else = 5 if {
+          1 < 2
+        }
+    query: data.test
+    want_result:
+      allow: 5
+
+  # cases from https://www.openpolicyagent.org/docs/latest/opa-1/#backwards-compatibility-in-opa-v10
+  - note: invalid1
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p { true }
+    query: data
+    error: "`if` keyword is required before rule body"
+
+  - note: invalid2
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a { true }
+    query: data
+    error: "`if` keyword is required before rule body"
+
+  - note: invalid3
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b { true }
+    query: data
+    error: "`if` keyword is required before rule body"
+
+  - note: valid1
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p if true
+    query: data.test
+    want_result:
+      p: true
+
+  - note: valid2
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a if true
+    query: data.test
+    want_result:
+      p:
+        a: true
+
+  - note: valid3
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b if true
+    query: data.test
+    want_result:
+      p:
+        a:
+          b: true
+
+  - note: valid4
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p contains "a"
+    query: data.test
+    want_result:
+      p:
+        set!: ["a"]
+
+  - note: valid5
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p := 1
+    query: data.test
+    want_result:
+      p: 1
+
+  - note: valid6
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a := 1
+    query: data.test
+    want_result:
+      p:
+        a: 1
+
+  - note: valid6
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b := 1
+    query: data.test
+    want_result:
+      p:
+        a:
+          b: 1
+
+  - note: invalid11
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p
+    query: data.test
+    error: rule must have a body
+
+  - note: invalid12
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a
+    query: data.test
+    error: "`contains` keyword is required for partial set rules"
+
+  - note: invalid13
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b
+    query: data.test
+    error: rule must have a body
+
+  - note: invalid21
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p { true }
+    query: data.test
+    error: "`if` keyword is required before rule body"
+
+  - note: valid21
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p if { true }
+    query: data.test
+    want_result:
+      p: true
+
+  - note: invalid22
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a
+    query: data.test
+    error: "`contains` keyword is required for partial set rules"
+
+  - note: valid22
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p contains "a"
+    query: data.test
+    want_result:
+      p:
+        set!: ["a"]
+
+  - note: invalid23
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a { true }
+    query: data.test
+    error: "`if` keyword is required before rule body"
+
+  - note: valid22
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p contains "a" if { true }
+    query: data.test
+    want_result:
+      p:
+        set!: ["a"]
+
+  - note: invalid24
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b
+    query: data.test
+    error: "rule must have a body or assignment"
+
+  - note: valid22
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b := true
+    query: data.test
+    want_result:
+      p:
+        a:
+          b: true
+
+  - note: invalid25
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b { true }
+    query: data.test
+    error: "`if` keyword is required before rule body"
+
+  - note: valid22
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        p.a.b if { true }
+    query: data.test
+    want_result:
+      p:
+        a:
+          b: true
+
+  - note: data-shadowed-by-rule
+    data: {}
+    modules:
+      - |
+        package test
+        data = 1
+    query: data.test
+    want_result:
+      data: 1
+
+  - note: invalid-data-shadowed-by-rule
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        data = 1
+    query: data.test
+    error: data cannot be shadowed
+
+  - note: input-shadowed-by-rule
+    data: {}
+    modules:
+      - |
+        package test
+        input = 1
+    query: data.test
+    want_result:
+      input: 1
+
+  - note: invalid-input-shadowed-by-rule
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        input = 1
+    query: data.test
+    error: input cannot be shadowed
+
+  - note: input-shadowed-by-local-var
+    data: {}
+    modules:
+      - |
+        package test
+        x {
+          input := 1
+          input > 0
+        }
+        y {
+           # This evaluates to false
+           input = 1
+           input > 0
+        }
+    query: data.test
+    want_result:
+      x: true
+
+  - note: invalid-input-shadowed-by-local-var
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        x if {
+          input := 1
+          input > 0
+        }
+    query: data.test
+    error: input cannot be shadowed
+
+  - note: data-shadowed-by-local-var
+    data: {}
+    modules:
+      - |
+        package test
+        x {
+          data := 1
+          data > 0
+        }
+    query: data.test
+    want_result:
+      x: true
+
+  - note: invalid-data-shadowed-by-local-var
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        x if {
+          data := 1
+          data > 0
+        }
+    query: data.test
+    error: data cannot be shadowed
+
+  - note: deprecated-function
+    data: {}
+    modules:
+      - |
+        package test
+        x {
+          cast_array([1])
+        }
+    query: data.test
+    want_result:
+      x: true
+      
+  - note: invalid-deprecated-function
+    data: {}
+    modules:
+      - |
+        package test
+        import rego.v1
+        x if {
+          cast_array([1])
+        }
+    query: data.test
+    error: is deprecated

--- a/tests/opa.rs
+++ b/tests/opa.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 const OPA_REPO: &str = "https://github.com/open-policy-agent/opa";
-const OPA_BRANCH: &str = "v0.60.0";
+const OPA_BRANCH: &str = "v0.61.0";
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]

--- a/tests/parser/cases/import/import.yaml
+++ b/tests/parser/cases/import/import.yaml
@@ -224,13 +224,13 @@ cases:
     rego: |
       package test
       import foo
-    error: "import path must begin with one of: {data, future, input}"
+    error: "import path must begin with one of: {data, future, input, rego}"
 
   - note: invalid-beginning-1
     rego: |
       package test
       import foo.bar
-    error: "import path must begin with one of: {data, future, input}"
+    error: "import path must begin with one of: {data, future, input, rego}"
 
   - note: missing-field-1
     rego: |


### PR DESCRIPTION
Implement `import rego.v1`
https://www.openpolicyagent.org/docs/latest/policy-language/#the-regov1-import

- `if` required before rule body
- import rego.v1 automatically imports future.keywords
- handle import shadowing
- data, input cannot be shadowed
- deprecated functions as disallowed
- rules must have assignment or body
- `contains` required for parital set