### PR TITLE
Add test-ruby CI for github actions

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -1,0 +1,30 @@
+name: test-ruby
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Ruby and Rust
+        uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: "3.3.1"
+          rustup-toolchain: "stable"
+          bundler-cache: true
+          cargo-cache: true
+          working-directory: "bindings/ruby"
+
+      - name: Run ruby tests
+        run:  |
+          cd bindings/ruby
+          bundle exec rake


### PR DESCRIPTION
This change adds a `test-ruby` CI workflow that is triggered on pushes and pull requests to `main`, and will run the default rake task of `compile test rubocop`.

Happy to change the naming or triggers here, but wanted to see what it would take to get the ruby test suite run as part of CI.

see https://github.com/oxidize-rb/actions/blob/main/setup-ruby-and-rust/readme.md for docs on the rust and ruby setup action.

see https://github.com/thedavemarshall/regorus/actions/runs/9142734035/job/25138614189 for an example run of this workflow.
