### PR TITLE
Separately keep track of whether rules have been evaluated or not

### DIFF
--- a/tests/aci/main.rs
+++ b/tests/aci/main.rs
@@ -41,7 +41,7 @@ fn eval_test_case(dir: &Path, case: &TestCase) -> Result<Value> {
         }
     }
 
-    let query_results = engine.eval_query(case.query.clone(), true)?;
+    let query_results = engine.eval_query(case.query.clone(), false)?;
 
     let mut values = vec![];
     for qr in query_results.result {

--- a/tests/interpreter/cases/rule/dependency.yaml
+++ b/tests/interpreter/cases/rule/dependency.yaml
@@ -39,3 +39,19 @@ cases:
       b:
         y: 10
         z: 25
+
+  - note: inter
+    data: {}
+    modules:
+      - |
+        package test
+        a.b.c = 1
+        a.b.d = a.b.e
+        a.b.e = a.b.c
+    query: data.test
+    want_result:
+      a:
+        b:
+          c: 1
+          d: 1
+          e: 1

--- a/tests/interpreter/cases/rule/prefix.yaml
+++ b/tests/interpreter/cases/rule/prefix.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: prefix after rules
+    data: {}
+    modules:
+      - |
+        package test
+        a.b.c = 1
+        a.b.d = 2
+        y = a.b
+    query: data.test
+    want_result:
+      a:
+        b:
+          c: 1
+          d: 2
+      y:
+        c: 1
+        d: 2
+
+  - note: prefix between rules
+    data: {}
+    modules:
+      - |
+        package test
+        a.b.c = 1
+        y = a.b
+        a.b.d = 2
+    query: data.test
+    want_result:
+      a:
+        b:
+          c: 1
+          d: 2
+      y:
+        c: 1
+        d: 2
+
+  - note: prefix between rules
+    data: {}
+    modules:
+      - |
+        package test
+        a.b.c = 1
+        y = a.b
+        a.b.d = 2
+        a[p][q] = 3 {
+          p = "b"
+          q = "e"
+        }
+    query: data.test
+    want_result:
+      a:
+        b:
+          c: 1
+          d: 2
+          e: 3
+      y:
+        c: 1
+        d: 2
+        e: 3
+    skip: true


### PR DESCRIPTION
Previously we used to rely on whether there was a value in the data document for a given rule path. This approach cannot handle the case of evaluating a.b when a.b.c has been evaluated but a.b.d has not been evaluated. Upon evaluating a.b.c, the data document will already have a value of a.b even though a.b.d has not yet been evaluated.

Hence we need to keep track of evaluated rules separately.

fixes #162 