### PR TITLE
Fix regression

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2561,7 +2561,8 @@ impl Interpreter {
             path.push(name.text());
 
             if self.is_processed(&path)? {
-                return Ok(Self::get_value_chained(self.data.clone(), &path));
+                let value = Self::get_value_chained(self.data.clone(), &path);
+                return Ok(Self::get_value_chained(value, fields));
             }
 
             // Ensure that all the rules having common prefix (name) are evaluated.

--- a/tests/interpreter/cases/variables/basic.yaml
+++ b/tests/interpreter/cases/variables/basic.yaml
@@ -36,7 +36,7 @@ cases:
            true: false,
            [1, 3] : {"hello", "world"}
         }
-        
+
     query: data.test
     want_result:
       array: [1, 2, 3]
@@ -71,5 +71,19 @@ cases:
               set!:
                 - "hello"
                 - "world"
-          
-              
+
+
+  - note: value chain (unqualified)
+    data: {}
+    modules:
+      - |
+        package test
+
+        a = {
+          "b" : 5
+        }
+        x = a.b
+        # The second look up must also produce the same value.
+        y = a.b
+    query: data.test.y
+    want_result: 5


### PR DESCRIPTION
Second lookup of an object rule without fully qualified path, resulted in returning the object instead of the requested field.