### PR TITLE
rename method from Clone to clone inEngine class to match the java naming convention and definition in the java.lang.Object.

### DIFF
--- a/bindings/java/src/main/java/com/microsoft/regorus/Engine.java
+++ b/bindings/java/src/main/java/com/microsoft/regorus/Engine.java
@@ -60,7 +60,7 @@ public class Engine implements AutoCloseable, Cloneable {
     /**
      * Efficiently clones an Engine.
      */
-    public Engine Clone() {
+    public Engine clone() {
 	return new Engine(nativeClone(enginePtr));
     }
     


### PR DESCRIPTION
rename method from `Clone` to `clone` in `Engine` class to match the java naming convention and definition in the `java.lang.Object`.

An alternative would be to mark the current `Clone` as `@Deprecated` and add a new method `clone`. As the fails happens on compile time and Regorus is not at a peak adoption,  I think that just renaming the method is better. 
