### PR TITLE
Fix anyhow dependency issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ full-opa = [
 opa-testutil = []
 
 [dependencies]
-anyhow = {version = "1.0.66", features = ["backtrace"] }
+anyhow = { version = "1.0.45", default-features=false }
 serde = {version = "1.0.150", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 serde_yaml = {version = "0.9.16", optional = true }
@@ -108,7 +108,7 @@ test-generator = "0.3.1"
 walkdir = "2.3.2"
 
 [build-dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0"
 
 [profile.release]
 debug = true

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow = "1.0"
 regorus = { path  = "../.." }
 serde_json = "1.0.113"
 

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["interpreter", "opa", "policy-as-code", "rego"]
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow = "1.0"
 serde_json = "1.0.112"
 jni = "0.21.1"
 regorus = { path = "../.." }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["interpreter", "opa", "policy-as-code", "rego"]
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow = "1.0"
 ordered-float = "4.2.0"
 pyo3 = {version = "0.21.0", features = ["anyhow", "extension-module"] }
 regorus = { path  = "../.." }

--- a/src/builtins/semver.rs
+++ b/src/builtins/semver.rs
@@ -12,7 +12,7 @@ use semver::Version;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use anyhow::{Ok, Result};
+use anyhow::Result;
 
 pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("semver.compare", (compare, 2));

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -9,7 +9,7 @@ use crate::value::Value;
 
 use std::collections::{BTreeMap, HashMap};
 
-use anyhow::{Ok, Result};
+use anyhow::Result;
 use uuid::{Timestamp, Uuid};
 
 pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {


### PR DESCRIPTION
- Do not require backtrace feature
- Starting version 1.0.77, anyhow gathers backtrace is std feature (enabled by default) is specified even if backtrace feature is not enabled. Therefore specify default features as false.
- Specify version 1.0.45 since that is the minimul version required to successfully compile regorus