### PR TITLE
fix: Handle aliases in scheduler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(unknown_lints)]
+#![allow(clippy::doc_lazy_continuation)]
 // Use README.md as crate documentation.
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 // We'll default to building for no_std - use core, alloc instead of std.

--- a/tests/interpreter/cases/import/tests.yaml
+++ b/tests/interpreter/cases/import/tests.yaml
@@ -34,6 +34,7 @@ cases:
         
       - |
         package b
+        import rego.v1
         # Both the following imports are overridden by rules
         #import data.a.b as a
         #import data.a.b
@@ -43,6 +44,10 @@ cases:
 
         a = 10
         c = C + b
+
+        r if {
+          some v in [C]
+        }
     query: data
     want_result:
       a:
@@ -50,6 +55,7 @@ cases:
       b:
         a: 10
         c: 22
+        r: true
         
   - note: import overridden by rule
     modules:


### PR DESCRIPTION
Earlier scheduler only recognized rules and would raise an `unsafe var` error on alias.

Register alias var names to fix this.

fixes #284