### PR TITLE
expose policy info from the engine

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -129,6 +129,61 @@ impl Engine {
             .collect()
     }
 
+    pub fn get_packages_texts(&self) -> Result<Map<String, String>> {
+        let mut packages_text: Map<String, String> = Map::new();
+
+        for module in &self.modules {
+            let path_string = Interpreter::get_path_string(&module.package.refr, Some("data"))?;
+            let package_text = module.package.span.text().to_string();
+            packages_text.insert(path_string, package_text);
+        }
+
+        Ok(packages_text)
+    }
+
+    pub fn get_packages_imports(&self) -> Result<Map<String, Vec<String>>> {
+        let mut packages_imports: Map<String, Vec<String>> = Map::new();
+
+        for module in &self.modules {
+            let path_string = Interpreter::get_path_string(&module.package.refr, Some("data"))?;
+            let import_strings: Result<Vec<String>> = module
+                .imports
+                .iter()
+                .map(|import| Ok(import.span.text().to_string()))
+                .collect();
+            packages_imports.insert(path_string, import_strings?);
+        }
+
+        Ok(packages_imports)
+    }
+
+    pub fn get_packages_policies(&self) -> Result<Map<String, Vec<String>>> {
+        let mut packages_policies: Map<String, Vec<String>> = Map::new();
+
+        for module in &self.modules {
+            let path_string = Interpreter::get_path_string(&module.package.refr, Some("data"))?;
+            let policy_strings: Result<Vec<String>> = module
+                .policy
+                .iter()
+                .map(|policy| Ok(policy.span().text().to_string()))
+                .collect();
+            packages_policies.insert(path_string, policy_strings?);
+        }
+
+        Ok(packages_policies)
+    }
+
+    pub fn get_package_rego_v1(&self) -> Result<Map<String, bool>> {
+        let mut packages_rego_v1s: Map<String, bool> = Map::new();
+
+        for module in &self.modules {
+            let path_string = Interpreter::get_path_string(&module.package.refr, Some("data"))?;
+            packages_rego_v1s.insert(path_string, module.rego_v1);
+        }
+
+        Ok(packages_rego_v1s)
+    }
+
     /// Set the input document.
     ///
     /// * `input`: Input documented. Typically this [Value] is constructed from JSON or YAML.


### PR DESCRIPTION
This change is to expose more package data from the engine, potentially addressing https://github.com/microsoft/regorus/issues/254

@anakrish I know you've mentioned the ast and some of the internals are unstable and being iterated on, so I'd love you input here if this is a good approach, or if you're not ready to expose these things through the engine.

I had some trouble getting a method of `package name -> [rule_name1, rule_name2]` , so I'm curious if there's a good way to do that with the current abstractions, or if that's something I could potentially help out with.