### PR TITLE
Fix issues in c,cpp,no-std binding examples

### DIFF
--- a/.github/workflows/test-c-cpp.yml
+++ b/.github/workflows/test-c-cpp.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Setup gcc, g++, cmake, ninja
         run: sudo apt update && sudo apt install -y gcc g++ cmake ninja-build
 
+      - name: Workaround to ensure that regorus.h is generated
+        run: |
+          cargo build -r
+        working-directory: ./bindings/ffi
+        
       - name: Test c binding
         run: |
           mkdir bindings/c/build

--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -1,4 +1,4 @@
-name: bindings/c-cpp
+name: bindings/ffi
 
 on:
   push:

--- a/bindings/c-nostd/CMakeLists.txt
+++ b/bindings/c-nostd/CMakeLists.txt
@@ -38,4 +38,4 @@ corrosion_import_crate(
 add_executable(regorus_test main.c)
 # Add path to <regorus-source-folder>/bindings/ffi
 target_include_directories(regorus_test PRIVATE "../ffi")
-target_link_libraries(regorus_test regorus-ffi)
+target_link_libraries(regorus_test regorus_ffi)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -31,4 +31,4 @@ corrosion_import_crate(
 add_executable(regorus_test main.c)
 # Add path to <regorus-source-folder>/bindings/ffi
 target_include_directories(regorus_test PRIVATE "../ffi")
-target_link_libraries(regorus_test regorus-ffi)
+target_link_libraries(regorus_test regorus_ffi)

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -31,4 +31,4 @@ corrosion_import_crate(
 add_executable(regorus_test main.cpp)
 # Add path to <regorus-source-folder>/bindings/ffi
 target_include_directories(regorus_test PRIVATE "../ffi")
-target_link_libraries(regorus_test regorus-ffi)
+target_link_libraries(regorus_test regorus_ffi)


### PR DESCRIPTION
All of a sudden these fail due to
- `regorus.h` not being available. Smething has likely changed in corrosion-rs to cause the main to be compiled before the headers are generated. It could also be a latent issue.
- Link error due to missing libregorus-ffi.so. 

The fix for the former is to ensure in the workflow file that the header is generated by explicitly compiling the ffi binding.
The fix for the latter is to use `regorus_ffi` in target_link_libraries instead of `regorus-ffi`.