### PR TITLE
early return

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ itertools = "0.12.1"
 [dev-dependencies]
 cfg-if = "1.0.0"
 clap = { version = "4.4.7", features = ["derive"] }
-colored-diff = "0.2.3"
+prettydiff = { version = "0.6.4", default-features = false }
 serde_yaml = "0.9.16"
 test-generator = "0.3.1"
 walkdir = "2.3.2"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -114,7 +114,17 @@ impl<'source> Parser<'source> {
             }
             Expr::Var(v) => comps.push(v.0.clone()),
             Expr::String(s) => comps.push(s.0.clone()),
-            _ => bail!("internal error: not a simple ref"),
+            Expr::True(s) | Expr::False(s) | Expr::Null(s) => comps.push(s.clone()),
+            Expr::Number(s) => {
+                // Ensure that the span will be the serialized representation.
+                if *s.0.text() == s.1.to_json_str()? {
+                    comps.push(s.0.clone());
+                } else {
+                    bail!(refr.span().error("not a valid ref"));
+                }
+            }
+
+            _ => bail!(refr.span().error("not a valid ref")),
         }
         Ok(())
     }

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -73,10 +73,10 @@ fn match_values(computed: &Value, expected: &Value) -> Result<()> {
     if computed != expected {
         panic!(
             "{}",
-            colored_diff::PrettyDifference {
-                expected: &serde_yaml::to_string(&expected)?,
-                actual: &serde_yaml::to_string(&computed)?
-            }
+            prettydiff::diff_chars(
+                &serde_yaml::to_string(&expected)?,
+                &serde_yaml::to_string(&computed)?
+            )
         );
     }
     Ok(())
@@ -347,7 +347,7 @@ fn yaml_test(file: &str) -> Result<()> {
         Err(e) => {
             // If Err is returned, it doesn't always get printed by cargo test.
             // Therefore, panic with the error.
-            panic!("{}", e);
+            panic!("{e}");
         }
     }
 }

--- a/tests/aci/main.rs
+++ b/tests/aci/main.rs
@@ -92,10 +92,10 @@ fn run_aci_tests(dir: &Path) -> Result<()> {
                 Ok(actual) => {
                     println!(
                         "DIFF {}",
-                        colored_diff::PrettyDifference {
-                            expected: &serde_yaml::to_string(&case.want_result)?,
-                            actual: &serde_yaml::to_string(&actual)?
-                        }
+                        prettydiff::diff_chars(
+                            &serde_yaml::to_string(&case.want_result)?,
+                            &serde_yaml::to_string(&actual)?
+                        )
                     );
 
                     nfailures += 1;

--- a/tests/interpreter/cases/loop/basic.yaml
+++ b/tests/interpreter/cases/loop/basic.yaml
@@ -21,3 +21,87 @@ cases:
       x1: [[1, 0], [2, 1], [3, 2], [4, 3]]
       x2: [[1, 1], [2, 2], [3, 3], [4, 4]]
       x3: [["q", "p"], ["s", "r"]]
+
+  - note: early return
+    data: {}
+    modules:
+      - |
+        package test
+        import future.keywords
+
+        a = [1, "hello"]
+        # Implicit value
+        b1 {
+            a[_] + 1
+        }
+
+        # Literals
+        b2 := true { a[_] + 1 }
+        b3 := false { a[_] + 1 }
+        b4 := 1 { a[_] + 1 }
+        b5 := null { a[_] + 1 }
+        b6 := "hello" { a[_] + 1 }
+        b7 := `world` { a[_] + 1 }
+
+        # constant refs
+        c[null] := true { a[_] + 1 }
+        c["hello"] := false { a[_] + 1 }
+        c[`world`] := 1 { a[_] + 1 }
+        c[true] := null { a[_] + 1 }
+        c[false] := "hello" { a[_] + 1 }
+        c[7] := `world` { a[_] + 1 }
+
+        # Old style set must should also be considered for early return.
+        old.style { a[_] + 1 }
+
+        # Multi part constant refactor
+        multi[1]["hello"] := 5 { a[_] +1 }
+        
+        # Two elements must be produced
+        d = [1 | [1,2][_] ]
+
+        # Non simple ref must not result in early return.
+        f[p] = 5 {
+          p := a[_]
+        }
+
+        f1[p] = 5 {
+          a[p]
+        }
+
+        # Contains syntax
+        g contains p if {
+          p := a[_]
+        }
+    query: data.test
+    want_result:
+      a: [1, "hello"]
+      b1: true
+      b2: true
+      b3: false
+      b4: 1
+      b5: null
+      b6: "hello"
+      b7: "world"
+      c:
+        null: true
+        "hello": false
+        "world": 1
+        true: null
+        false: "hello"
+        7: "world"
+      d: [1, 1]
+      f:
+        1: 5
+        "hello": 5
+      f1:
+        0: 5
+        1: 5
+      g:
+        set!: [1, "hello"]
+      multi:
+        1:
+          "hello": 5
+      old:
+        set!: ["style"]
+        


### PR DESCRIPTION
If a rule is written to produce a constant value, then not all iterations of loops within it need to be executed. Execution can stop via early return once the first iteration that produces a value has been executed.

This brings forth the question : What if one of the subsequent iterations would have resulted in an error?
e.g:
x {
  [1, "hello"][_] + 1
}

Such errors are not raised; consistent with OPA.

Closes #209 
fixes #159 