### PR TITLE
add `std` feature

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,8 @@ jobs:
       run: sudo apt update && sudo apt install -y musl-tools
     - name: Format Check
       run: cargo fmt --check
+    - name: Build (all features)
+      run: cargo build -r --all-features --verbose
     - name: Build
       run: cargo build -r --verbose
     - name: Doc Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,10 @@ jsonschema = ["dep:jsonschema"]
 opa-runtime = []
 regex = ["dep:regex"]
 semver = ["dep:semver"]
+std = ["serde_json/std"]
+time = ["dep:chrono", "dep:chrono-tz"]
 uuid = ["dep:uuid"]
 urlquery = ["dep:url"]
-time = ["dep:chrono", "dep:chrono-tz"]
 yaml = ["serde_yaml"]
 full-opa = [
     "base64",
@@ -59,6 +60,7 @@ full-opa = [
     "opa-runtime",
     "regex",
     "semver",
+    "std",
     "time",
     "uuid",
     "urlquery",
@@ -70,8 +72,8 @@ opa-testutil = []
 
 [dependencies]
 anyhow = { version = "1.0.45", default-features=false }
-serde = {version = "1.0.150", features = ["derive", "rc"] }
-serde_json = "1.0.89"
+serde = {version = "1.0.150", default-features = false, features = ["derive", "rc"] }
+serde_json = { version = "1.0.89", default-features=false, features = ["alloc"] }
 serde_yaml = {version = "0.9.16", optional = true }
 lazy_static = "1.4.0"
 rand = "0.8.5"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -11,6 +11,9 @@ if [ -f Cargo.toml ]; then
 
    # Ensure that the public API works
    cargo test -r --doc
+
+   # Ensure that we can build with all features
+   cargo build -r --all-features
    
    # Ensure that all tests pass
    cargo test -r

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,7 @@
 
 use crate::lexer::*;
 use crate::value::Value;
-use crate::Rc;
+use crate::*;
 
 use core::{cmp, fmt, ops::Deref};
 

--- a/src/builtins/aggregates.rs
+++ b/src/builtins/aggregates.rs
@@ -7,6 +7,7 @@ use crate::builtins::utils::{ensure_args_count, ensure_numeric};
 use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 

--- a/src/builtins/conversions.rs
+++ b/src/builtins/conversions.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::ensure_args_count;
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 

--- a/src/builtins/debugging.rs
+++ b/src/builtins/debugging.rs
@@ -5,6 +5,7 @@ use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 
@@ -43,8 +44,10 @@ pub fn print_to_string(
 fn print(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let msg = print_to_string(span, params, args, strict)?;
 
+    #[cfg(feature = "std")]
     if !msg.is_empty() {
-        eprintln!("{}", &msg[1..]);
+        std::eprintln!("{}", &msg[1..]);
     }
+
     Ok(Value::Bool(true))
 }

--- a/src/builtins/deprecated.rs
+++ b/src/builtins/deprecated.rs
@@ -7,6 +7,7 @@ use crate::builtins::utils::{ensure_args_count, ensure_set};
 use crate::builtins::BuiltinFcn;
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 use lazy_static::lazy_static;

--- a/src/builtins/encoding.rs
+++ b/src/builtins/encoding.rs
@@ -9,6 +9,7 @@ use crate::builtins::utils::{
 };
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 #[allow(unused)]
 use anyhow::{anyhow, bail, Context, Result};

--- a/src/builtins/glob.rs
+++ b/src/builtins/glob.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_string, ensure_string_collection};
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 //use glob::{Pattern, MatchOptions};

--- a/src/builtins/graph.rs
+++ b/src/builtins/graph.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_object};
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 

--- a/src/builtins/jwt.rs
+++ b/src/builtins/jwt.rs
@@ -4,6 +4,7 @@
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_string};
+use crate::*;
 
 use crate::lexer::Span;
 use crate::value::Value;

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -47,7 +47,7 @@ use crate::ast::{Expr, Ref};
 use crate::lexer::Span;
 use crate::value::Value;
 
-use std::collections::HashMap as BuiltinsMap;
+use crate::Map as BuiltinsMap;
 
 use anyhow::Result;
 use lazy_static::lazy_static;

--- a/src/builtins/numbers.rs
+++ b/src/builtins/numbers.rs
@@ -7,6 +7,7 @@ use crate::builtins::utils::{ensure_args_count, ensure_numeric, ensure_string};
 use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 use rand::{thread_rng, Rng};

--- a/src/builtins/objects.rs
+++ b/src/builtins/objects.rs
@@ -7,6 +7,7 @@ use crate::builtins::utils::{ensure_args_count, ensure_array, ensure_object};
 use crate::lexer::Span;
 use crate::Rc;
 use crate::Value;
+use crate::*;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use core::iter::Iterator;

--- a/src/builtins/opa.rs
+++ b/src/builtins/opa.rs
@@ -4,6 +4,7 @@
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::ensure_args_count;
+use crate::*;
 
 use crate::lexer::Span;
 use crate::value::Value;

--- a/src/builtins/regex.rs
+++ b/src/builtins/regex.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_numeric, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 use regex::Regex;

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_set};
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use alloc::collections::BTreeSet;
 

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -10,6 +10,7 @@ use crate::builtins::utils::{
 use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_numeric, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use anyhow::{bail, Result};
 

--- a/src/builtins/time/compat.rs
+++ b/src/builtins/time/compat.rs
@@ -31,6 +31,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+use crate::*;
 use core::fmt;
 use core::iter;
 use std::error::Error;
@@ -1242,7 +1243,7 @@ mod tests {
         ];
 
         for tc in test_cases {
-            println!("Test case {}", tc.name);
+            std::println!("Test case {}", tc.name);
             let time = parse(&tc.format, &tc.value).unwrap();
             check_time(time, &tc);
         }
@@ -1313,7 +1314,7 @@ mod tests {
         let time = PST8PDT.timestamp_nanos(1233810057012345600);
 
         for tc in test_cases {
-            println!("Test case {}", tc.name);
+            std::println!("Test case {}", tc.name);
             let result = format(time, &tc.format);
             assert_eq!(result, tc.result);
         }

--- a/src/builtins/units.rs
+++ b/src/builtins/units.rs
@@ -7,8 +7,9 @@ use crate::builtins::utils::{ensure_args_count, ensure_string};
 use crate::lexer::Span;
 use crate::number::Number;
 use crate::value::Value;
+use crate::*;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 
 pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("units.parse", (parse, 1));
@@ -87,12 +88,13 @@ fn parse(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Re
         _ => (string, ""),
     };
 
+    // Propagating the underlying error is not useful here.
     let v: Value = if number_part.starts_with('.') {
         serde_json::from_str(format!("0{number_part}").as_str())
     } else {
         serde_json::from_str(number_part)
     }
-    .with_context(|| span.error("could not parse number"))?;
+    .map_err(|_| params[0].span().error("could not parse number"))?;
 
     let mut n = match v {
         Value::Number(n) => n.clone(),

--- a/src/builtins/utils.rs
+++ b/src/builtins/utils.rs
@@ -6,6 +6,7 @@ use crate::lexer::Span;
 use crate::number::Number;
 use crate::Rc;
 use crate::Value;
+use crate::*;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -6,6 +6,7 @@ use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_string};
 use crate::lexer::Span;
 use crate::value::Value;
+use crate::*;
 
 use alloc::collections::BTreeMap;
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -8,10 +8,8 @@ use crate::parser::*;
 use crate::scheduler::*;
 use crate::utils::gather_functions;
 use crate::value::*;
+use crate::*;
 use crate::{Extension, QueryResults};
-
-use core::convert::AsRef;
-use std::path::Path;
 
 use anyhow::{bail, Result};
 
@@ -89,7 +87,8 @@ impl Engine {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn add_policy_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+    #[cfg(feature = "std")]
+    pub fn add_policy_from_file<P: AsRef<std::path::Path>>(&mut self, path: P) -> Result<()> {
         let source = Source::from_file(path)?;
         let mut parser = Parser::new(&source)?;
         self.modules.push(Ref::new(parser.parse()?));

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::*;
 use core::cmp;
-use core::convert::AsRef;
 use core::fmt::{self, Debug, Formatter};
 use core::iter::Peekable;
 use core::str::CharIndices;
 
-use std::hash::{Hash, Hasher};
-use std::path::Path;
-
-use crate::Rc;
 use crate::Value;
 
 use anyhow::{anyhow, bail, Result};
@@ -47,8 +43,9 @@ impl cmp::PartialEq for Source {
 
 impl cmp::Eq for Source {}
 
-impl Hash for Source {
-    fn hash<H: Hasher>(&self, state: &mut H) {
+#[cfg(feature = "std")]
+impl std::hash::Hash for Source {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         Rc::as_ptr(&self.src).hash(state)
     }
 }
@@ -156,7 +153,8 @@ impl Source {
         })
     }
 
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Source> {
+    #[cfg(feature = "std")]
+    pub fn from_file<P: AsRef<std::path::Path>>(path: P) -> Result<Source> {
         let contents = match std::fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => bail!("Failed to read {}. {e}", path.as_ref().display()),

--- a/src/number.rs
+++ b/src/number.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, bail, Result};
 use serde::ser::Serializer;
 use serde::Serialize;
 
-use crate::Rc;
+use crate::*;
 
 pub type BigInt = i128;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use crate::ast::*;
 use crate::lexer::*;
 use crate::number::*;
 use crate::value::*;
+use crate::*;
 
 use alloc::collections::BTreeMap;
 use core::str::FromStr;
@@ -73,7 +74,8 @@ impl<'source> Parser<'source> {
         let msg = format!(
             "`{kw}` will be treated as identifier due to missing `import future.keywords.{kw}`"
         );
-        println!(
+        #[cfg(feature = "std")]
+        std::println!(
             "{}",
             self.source
                 .message(self.tok.1.line, self.tok.1.col, "warning", &msg)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::ast::Expr::*;
+use crate::ast::Expr::{Set, *};
 use crate::ast::*;
 use crate::lexer::*;
 use crate::utils::*;
+use crate::*;
 
 use alloc::collections::{BTreeMap, BTreeSet, VecDeque};
 use alloc::string::String;
@@ -196,7 +197,8 @@ pub fn schedule<Str: Clone + cmp::Ord + fmt::Debug>(
     }
 
     if order.len() != num_statements {
-        eprintln!("could not schedule all statements {order:?} {orig_infos:?}");
+        #[cfg(feature = "std")]
+        std::eprintln!("could not schedule all statements {order:?} {orig_infos:?}");
         return Ok(SortResult::Order(
             (0..num_statements).map(|i| i as u16).collect(),
         ));

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -176,7 +176,7 @@ pub fn eval_file(
         let r = engine.eval_query(query.to_string(), enable_tracing)?;
         let r_full = engine_full.eval_query_and_all_rules(query.to_string(), enable_tracing)?;
         if r != r_full {
-            println!(
+            std::println!(
                 "{}\n{}",
                 serde_json::to_string_pretty(&r_full)?,
                 serde_json::to_string_pretty(&r)?
@@ -194,7 +194,7 @@ pub fn eval_file(
             let r = engine.eval_query(query.to_string(), enable_tracing)?;
             let r_full = engine_full.eval_query_and_all_rules(query.to_string(), enable_tracing)?;
             if r != r_full {
-                println!(
+                std::println!(
                     "{}\n{}",
                     serde_json::to_string_pretty(&r_full)?,
                     serde_json::to_string_pretty(&r)?
@@ -277,12 +277,12 @@ fn yaml_test_impl(file: &str) -> Result<()> {
     let yaml_str = std::fs::read_to_string(file)?;
     let test: YamlTest = serde_yaml::from_str(&yaml_str)?;
 
-    println!("running {file}");
+    std::println!("running {file}");
 
     for case in test.cases {
-        print!("case {} ", case.note);
+        std::print!("case {} ", case.note);
         if case.skip == Some(true) {
-            println!("skipped");
+            std::println!("skipped");
             continue;
         }
 
@@ -329,13 +329,13 @@ fn yaml_test_impl(file: &str) -> Result<()> {
                             expected
                         );
                     }
-                    println!("{actual}");
+                    std::println!("{actual}");
                 }
                 _ => return Err(actual),
             },
         }
 
-        println!("passed");
+        std::println!("passed");
     }
 
     Ok(())

--- a/src/tests/scheduler/analyzer/mod.rs
+++ b/src/tests/scheduler/analyzer/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::*;
 use crate::{ast::*, lexer::*, parser::*, scheduler::*};
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
@@ -73,25 +74,25 @@ fn analyze_file(regos: &[String], expected_scopes: &[Scope]) -> Result<()> {
             to_string_set(scope.inputs.iter()),
             expected_scopes[idx].inputs
         );
-        println!("scope {idx} matched.")
+        std::println!("scope {idx} matched.")
     }
 
     Ok(())
 }
 
 fn yaml_test_impl(file: &str) -> Result<()> {
-    println!("\nrunning {file}");
+    std::println!("\nrunning {file}");
 
     let yaml_str = std::fs::read_to_string(file)?;
     let test: YamlTest = serde_yaml::from_str(&yaml_str)?;
 
     for case in &test.cases {
-        print!("\ncase {} ", case.note);
+        std::print!("\ncase {} ", case.note);
         analyze_file(&case.modules, &case.scopes)?;
-        println!("passed");
+        std::println!("passed");
     }
 
-    println!("{} cases passed.", test.cases.len());
+    std::println!("{} cases passed.", test.cases.len());
     Ok(())
 }
 

--- a/src/tests/scheduler/mod.rs
+++ b/src/tests/scheduler/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::scheduler::*;
+use crate::*;
 use anyhow::{bail, Result};
 
 mod analyzer;
@@ -20,7 +21,7 @@ fn make_info(definitions: &[(&'static str, &[&'static str])]) -> StmtInfo<&'stat
 
 fn print_stmts(stmts: &[&str], order: &[u16]) {
     for idx in order.iter().cloned() {
-        println!("{}", stmts[idx as usize]);
+        std::println!("{}", stmts[idx as usize]);
     }
 }
 
@@ -29,7 +30,7 @@ fn check_result(stmts: &[&str], expected: &[&str], r: SortResult) -> Result<()> 
         SortResult::Order(order) => {
             print_stmts(stmts, &order);
             for (i, o) in order.iter().cloned().enumerate() {
-                println!("{:30}{}", stmts[o as usize], expected[i]);
+                std::println!("{:30}{}", stmts[o as usize], expected[i]);
             }
             for (i, o) in order.iter().cloned().enumerate() {
                 assert_eq!(stmts[o as usize], expected[i]);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@
 use crate::ast::*;
 use crate::builtins::*;
 use crate::lexer::*;
+use crate::*;
 
 use alloc::collections::BTreeMap;
 


### PR DESCRIPTION
- `std` feature is enabled by default
- By default enable #![no_std] compilation
- Import std create if `std` feature is enabled or if testing
- Use core, alloc types
- Make it clear where std types are being used
- In no std, use BTreeMap in place of HashMap. HashMap is not available in no std due to lack of a secure random number generator

Note: The project does not yet compile without std feature being specified. But it's really close to being able to do so.