### PR TITLE
build: remove unused compact-rc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ uuid = { version = "1.6.1", features = ["v4", "fast-rng"], optional = true }
 jsonschema = { version = "0.17.1", default-features = false, optional = true }
 chrono = { version = "0.4.31", optional = true }
 chrono-tz = { version = "0.8.5", optional = true }
-compact-rc = "0.5.2"
 jsonwebtoken = { version = "9.2.0", optional = true }
 itertools = "0.12.1"
 


### PR DESCRIPTION
Remove unused compact-rc dependency, to avoid a build error:

error[E0658]: use of unstable library feature 'ptr_addr_eq' <...>/registry/src/index.crates.io-6f17d22bba15001f/compact-rc-0.5.4/src/base.rs:319:9
    |
319 |         std::ptr::addr_eq(Self::as_ptr(this), Self::as_ptr(other))