### PR TITLE
fix: Issues #302, #303

### DIFF
--- a/tests/interpreter/cases/rule/else.yaml
+++ b/tests/interpreter/cases/rule/else.yaml
@@ -2,17 +2,34 @@
 # Licensed under the MIT License.
 
 cases:
-  - note: else without body
+  # - note: else without body
+  #   data: {}
+  #   modules:
+  #     - |
+  #       package test
+  #       x = 4 {
+  #         false
+  #       } else = 5
+
+  #       y = 6
+  #   query: data.test
+  #   want_result:
+  #     x: 5
+  #     y: 6
+  - note: undefined values being assigned
     data: {}
     modules:
       - |
         package test
-        x = 4 {
-          false
-        } else = 5
-
-        y = 6
+        
+        import rego.v1
+        
+        x := data.y if {
+          true
+        } else := 2 if {
+          true
+        }        
     query: data.test
     want_result:
-      x: 5
-      y: 6
+      x: 2
+        

--- a/tests/interpreter/cases/rule/generic.yaml
+++ b/tests/interpreter/cases/rule/generic.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: undefined components
+    data: {}
+    modules:
+      - |
+        package test
+        
+        import rego.v1
+        
+        principal := input.principal
+        action := input.action
+        
+        p[principal][action] := 1 if {
+          some a in []					    
+        }
+
+        q[principal][action] contains 1 if {
+          some a in []					    
+        }
+    query: data.test
+    want_result:
+      p: {}
+      q: {}


### PR DESCRIPTION
Handle undefined values correctly in ordered-else. Previously an undefined value in one of the blocks could cause the entire rule to evaluate to undefined.

Handle undefined values correctly in generic rule refs to prevent them from propagating to output.

fixes #302, fixes #303