### PR TITLE
fix: Match OPA behavior for split

### DIFF
--- a/tests/interpreter/cases/builtins/strings/split.yaml
+++ b/tests/interpreter/cases/builtins/strings/split.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: empty separator
+    data: {}
+    modules: []
+    query: "x := split(\"test\", \"\")"
+    want_result:
+      x: ["t", "e", "s", "t"]
+      
+  - note: empty separator, empty string
+    data: {}
+    modules: []
+    query: "x := split(\"\", \"\")"
+    want_result:
+      x: []


### PR DESCRIPTION
In case of empty delimiter, Rust's split returns leading and trailing empty strings whereas Golang's doesn't.
Change behavior to match Golang/OPA.

fixes #291