### PR TITLE
chore: update to OPA v0.69.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Regorus is also
   - *cross-platform* - Written in platform-agnostic Rust.
   - *no_std compatible* - Regorus can be used in `no_std` environments too. Most of the builtins are supported.
   - *current* - We strive to keep Regorus up to date with latest OPA release. Regorus supports `import rego.v1`.
-  - *compliant* - Regorus is mostly compliant with the latest [OPA release v0.68.0](https://github.com/open-policy-agent/opa/releases/tag/v0.68.0). See [OPA Conformance](#opa-conformance) for details. Note that while we behaviorally produce the same results, we don't yet support all the builtins.
+  - *compliant* - Regorus is mostly compliant with the latest [OPA release v0.69.0](https://github.com/open-policy-agent/opa/releases/tag/v0.69.0). See [OPA Conformance](#opa-conformance) for details. Note that while we behaviorally produce the same results, we don't yet support all the builtins.
   - *extensible* - Extend the Rego language by implementing custom stateful builtins in Rust.
     See [add_extension](https://github.com/microsoft/regorus/blob/fc68bf9c8bea36427dae9401a7d1f6ada771f7ab/src/engine.rs#L352).
     Support for extensibility using other languages coming soon.
@@ -99,7 +99,7 @@ $ cargo build -r --example regorus --no-default-features; strip target/release/e
 -rwxr-xr-x  1 anand  staff   1.9M May 11 22:04 target/release/examples/regorus*
 ```
 
-Regorus passes the [OPA v0.68.0 test-suite](https://www.openpolicyagent.org/docs/latest/ir/#test-suite) barring a few
+Regorus passes the [OPA v0.69.0 test-suite](https://www.openpolicyagent.org/docs/latest/ir/#test-suite) barring a few
 builtins. See [OPA Conformance](#opa-conformance) below.
 
 ## Bindings
@@ -276,7 +276,7 @@ Benchmark 1: opa eval -b tests/aci -d tests/aci/data.json -i tests/aci/input.jso
 ```
 ## OPA Conformance
 
-Regorus has been verified to be compliant with [OPA v0.68.0](https://github.com/open-policy-agent/opa/releases/tag/v0.68.0)
+Regorus has been verified to be compliant with [OPA v0.69.0](https://github.com/open-policy-agent/opa/releases/tag/v0.69.0)
 using a [test driver](https://github.com/microsoft/regorus/blob/main/tests/opa.rs) that loads and runs the OPA testsuite using Regorus, and verifies that expected outputs are produced.
 
 The test driver can be invoked by running:

--- a/src/value.rs
+++ b/src/value.rs
@@ -322,7 +322,8 @@ impl Value {
     /// // Convert the value back to json.
     /// let json_str = value.to_json_str()?;
     ///
-    /// assert_eq!(json_str.trim(), std::fs::read_to_string("tests/aci/input.json")?.trim());
+    /// assert_eq!(json_str.trim(),
+    ///            std::fs::read_to_string("tests/aci/input.json")?.trim().replace("\r\n", "\n"));
     /// # Ok(())
     /// # }
     /// ```
@@ -345,7 +346,8 @@ impl Value {
     /// // Convert the value back to json.
     /// let json_str = value.to_json_str()?;
     ///
-    /// assert_eq!(json_str.trim(), std::fs::read_to_string("tests/aci/input.json")?.trim());
+    /// assert_eq!(json_str.trim(),
+    ///            std::fs::read_to_string("tests/aci/input.json")?.trim().replace("\r\n", "\n"));
     /// # Ok(())
     /// # }
     /// ```

--- a/tests/opa.rs
+++ b/tests/opa.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 const OPA_REPO: &str = "https://github.com/open-policy-agent/opa";
-const OPA_BRANCH: &str = "v0.68.0";
+const OPA_BRANCH: &str = "v0.69.0";
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 #[serde(deny_unknown_fields)]
@@ -174,7 +174,7 @@ fn run_opa_tests(opa_tests_dir: String, folders: &[String]) -> Result<()> {
             continue;
         }
 
-        let is_rego_v1_test = path_dir_str.starts_with("v1/");
+        let is_rego_v1_test = path_dir_str.starts_with("v1/") || path_dir.starts_with("v1\\");
         let entry = status.entry(path_dir_str).or_insert((0, 0, 0));
 
         let yaml_str = std::fs::read_to_string(&path_str)?;


### PR DESCRIPTION
Also fix CRLF vs LF related test failures in two doc tests on Windows