### PR TITLE
Do not enable serde_json/arbitrary_precision by default

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
       run: cargo test -r --test aci
     - name: Run tests (OPA Conformance)
       run: >-
-        cargo test -r --test opa --features opa-testutil  -- $(tr '\n' ' ' < tests/opa.passing)
+        cargo test -r --test opa --features opa-testutil,serde_json/arbitrary_precision  -- $(tr '\n' ' ' < tests/opa.passing)
     - name: Build (MUSL)
       run: cargo build --verbose --all-targets --target x86_64-unknown-linux-musl
     - name: Run tests (MUSL)
@@ -41,4 +41,4 @@ jobs:
       run: cargo test -r --test aci --target x86_64-unknown-linux-musl
     - name: Run tests (MUSL OPA Conformance)
       run: >-
-        cargo test -r --test opa --features opa-testutil --target x86_64-unknown-linux-musl  -- $(tr '\n' ' ' < tests/opa.passing)
+        cargo test -r --test opa --features opa-testutil,serde_json/arbitrary_precision --target x86_64-unknown-linux-musl  -- $(tr '\n' ' ' < tests/opa.passing)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ opa-testutil = []
 [dependencies]
 anyhow = {version = "1.0.66", features = ["backtrace"] }
 serde = {version = "1.0.150", features = ["derive", "rc"] }
-serde_json = {version = "1.0.89", features = ["arbitrary_precision"] }
+serde_json = "1.0.89"
 serde_yaml = {version = "0.9.16", optional = true }
 lazy_static = "1.4.0"
 rand = "0.8.5"

--- a/README.md
+++ b/README.md
@@ -246,13 +246,12 @@ Benchmark 1: opa eval -b tests/aci -d tests/aci/data.json -i tests/aci/input.jso
 ## OPA Conformance
 
 Regorus has been verified to be compliant with [OPA v0.63.0](https://github.com/open-policy-agent/opa/releases/tag/v0.63.0)
-using a [test driver](https://github.com/microsoft/regorus/blob/main/tests/opa.rs) that loads and runs the OPA testsuite using Regorus, and verifies that expected outputs
-are produced.
+using a [test driver](https://github.com/microsoft/regorus/blob/main/tests/opa.rs) that loads and runs the OPA testsuite using Regorus, and verifies that expected outputs are produced.
 
 The test driver can be invoked by running:
 
 ```bash
-$ cargo test -r --test opa
+$ cargo test -r --test opa --features opa-testutil,serde_json/arbitrary_precision
 ```
 
 Currently, Regorus passes all the non-builtin specific tests.

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -17,5 +17,5 @@ if [ -f Cargo.toml ]; then
    cargo test -r --test aci
 
    # Ensure that OPA conformance tests don't regress.
-   cargo test -r --features opa-testutil --test opa -- $(tr '\n' ' ' < tests/opa.passing)
+   cargo test -r --features opa-testutil,serde_json/arbitrary_precision --test opa -- $(tr '\n' ' ' < tests/opa.passing)
 fi

--- a/src/value.rs
+++ b/src/value.rs
@@ -460,8 +460,8 @@ impl From<u128> for Value {
     /// # use regorus::*;
     /// # fn main() -> anyhow::Result<()> {
     /// assert_eq!(
-    ///   Value::from(340_282_366_920_938_463_463_374_607_431_768_211_455u128),
-    ///   Value::from_json_str("340282366920938463463374607431768211455")?);
+    ///   Value::from(340_282_366_920_938_463_463_374_607_431_768_211_455u128).as_u128()?,
+    ///   340_282_366_920_938_463_463_374_607_431_768_211_455u128);
     /// # Ok(())
     /// # }
     fn from(n: u128) -> Self {
@@ -475,8 +475,8 @@ impl From<i128> for Value {
     /// # use regorus::*;
     /// # fn main() -> anyhow::Result<()> {
     /// assert_eq!(
-    ///   Value::from(-170141183460469231731687303715884105728i128),
-    ///   Value::from_json_str("-170141183460469231731687303715884105728")?);
+    ///   Value::from(-170141183460469231731687303715884105728i128).as_i128()?,
+    ///   -170141183460469231731687303715884105728i128);
     /// # Ok(())
     /// # }
     fn from(n: i128) -> Self {
@@ -551,7 +551,7 @@ impl From<f64> for Value {
     /// # fn main() -> anyhow::Result<()> {
     /// assert_eq!(
     ///   Value::from(3.141592653589793),
-    ///   Value::from_json_str("3.141592653589793")?);
+    ///   Value::from_numeric_string("3.141592653589793")?);
     /// # Ok(())
     /// # }
     /// ```
@@ -559,19 +559,19 @@ impl From<f64> for Value {
     /// Note, f64 can store only around 15 digits of precision whereas [`Value::Number`]
     /// can store arbitrary precision. Adding an extra digit to the f64 literal in the above
     /// example causes loss of precision and the Value created from f64 does not match the
-    /// Value parsed from json string (which is more precise).
+    /// Value parsed from numeric string (which is more precise).
     /// ```
     /// # use regorus::*;
     /// # fn main() -> anyhow::Result<()> {
     /// // The last digit is lost in f64.
     /// assert_ne!(
     ///   Value::from(3.1415926535897932),
-    ///   Value::from_json_str("3.141592653589793232")?);
+    ///   Value::from_numeric_string("3.141592653589793232")?);
     ///
     /// // The value, in this case is equal to parsing the json number with last digit omitted.
     /// assert_ne!(
     ///   Value::from(3.1415926535897932),
-    ///   Value::from_json_str("3.14159265358979323")?);
+    ///   Value::from_numeric_string("3.14159265358979323")?);
     /// # Ok(())
     /// # }
     /// ```
@@ -643,9 +643,9 @@ impl Value {
     /// # fn main() -> anyhow::Result<()> {
     /// let v = Value::from_numeric_string("3.14159265358979323846264338327950288419716939937510")?;
     ///
-    /// assert_eq!(
-    ///   v.to_json_str()?,
-    ///   "3.1415926535897932384626433832795028841971693993751");
+    /// println!("{}", v.to_json_str()?);
+    /// // Prints 3.1415926535897932384626433832795028841971693993751 if serde_json/arbitrary_precision feature is enabled.
+    /// // Prints 3.141592653589793 if serde_json/arbitrary_precision is not enabled.
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
The feature does not interoperate well with other serde_json features like untagged enums.

Fixes #199