### PR TITLE
Preserve false in single-expression queries

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -233,7 +233,7 @@ impl Engine {
     /// // Load input and make query.
     /// engine.set_input(Value::new_object());
     /// let results = engine.eval_query("data.framework.mount_overlay.allowed".to_string(), false)?;
-    /// assert!(results.result.is_empty());
+    /// assert_eq!(results.result[0].expressions[0].value, Value::from(false));
     ///
     /// // Evaluate query with different inputs.
     /// engine.set_input(Value::from_json_file("tests/aci/input.json")?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,17 +186,33 @@ impl Default for QueryResult {
 /// ```
 /// # use regorus::*;
 /// # fn main() -> anyhow::Result<()> {
-/// // Create engine and evaluate "true; true; false".
+/// // Create engine and evaluate "1 + 1".
 /// let results = Engine::new().eval_query("1 + 1".to_string(), false)?;
 ///
-/// assert!(results.result.len() == 1);
+/// assert_eq!(results.result.len(), 1);
 /// assert_eq!(results.result[0].expressions[0].value, Value::from(2u64));
 /// assert_eq!(results.result[0].expressions[0].text.as_ref(), "1 + 1");
 /// # Ok(())
 /// # }
 /// ```
 ///
-/// If any expression evaluates to false, then no results are produced.
+/// If a query contains only one expression, and even if the expression evaluates
+/// to false, the value will be returned.
+/// ```
+/// # use regorus::*;
+/// # fn main() -> anyhow::Result<()> {
+/// // Create engine and evaluate "1 > 2" which is false.
+/// let results = Engine::new().eval_query("1 > 2".to_string(), false)?;
+///
+/// assert_eq!(results.result.len(), 1);
+/// assert_eq!(results.result[0].expressions[0].value, Value::from(false));
+/// assert_eq!(results.result[0].expressions[0].text.as_ref(), "1 > 2");
+/// # Ok(())
+/// # }
+/// ```
+///
+/// In a query containing multiple expressions, if  any expression evaluates to false,
+/// then no results are produced.
 /// ```
 /// # use regorus::*;
 /// # fn main() -> anyhow::Result<()> {
@@ -204,6 +220,26 @@ impl Default for QueryResult {
 /// let results = Engine::new().eval_query("true; true; false".to_string(), false)?;
 ///
 /// assert!(results.result.is_empty());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Note that `=` is different from `==`. The former evaluates to undefined if the LHS and RHS
+/// are not equal. The latter evaluates to either true or false.
+/// ```
+/// # use regorus::*;
+/// # fn main() -> anyhow::Result<()> {
+/// // Create engine and evaluate "1 = 2" which is undefined and produces no resutl.
+/// let results = Engine::new().eval_query("1 = 2".to_string(), false)?;
+///
+/// assert_eq!(results.result.len(), 0);
+///
+/// // Create engine and evaluate "1 == 2" which evaluates to false.
+/// let results = Engine::new().eval_query("1 == 2".to_string(), false)?;
+///
+/// assert_eq!(results.result.len(), 1);
+/// assert_eq!(results.result[0].expressions[0].value, Value::from(false));
+/// assert_eq!(results.result[0].expressions[0].text.as_ref(), "1 == 2");
 /// # Ok(())
 /// # }
 /// ```

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -234,6 +234,7 @@ struct TestCase {
     query: String,
     sort_bindings: Option<bool>,
     want_result: Option<ValueOrVec>,
+    no_result: Option<bool>,
     skip: Option<bool>,
     error: Option<String>,
     traces: Option<bool>,
@@ -267,7 +268,10 @@ fn yaml_test_impl(file: &str) -> Result<()> {
 
         match (&case.want_result, &case.error) {
             (Some(_), None) | (None, Some(_)) => (),
-            _ => panic!("either want_result or error must be specified in test case."),
+            _ if case.no_result != Some(true) => {
+                panic!("either want_result, error or no_result must be specified in test case.")
+            }
+            _ => (),
         }
 
         let enable_tracing = case.traces.is_some() && case.traces.unwrap();
@@ -292,6 +296,7 @@ fn yaml_test_impl(file: &str) -> Result<()> {
 
                     check_output(&results, &expected_results)?;
                 }
+                _ if case.no_result == Some(true) => (),
                 _ => bail!("eval succeeded and did not produce any errors"),
             },
             Err(actual) => match &case.error {

--- a/tests/interpreter/cases/query/tests.yaml
+++ b/tests/interpreter/cases/query/tests.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+cases:
+  - note: single-expression query producing false
+    data: {}
+    modules: []
+    query: 1 == 2
+    want_result: false
+
+  - note: single-expression query producing no results (due to undefined)
+    data: {}
+    modules: []
+    query: 1 = 2
+    no_result: true
+
+  - note: multi-expression query in which one expression is false (1)
+    data: {}
+    modules: []
+    query: "1 == 1; 1 == 2"
+    no_result: true
+
+  - note: multi-expression query in which one expression is false (2)
+    data: {}
+    modules: []
+    query: "1 == 2; 1 == 1"
+    no_result: true


### PR DESCRIPTION
Note: 1 = 2 is different from 1 == 2
See issue for details

fixes #144