### PR TITLE
Use alloc, core instead of std

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,7 +5,7 @@ use crate::lexer::*;
 use crate::value::Value;
 use crate::Rc;
 
-use std::ops::Deref;
+use core::{cmp, fmt, ops::Deref};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BinOp {
@@ -48,28 +48,28 @@ impl<T> Clone for NodeRef<T> {
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for NodeRef<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: fmt::Debug> fmt::Debug for NodeRef<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.r.as_ref().fmt(f)
     }
 }
 
-impl<T> std::cmp::PartialEq for NodeRef<T> {
+impl<T> cmp::PartialEq for NodeRef<T> {
     fn eq(&self, other: &Self) -> bool {
         Rc::as_ptr(&self.r).eq(&Rc::as_ptr(&other.r))
     }
 }
 
-impl<T> std::cmp::Eq for NodeRef<T> {}
+impl<T> cmp::Eq for NodeRef<T> {}
 
-impl<T> std::cmp::Ord for NodeRef<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+impl<T> cmp::Ord for NodeRef<T> {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         Rc::as_ptr(&self.r).cmp(&Rc::as_ptr(&other.r))
     }
 }
 
-impl<T> std::cmp::PartialOrd for NodeRef<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+impl<T> cmp::PartialOrd for NodeRef<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/src/builtins/aggregates.rs
+++ b/src/builtins/aggregates.rs
@@ -8,11 +8,9 @@ use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("count", (count, 1));
     m.insert("max", (max, 1));
     m.insert("min", (min, 1));

--- a/src/builtins/arrays.rs
+++ b/src/builtins/arrays.rs
@@ -8,11 +8,9 @@ use crate::lexer::Span;
 use crate::Rc;
 use crate::Value;
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("array.concat", (concat, 2));
     m.insert("array.reverse", (reverse, 1));
     m.insert("array.slice", (slice, 3));

--- a/src/builtins/bitwise.rs
+++ b/src/builtins/bitwise.rs
@@ -8,11 +8,9 @@ use crate::builtins::utils::{ensure_args_count, ensure_numeric};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("bits.and", (and, 2));
     m.insert("bits.lsh", (lsh, 2));
     m.insert("bits.negate", (negate, 1));

--- a/src/builtins/conversions.rs
+++ b/src/builtins/conversions.rs
@@ -7,11 +7,9 @@ use crate::builtins::utils::ensure_args_count;
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("to_number", (to_number, 1));
 }
 

--- a/src/builtins/crypto.rs
+++ b/src/builtins/crypto.rs
@@ -7,8 +7,6 @@ use crate::builtins::utils::{ensure_args_count, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 use constant_time_eq::constant_time_eq;
 use hmac::{Hmac, Mac};
@@ -16,7 +14,7 @@ use md5::{Digest, Md5};
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("crypto.hmac.equal", (hmac_equal_fixed_time, 2));
     m.insert("crypto.hmac.md5", (hmac_md5, 2));
     m.insert("crypto.hmac.sha1", (hmac_sha1, 2));

--- a/src/builtins/debugging.rs
+++ b/src/builtins/debugging.rs
@@ -6,14 +6,12 @@ use crate::builtins;
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 
 // TODO: Should we avoid this limit?
-const MAX_ARGS: u8 = std::u8::MAX;
+const MAX_ARGS: u8 = core::u8::MAX;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("print", (print, MAX_ARGS));
 }
 

--- a/src/builtins/deprecated.rs
+++ b/src/builtins/deprecated.rs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 use crate::ast::{Expr, Ref};
+use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_set};
 use crate::builtins::BuiltinFcn;
 use crate::lexer::Span;
 use crate::value::Value;
-
-use std::collections::HashMap;
 
 use anyhow::{bail, Result};
 use lazy_static::lazy_static;
@@ -17,8 +16,8 @@ use crate::builtins::regex::regex_match;
 
 #[rustfmt::skip]
 lazy_static! {
-    pub static ref DEPRECATED: HashMap<&'static str, BuiltinFcn> = {
-	let mut m : HashMap<&'static str, BuiltinFcn>  = HashMap::new();
+    pub static ref DEPRECATED: builtins::BuiltinsMap<&'static str, BuiltinFcn> = {
+	let mut m : builtins::BuiltinsMap<&'static str, BuiltinFcn>  = builtins::BuiltinsMap::new();
 	
 	m.insert("all", (all, 1));
 	m.insert("any", (any, 1));

--- a/src/builtins/encoding.rs
+++ b/src/builtins/encoding.rs
@@ -10,12 +10,10 @@ use crate::builtins::utils::{
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 #[allow(unused)]
 use anyhow::{anyhow, bail, Context, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     #[cfg(feature = "base64")]
     {
         m.insert("base64.decode", (base64_decode, 1));
@@ -238,7 +236,7 @@ fn urlquery_decode_object(
         Err(_) => bail!(params[0].span().error("not a valid url query")),
     };
 
-    let mut map = std::collections::BTreeMap::new();
+    let mut map = alloc::collections::BTreeMap::new();
     for (k, v) in url.query_pairs() {
         let key = Value::String(k.clone().into());
         let value = Value::String(v.clone().into());

--- a/src/builtins/glob.rs
+++ b/src/builtins/glob.rs
@@ -7,13 +7,11 @@ use crate::builtins::utils::{ensure_args_count, ensure_string, ensure_string_col
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 //use glob::{Pattern, MatchOptions};
 use wax::{Glob, Pattern};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("glob.match", (glob_match, 3));
     m.insert("glob.quote_meta", (quote_meta, 1));
 }

--- a/src/builtins/graph.rs
+++ b/src/builtins/graph.rs
@@ -7,11 +7,11 @@ use crate::builtins::utils::{ensure_args_count, ensure_object};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("graph.reachable", (reachable, 2));
     m.insert("graph.reachable_paths", (reachable_paths, 2));
     m.insert("walk", (walk, 1));

--- a/src/builtins/http.rs
+++ b/src/builtins/http.rs
@@ -8,11 +8,9 @@ use crate::builtins::utils::ensure_args_count;
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("http.send", (send, 1));
 }
 

--- a/src/builtins/jwt.rs
+++ b/src/builtins/jwt.rs
@@ -9,11 +9,10 @@ use crate::lexer::Span;
 use crate::value::Value;
 
 use itertools::Itertools;
-use std::collections::HashMap;
 
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("io.jwt.decode", (jwt_decode, 1));
     m.insert("io.jwt.decode_verify", (jwt_decode_verify, 2));
 }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -47,7 +47,7 @@ use crate::ast::{Expr, Ref};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
+use std::collections::HashMap as BuiltinsMap;
 
 use anyhow::Result;
 use lazy_static::lazy_static;
@@ -61,8 +61,8 @@ pub use deprecated::DEPRECATED;
 
 #[rustfmt::skip]
 lazy_static! {
-    pub static ref BUILTINS: HashMap<&'static str, BuiltinFcn> = {
-	let mut m : HashMap<&'static str, BuiltinFcn>  = HashMap::new();
+    pub static ref BUILTINS: BuiltinsMap<&'static str, BuiltinFcn> = {
+	let mut m : BuiltinsMap<&'static str, BuiltinFcn>  = BuiltinsMap::new();
 	
 	// comparison functions are directly called.
 	numbers::register(&mut m);

--- a/src/builtins/numbers.rs
+++ b/src/builtins/numbers.rs
@@ -8,12 +8,10 @@ use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 use rand::{thread_rng, Rng};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("abs", (abs, 1));
     m.insert("ceil", (ceil, 1));
     m.insert("floor", (floor, 1));

--- a/src/builtins/objects.rs
+++ b/src/builtins/objects.rs
@@ -8,12 +8,12 @@ use crate::lexer::Span;
 use crate::Rc;
 use crate::Value;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::iter::Iterator;
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::iter::Iterator;
 
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("json.filter", (json_filter, 2));
     m.insert("json.remove", (json_remove, 2));
     m.insert("object.filter", (filter, 2));

--- a/src/builtins/opa.rs
+++ b/src/builtins/opa.rs
@@ -8,11 +8,11 @@ use crate::builtins::utils::ensure_args_count;
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::{BTreeMap, HashMap};
+use alloc::collections::BTreeMap;
 
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("opa.runtime", (opa_runtime, 0));
 }
 

--- a/src/builtins/regex.rs
+++ b/src/builtins/regex.rs
@@ -7,12 +7,10 @@ use crate::builtins::utils::{ensure_args_count, ensure_numeric, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 use regex::Regex;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert(
         "regex.find_all_string_submatch_n",
         (find_all_string_submatch_n, 3),

--- a/src/builtins/semver.rs
+++ b/src/builtins/semver.rs
@@ -9,12 +9,11 @@ use crate::value::Value;
 
 use semver::Version;
 
-use std::cmp::Ordering;
-use std::collections::HashMap;
+use core::cmp::Ordering;
 
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("semver.compare", (compare, 2));
     m.insert("semver.is_valid", (is_valid, 1));
 }

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -7,11 +7,11 @@ use crate::builtins::utils::{ensure_args_count, ensure_set};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::{BTreeSet, HashMap};
+use alloc::collections::BTreeSet;
 
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("intersection", (intersection_of_set_of_sets, 1));
     m.insert("union", (union_of_set_of_sets, 1));
 }
@@ -56,7 +56,7 @@ fn intersection_of_set_of_sets(
         };
 
         if first {
-            res = (**s).clone();
+            res.clone_from(s);
             first = false;
         } else {
             res = res.intersection(s).cloned().collect();

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -11,11 +11,9 @@ use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("concat", (concat, 2));
     m.insert("contains", (contains, 2));
     m.insert("endswith", (endswith, 2));

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -8,12 +8,11 @@ use crate::builtins::utils::{ensure_args_count, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
 use std::thread;
 
 use anyhow::{Ok, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("test.sleep", (sleep, 1));
 }
 

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -7,8 +7,6 @@ use crate::builtins::utils::{ensure_args_count, ensure_numeric, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Result};
 
 use chrono::{
@@ -20,7 +18,7 @@ use chrono_tz::Tz;
 pub(in crate::builtins) mod compat;
 mod diff;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("time.add_date", (add_date, 4));
     m.insert("time.clock", (clock, 1));
     m.insert("time.date", (date, 1));

--- a/src/builtins/time/compat.rs
+++ b/src/builtins/time/compat.rs
@@ -31,9 +31,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use core::fmt;
+use core::iter;
 use std::error::Error;
-use std::fmt;
-use std::iter;
 
 use chrono::TimeZone;
 use chrono::{

--- a/src/builtins/tracing.rs
+++ b/src/builtins/tracing.rs
@@ -7,11 +7,9 @@ use crate::builtins::utils::{ensure_args_count, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("trace", (trace, 1));
 }
 

--- a/src/builtins/types.rs
+++ b/src/builtins/types.rs
@@ -7,11 +7,9 @@ use crate::builtins::utils::ensure_args_count;
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("is_array", (is_array, 1));
     m.insert("is_boolean", (is_boolean, 1));
     m.insert("is_null", (is_null, 1));

--- a/src/builtins/units.rs
+++ b/src/builtins/units.rs
@@ -8,11 +8,9 @@ use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Context, Result};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("units.parse", (parse, 1));
     m.insert("units.parse_bytes", (parse_bytes, 1));
 }

--- a/src/builtins/utils.rs
+++ b/src/builtins/utils.rs
@@ -7,7 +7,7 @@ use crate::number::Number;
 use crate::Rc;
 use crate::Value;
 
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{bail, Result};
 

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -7,12 +7,12 @@ use crate::builtins::utils::{ensure_args_count, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::{BTreeMap, HashMap};
+use alloc::collections::BTreeMap;
 
 use anyhow::Result;
 use uuid::{Timestamp, Uuid};
 
-pub fn register(m: &mut HashMap<&'static str, builtins::BuiltinFcn>) {
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("uuid.parse", (parse, 1));
     m.insert("uuid.rfc4122", (rfc4122, 1));
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -10,7 +10,7 @@ use crate::utils::gather_functions;
 use crate::value::*;
 use crate::{Extension, QueryResults};
 
-use std::convert::AsRef;
+use core::convert::AsRef;
 use std::path::Path;
 
 use anyhow::{bail, Result};

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use core::fmt::{Debug, Formatter};
+use core::cmp;
+use core::convert::AsRef;
+use core::fmt::{self, Debug, Formatter};
 use core::iter::Peekable;
 use core::str::CharIndices;
 
-use std::convert::AsRef;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 
@@ -26,25 +27,25 @@ pub struct Source {
     src: Rc<SourceInternal>,
 }
 
-impl std::cmp::Ord for Source {
-    fn cmp(&self, other: &Source) -> std::cmp::Ordering {
+impl cmp::Ord for Source {
+    fn cmp(&self, other: &Source) -> cmp::Ordering {
         Rc::as_ptr(&self.src).cmp(&Rc::as_ptr(&other.src))
     }
 }
 
-impl std::cmp::PartialOrd for Source {
-    fn partial_cmp(&self, other: &Source) -> Option<std::cmp::Ordering> {
+impl cmp::PartialOrd for Source {
+    fn partial_cmp(&self, other: &Source) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::cmp::PartialEq for Source {
+impl cmp::PartialEq for Source {
     fn eq(&self, other: &Source) -> bool {
         Rc::as_ptr(&self.src) == Rc::as_ptr(&other.src)
     }
 }
 
-impl std::cmp::Eq for Source {}
+impl cmp::Eq for Source {}
 
 impl Hash for Source {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -53,7 +54,7 @@ impl Hash for Source {
 }
 
 impl Debug for Source {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         self.src.file.fmt(f)
     }
 }
@@ -66,14 +67,14 @@ pub struct SourceStr {
 }
 
 impl Debug for SourceStr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         self.text().fmt(f)
     }
 }
 
-impl std::fmt::Display for SourceStr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        std::fmt::Display::fmt(&self.text(), f)
+impl fmt::Display for SourceStr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        fmt::Display::fmt(&self.text(), f)
     }
 }
 
@@ -95,22 +96,22 @@ impl SourceStr {
     }
 }
 
-impl std::cmp::PartialEq for SourceStr {
+impl cmp::PartialEq for SourceStr {
     fn eq(&self, other: &Self) -> bool {
         self.text().eq(other.text())
     }
 }
 
-impl std::cmp::Eq for SourceStr {}
+impl cmp::Eq for SourceStr {}
 
-impl std::cmp::PartialOrd for SourceStr {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+impl cmp::PartialOrd for SourceStr {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.text().cmp(other.text()))
     }
 }
 
-impl std::cmp::Ord for SourceStr {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+impl cmp::Ord for SourceStr {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.text().cmp(other.text())
     }
 }
@@ -240,7 +241,7 @@ impl Span {
 }
 
 impl Debug for Span {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let t = self.text().escape_debug().to_string();
         let max = 32;
         let (txt, trailer) = if t.len() > max {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+extern crate alloc;
 use serde::Serialize;
 
 mod ast;
@@ -22,10 +23,12 @@ pub use engine::Engine;
 pub use value::Value;
 
 #[cfg(feature = "arc")]
-use std::sync::Arc as Rc;
+use alloc::sync::Arc as Rc;
 
 #[cfg(not(feature = "arc"))]
-use std::rc::Rc;
+use alloc::rc::Rc;
+
+use core::fmt;
 
 /// Location of an [`Expression`] in a Rego query.
 ///
@@ -334,8 +337,8 @@ impl<'a> Clone for Box<dyn 'a + Extension> {
     }
 }
 
-impl std::fmt::Debug for dyn Extension {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+impl fmt::Debug for dyn Extension {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> core::result::Result<(), fmt::Error> {
         f.write_fmt(format_args!("<extension>"))
     }
 }
@@ -353,10 +356,10 @@ pub mod coverage {
         pub code: String,
 
         /// Lines that were evaluated.
-        pub covered: std::collections::BTreeSet<u32>,
+        pub covered: alloc::collections::BTreeSet<u32>,
 
         /// Lines that were not evaluated.
-        pub not_covered: std::collections::BTreeSet<u32>,
+        pub not_covered: alloc::collections::BTreeSet<u32>,
     }
 
     #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -398,7 +401,7 @@ pub mod coverage {
             }
 
             writeln!(&mut s)?;
-            Ok(std::str::from_utf8(&s)?.to_string())
+            Ok(core::str::from_utf8(&s)?.to_string())
         }
     }
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use alloc::str::FromStr;
+use core::cmp::{Ord, Ordering};
 use core::fmt::{Debug, Formatter};
-use std::cmp::{Ord, Ordering};
-use std::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
 
@@ -61,7 +61,7 @@ pub enum Number {
 }
 
 impl Debug for Number {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
         match self {
             Number::Big(b) => b.d.fmt(f),
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,8 +6,8 @@ use crate::lexer::*;
 use crate::number::*;
 use crate::value::*;
 
-use std::collections::BTreeMap;
-use std::str::FromStr;
+use alloc::collections::BTreeMap;
+use core::str::FromStr;
 
 use anyhow::{anyhow, bail, Result};
 
@@ -65,7 +65,7 @@ impl<'source> Parser<'source> {
     }
 
     fn is_imported_future_keyword(&self, kw: &str) -> bool {
-        self.future_keywords.get(kw).is_some()
+        self.future_keywords.contains_key(kw)
     }
 
     pub fn warn_future_keyword(&self) {
@@ -515,9 +515,9 @@ impl<'source> Parser<'source> {
         while possible_fcn {
             match expr {
                 Expr::Var(_) => break,
-                Expr::RefDot { refr, .. } => expr = &refr,
+                Expr::RefDot { refr, .. } => expr = refr,
                 Expr::RefBrack { refr, index, .. } => {
-                    expr = &refr;
+                    expr = refr;
                     possible_fcn = matches!(index.as_ref(), Expr::String(_));
                 }
                 _ => {
@@ -787,7 +787,7 @@ impl<'source> Parser<'source> {
         let start = self.tok.1.start;
         let mut expr = self.parse_bool_expr()?;
 
-        while self.token_text() == "in" && self.future_keywords.get("in").is_some() {
+        while self.token_text() == "in" && self.future_keywords.contains_key("in") {
             expr = self.parse_membership_tail(start, expr, None)?;
         }
 
@@ -976,7 +976,7 @@ impl<'source> Parser<'source> {
         match self.token_text() {
             "some" => return self.parse_some_stmt(),
             "every" => {
-                if self.future_keywords.get("every").is_some() {
+                if self.future_keywords.contains_key("every") {
                     return self.parse_every_stmt();
                 }
                 self.warn_future_keyword();
@@ -1326,7 +1326,7 @@ impl<'source> Parser<'source> {
     }
 
     pub fn if_is_keyword(&self) -> bool {
-        self.future_keywords.get("if").is_some()
+        self.future_keywords.contains_key("if")
     }
 
     pub fn parse_query_or_literal_stmt(&mut self) -> Result<Query> {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -6,13 +6,15 @@ use crate::ast::*;
 use crate::lexer::*;
 use crate::utils::*;
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
-use std::string::String;
+use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
+use alloc::string::String;
+use core::cmp;
+use core::fmt;
 
 use anyhow::{bail, Result};
 
 #[derive(Debug)]
-pub struct Definition<Str: Clone + std::cmp::Ord> {
+pub struct Definition<Str: Clone + cmp::Ord> {
     // The variable being defined.
     // This can be an empty string to indicate that
     // no variable is being defined.
@@ -24,7 +26,7 @@ pub struct Definition<Str: Clone + std::cmp::Ord> {
 }
 
 #[derive(Debug)]
-pub struct StmtInfo<Str: Clone + std::cmp::Ord> {
+pub struct StmtInfo<Str: Clone + cmp::Ord> {
     // A statement can define multiple variables.
     // A variable can also be defined by multiple statement.
     pub definitions: Vec<Definition<Str>>,
@@ -39,7 +41,7 @@ pub enum SortResult {
     Cycle(String, Vec<usize>),
 }
 
-pub fn schedule<Str: Clone + std::cmp::Ord + std::fmt::Debug>(
+pub fn schedule<Str: Clone + cmp::Ord + fmt::Debug>(
     infos: &mut [StmtInfo<Str>],
     empty: &Str,
 ) -> Result<SortResult> {
@@ -170,7 +172,7 @@ pub fn schedule<Str: Clone + std::cmp::Ord + std::fmt::Debug>(
         done = true;
 
         // Swap with temporary vec.
-        std::mem::swap(&mut vars_to_process, &mut tmp);
+        core::mem::swap(&mut vars_to_process, &mut tmp);
 
         // Loop through each unscheduled var.
         for var in tmp.iter().cloned() {
@@ -630,7 +632,7 @@ impl Analyzer {
         let mut used_vars = vec![];
         let mut comprs = vec![];
         let full_expr = expr;
-        std::convert::identity(&full_expr);
+        core::convert::identity(&full_expr);
         traverse(expr, &mut |e| match e.as_ref() {
             Var(v) if !matches!(v.0.text(), "_" | "input" | "data") => {
                 let name = v.0.source_str();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use crate::ast::*;
 use crate::builtins::*;
 use crate::lexer::*;
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use anyhow::{bail, Result};
 pub fn get_path_string(refr: &Expr, document: Option<&str>) -> Result<String> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,10 +3,11 @@
 
 use crate::number::Number;
 
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::fmt;
-use std::collections::{BTreeMap, BTreeSet};
+use core::ops;
+
 use std::convert::AsRef;
-use std::ops;
 use std::path::Path;
 use std::str::FromStr;
 
@@ -100,7 +101,7 @@ struct ValueVisitor;
 impl<'de> Visitor<'de> for ValueVisitor {
     type Value = Value;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a value")
     }
 
@@ -229,7 +230,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match serde_json::to_string(self) {
             Ok(s) => write!(f, "{s}"),
-            Err(_e) => Err(std::fmt::Error),
+            Err(_e) => Err(fmt::Error),
         }
     }
 }


### PR DESCRIPTION
- Replace std with alloc, core in most places in src Tests, bindings aren't changed.
- Introduce BuiltinsMap type alias inplace of HashMap. In no_std case, this could be aliases to BTreeMap
- Fix clippy warnings