### PR TITLE
Update ruby bindings for add_policy to return package name

### DIFF
--- a/bindings/ruby/Gemfile
+++ b/bindings/ruby/Gemfile
@@ -7,10 +7,10 @@ gemspec
 
 # These gems are required for local development and testing,
 # but won't be included in the published gem
-gem "minitest", "~> 5.16"
-gem "rake", "~> 13.0"
+gem "minitest", "~> 5.22"
+gem "rake", "~> 13.2"
 gem "rake-compiler"
 gem "rake-compiler-dock"
-gem "rubocop", "~> 1.62", require: false
+gem "rubocop", "~> 1.63", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-rake", require: false

--- a/bindings/ruby/Gemfile.lock
+++ b/bindings/ruby/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     regorusrb (0.1.0)
-      rb_sys (~> 0.9.91)
+      rb_sys (~> 0.9.97)
 
 GEM
   remote: https://rubygems.org/
@@ -10,9 +10,9 @@ GEM
     ast (2.4.2)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    minitest (5.22.3)
+    minitest (5.23.0)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     racc (1.7.3)
@@ -20,12 +20,12 @@ GEM
     rake (13.2.1)
     rake-compiler (1.2.7)
       rake
-    rake-compiler-dock (1.4.0)
-    rb_sys (0.9.91)
-    regexp_parser (2.9.0)
+    rake-compiler-dock (1.5.0)
+    rb_sys (0.9.97)
+    regexp_parser (2.9.2)
     rexml (3.2.8)
       strscan (>= 3.0.9)
-    rubocop (1.63.0)
+    rubocop (1.63.5)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -36,8 +36,8 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.2)
-      parser (>= 3.3.0.4)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
     rubocop-minitest (0.35.0)
       rubocop (>= 1.61, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -52,12 +52,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  minitest (~> 5.16)
-  rake (~> 13.0)
+  minitest (~> 5.22)
+  rake (~> 13.2)
   rake-compiler
   rake-compiler-dock
   regorusrb!
-  rubocop (~> 1.62)
+  rubocop (~> 1.63)
   rubocop-minitest
   rubocop-rake
 

--- a/bindings/ruby/ext/regorusrb/src/lib.rs
+++ b/bindings/ruby/ext/regorusrb/src/lib.rs
@@ -36,14 +36,14 @@ impl Engine {
         }
     }
 
-    fn add_policy(&self, path: String, rego: String) -> Result<(), Error> {
+    fn add_policy(&self, path: String, rego: String) -> Result<String, Error> {
         self.engine
             .borrow_mut()
             .add_policy(path, rego)
             .map_err(|e| Error::new(runtime_error(), format!("Failed to add policy: {}", e)))
     }
 
-    fn add_policy_from_file(&self, path: String) -> Result<(), Error> {
+    fn add_policy_from_file(&self, path: String) -> Result<String, Error> {
         self.engine
             .borrow_mut()
             .add_policy_from_file(path)

--- a/bindings/ruby/regorusrb.gemspec
+++ b/bindings/ruby/regorusrb.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/regorusrb/extconf.rb"]
-  spec.add_dependency "rb_sys", "~> 0.9.91"
+  spec.add_dependency "rb_sys", "~> 0.9.97"
 end

--- a/bindings/ruby/test/test_regorus.rb
+++ b/bindings/ruby/test/test_regorus.rb
@@ -59,7 +59,8 @@ class TestRegorus < Minitest::Test
   end
 
   def test_policy_addition
-    assert_silent { @engine.add_policy("example.rego", example_policy) }
+    # returns the package name from the REGO, not the filename
+    assert_equal "data.regorus_test", @engine.add_policy("example.rego", example_policy)
   end
 
   def test_object_creation_with_new


### PR DESCRIPTION
Update ruby bindings for `#add_policy()` and `#add_policy_from_file` to return string package name.

Also bump the `rb_sys` runtime dependency, and the development dependencies.