### PR TITLE
Rewrite so that code compiles with chrono_tz 0.8.5 and 0.9.0

### DIFF
--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -9,7 +9,7 @@ use crate::value::Value;
 
 use std::collections::HashMap;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 
 use chrono::{
     DateTime, Datelike, Days, FixedOffset, Local, Months, SecondsFormat, TimeZone, Timelike, Utc,
@@ -248,7 +248,10 @@ fn parse_epoch(
                     "UTC" | "" => Utc.timestamp_nanos(ns).fixed_offset(),
                     "Local" => Local.timestamp_nanos(ns).fixed_offset(),
                     _ => {
-                        let tz: Tz = tz.parse().map_err(|err: String| anyhow!(err))?;
+                        let tz: Tz = match tz.parse() {
+                            Ok(tz) => tz,
+                            Err(e) => bail!(e),
+                        };
                         tz.timestamp_nanos(ns).fixed_offset()
                     }
                 };


### PR DESCRIPTION
@unexge This is regarding #198 
I have rewritten the offending code so that it compiles with both 0.8.5 and 0.9.0.
Couple of questions:
1. Is there some idiomatic way to write this so that it compiles with both the versions?
2. Should we update chrono-tz or let it be? If we update, then we'd force a chrono-tz update on users of Regorus. If we don't, we might miss out on improvements that 0.9.0 might bring in. What would be your recommendation?