### PR TITLE
genpolicy tweaks

### DIFF
--- a/src/builtins/debugging.rs
+++ b/src/builtins/debugging.rs
@@ -35,7 +35,7 @@ fn print(span: &Span, _params: &[Ref<Expr>], args: &[Value], _strict: bool) -> R
     }
 
     if !msg.is_empty() {
-        println!("{}", &msg[1..]);
+        eprintln!("{}", &msg[1..]);
     }
     Ok(Value::Bool(true))
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3359,11 +3359,22 @@ impl Interpreter {
                             Expr::String(s) => s.text(),
                             _ => "",
                         },
+                        Expr::Var(v) if v.text() == "input" => {
+                            // Warn redundant import of input. Ignore it.
+                            eprintln!(
+                                "{}",
+                                import.refr.span().error("redundant import of `input`")
+                            );
+                            continue;
+                        }
                         _ => "",
                     },
                 };
                 if target.is_empty() {
-                    bail!(import.refr.span().error("invalid ref in import"));
+                    bail!(import
+                        .refr
+                        .span()
+                        .message("warning", "invalid ref in import"));
                 }
                 self.imports
                     .insert(module_path.clone() + "." + target, import.refr.clone());

--- a/tests/interpreter/cases/import/tests.yaml
+++ b/tests/interpreter/cases/import/tests.yaml
@@ -71,3 +71,11 @@ cases:
         import foo
     query: data
     error: "import path must begin with one of"
+
+  - note: redundant import input
+    modules:
+      - |
+        package test
+        import input
+    query: data.test
+    want_result: {}


### PR DESCRIPTION
Allow `import input` instead of erroring out.
This import is redundant and has no effect.

Emit `print` messages to stderr onstead of stdout.