### PR TITLE
build.rs create hooks dir if not exists

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,9 @@ fn main() -> Result<()> {
     // Copy hooks to appropriate location so that git will run them.
     // In git worktrees, .git is a symlink and the following commands fail.
     if Path::new(".git").is_dir() {
+        if !Path::new("./.git/hooks").exists() {
+            std::fs::create_dir_all("./.git/hooks")?;
+        }
         std::fs::copy("./scripts/pre-commit", "./.git/hooks/pre-commit")?;
         std::fs::copy("./scripts/pre-push", "./.git/hooks/pre-push")?;
     }

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -121,6 +121,7 @@ fn timestamp(uuid: &Uuid) -> Option<Timestamp> {
     // https://github.com/uuid-rs/uuid/blob/94ecea893fadac93248f1bd6f47673c09cec5912/src/lib.rs#L900-L904
     if uuid.get_version_num() == 2 {
         let (ticks, counter) = decode_rfc4122_timestamp(uuid);
+        #[allow(deprecated)]
         return Some(Timestamp::from_rfc4122(ticks, counter));
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -386,6 +386,7 @@ pub struct Analyzer {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct Schedule {
     pub scopes: BTreeMap<Ref<Query>, Scope>,
     pub order: BTreeMap<Ref<Query>, Vec<u16>>,


### PR DESCRIPTION
build.rs should create the `.git/hooks` directory if it does not exist, to address the following error when attempting to copy the hooks.

```
error: failed to run custom build command for `regorus v0.2.1 (C:\Source\regorus)`

Caused by:
  process didn't exit successfully: `C:\Source\regorus\target\debug\build\regorus-1728766aaa50ee3c\build-script-build` (exit code: 1)
  --- stderr
  Error: The system cannot find the path specified. (os error 3)
```