### PR TITLE
feat: or keyword

### DIFF
--- a/.github/workflows/pr-extensions.yml
+++ b/.github/workflows/pr-extensions.yml
@@ -1,0 +1,33 @@
+name: tests/release
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build only std
+      run: cargo build -r --example regorus --no-default-features --features "std,rego-extensions"
+    - name: Doc Tests
+      run: cargo test -r --doc --features rego-extensions
+    - name: Run tests
+      run: cargo test -r --features rego-extensions
+    - name: Run example
+      run: cargo run --example regorus --features rego-extensions -- eval -d examples/server/allowed_server.rego -i examples/server/input.json data.example
+    - name: Run tests (ACI)
+      run: cargo test -r --test aci --features rego-extensions
+    - name: Run tests (KATA)
+      run: cargo test -r --test kata --features rego-extensions
+    - name: Run tests (OPA Conformance)
+      run: >-
+        cargo test -r --test opa --features opa-testutil,serde_json/arbitrary_precision,rego-extensions  -- $(tr '\n' ' ' < tests/opa.passing)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,9 @@ full-opa = [
     "time",
     "uuid",
     "urlquery",
-    "yaml"
+    "yaml",
+
+    #"rego-extensions"
 ]
 
 # Features that can be used in no_std environments.
@@ -88,6 +90,9 @@ opa-no-std = [
   # Configure lazy_static to use spinlocks.
   "lazy_static/spin_no_std"
 ]
+
+# Rego language extensions
+rego-extensions = []
 
 # This feature enables some testing utils for OPA tests.
 opa-testutil = []

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -61,9 +61,9 @@ in-expr          ::= in-expr 'in' bool-expr
 bool-expr        ::= bool-expr bool-op or-expr
                  | or-expr
 bool-op          ::= '<' | '<=' | '==' | '>=' | '>' | '!='
-or-expr          ::= or-expr '|' and-expr
-                 | and-expr
-and-expr         ::= and-expr '&' arith-expr
+set-union-expr   ::= set-union-expr '|' set-intersection-expr
+                 | set-intersection-expr
+set-intersection-expr ::= set-intersection-expr '&' arith-expr
                  | arith-expr
 arith-expr       ::= arith-expr ('+' | '-') mul-div-expr
                  | mul-div-expr

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -30,6 +30,11 @@ if [ -f Cargo.toml ]; then
    cargo test -r --test aci
    cargo test -r --test kata
 
+   # Ensure that all tests pass with extensions
+   cargo test -r --features rego-extensions
+   cargo test -r --test aci rego-extensions
+   cargo test -r --test kata rego-extensions
+
    # Ensure that OPA conformance tests don't regress.
-   cargo test -r --features opa-testutil,serde_json/arbitrary_precision --test opa -- $(tr '\n' ' ' < tests/opa.passing)
+   cargo test -r --features opa-testutil,serde_json/arbitrary_precision,rego-extensions --test opa -- $(tr '\n' ' ' < tests/opa.passing)
 fi

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -10,8 +10,8 @@ use core::{cmp, fmt, ops::Deref};
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "ast", derive(serde::Serialize))]
 pub enum BinOp {
-    And,
-    Or,
+    Intersection,
+    Union,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -209,6 +209,13 @@ pub enum Expr {
         value: Ref<Expr>,
         collection: Ref<Expr>,
     },
+
+    #[cfg(feature = "rego-extensions")]
+    OrExpr {
+        span: Span,
+        lhs: Ref<Expr>,
+        rhs: Ref<Expr>,
+    },
 }
 
 impl Expr {
@@ -232,6 +239,8 @@ impl Expr {
             | ArithExpr { span, .. }
             | AssignExpr { span, .. }
             | Membership { span, .. } => span,
+            #[cfg(feature = "rego-extensions")]
+            OrExpr { span, .. } => span,
         }
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -258,6 +258,12 @@ pub fn traverse(expr: &Ref<Expr>, f: &mut dyn FnMut(&Ref<Expr>) -> Result<bool>)
             traverse(rhs, f)?;
         }
 
+        #[cfg(feature = "rego-extensions")]
+        OrExpr { lhs, rhs, .. } => {
+            traverse(lhs, f)?;
+            traverse(rhs, f)?;
+        }
+
         Membership {
             key,
             value,

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -385,6 +385,11 @@ fn yaml_test_impl(file: &str) -> Result<()> {
 }
 
 fn yaml_test(file: &str) -> Result<()> {
+    #[cfg(not(feature = "rego-extensions"))]
+    if file.contains("rego-extensions") {
+        return Ok(());
+    }
+
     match yaml_test_impl(file) {
         Ok(_) => Ok(()),
         Err(e) => {

--- a/tests/interpreter/cases/rego-extensions/or/tests.yaml
+++ b/tests/interpreter/cases/rego-extensions/or/tests.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+cases:
+  - note: basic
+    modules:
+      - |
+        package test
+        import rego.v1
+
+        x := data.foo or 2 # undefined lhs
+        y := false or 3 # false rhs
+        z := null or 4
+        a := data.foo or false or null or 5
+        b := startswith("a", "b") or startswith("a", "a")
+        c := 5 in [1,2] or 6 in [6]
+        d := x if {
+           x := false or [1, 2][_]
+           x > 1
+        }
+        e if 1 > 2 or false
+    query: data.test
+    want_result:
+      x: 2
+      y: 3
+      z: 4
+      a: 5
+      b: true
+      c: true
+      d: 2
+  - note: Azure Policy
+    modules:
+      - |
+        package policy
+
+        effect := parameters.effect if {
+          resource.type == "Microsoft.Storage/storageaccounts"
+          resource.properties.networkAcls.defaultAction == "Deny" 
+            or count(resource.properties.networkAcls.ipRules) >= 1
+        }
+
+        resource := input.resource
+        parameters := input.parameters
+    input:
+      resource:
+        type: "Microsoft.Storage/storageaccounts"
+        properties:
+        networksAcls:
+          ipRules: ["rule1", "rule2"]
+      parameters:
+        effect: "Deny"
+    query: data.policy.effect
+    want_result: "Deny"

--- a/tests/parser/mod.rs
+++ b/tests/parser/mod.rs
@@ -198,6 +198,13 @@ fn match_expr_impl(e: &Expr, v: &Value) -> Result<()> {
             match_expr(value, &v["inexpr"]["value"])?;
             match_expr(collection, &v["inexpr"]["collection"])
         }
+
+        #[cfg(feature = "rego-extensions")]
+        Expr::OrExpr { span, lhs, rhs } => {
+            match_span_opt(span, &v["orexpr"]["span"])?;
+            match_expr(lhs, &v["orexpr"]["lhs"])?;
+            match_expr(rhs, &v["orexpr"]["rhs"])
+        }
     }
 }
 
@@ -324,8 +331,8 @@ fn match_expr_opt(s: &Span, e: &Option<Ref<Expr>>, v: &Value) -> Result<()> {
 
 fn match_bin_op(s: &Span, op: &BinOp, v: &Value) -> Result<()> {
     match (op, v) {
-        (BinOp::And, Value::String(s)) if s.as_ref() == "&" => Ok(()),
-        (BinOp::Or, Value::String(s)) if s.as_ref() == "|" => Ok(()),
+        (BinOp::Intersection, Value::String(s)) if s.as_ref() == "&" => Ok(()),
+        (BinOp::Union, Value::String(s)) if s.as_ref() == "|" => Ok(()),
         _ => bail!(
             "{}",
             s.source.message(


### PR DESCRIPTION
Add `or` operator to Rego languages. Available via `rego-extensions` Cargo feature.

If the evaluated lhs value is not false, null or undefined it is returned. Otherwise rhs is evaluated and returned.

or operator has least precedence, and is left-associative.

closes #314