### PR TITLE
resolve anyhow compile errors

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -32,8 +32,8 @@ if [ -f Cargo.toml ]; then
 
    # Ensure that all tests pass with extensions
    cargo test -r --features rego-extensions
-   cargo test -r --test aci rego-extensions
-   cargo test -r --test kata rego-extensions
+   cargo test -r --test aci --features rego-extensions
+   cargo test -r --test kata --features rego-extensions
 
    # Ensure that OPA conformance tests don't regress.
    cargo test -r --features opa-testutil,serde_json/arbitrary_precision,rego-extensions --test opa -- $(tr '\n' ' ' < tests/opa.passing)

--- a/src/builtins/encoding.rs
+++ b/src/builtins/encoding.rs
@@ -337,11 +337,11 @@ fn yaml_is_valid(
 fn yaml_marshal(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
     let name = "yaml.marshal";
     ensure_args_count(span, name, params, args, 1)?;
-    Ok(Value::String(
-        serde_yaml::to_string(&args[0])
-            .with_context(|| span.error("could not serialize to yaml"))?
-            .into(),
-    ))
+
+    let serialized = serde_yaml::to_string(&args[0])
+        .map_err(|err| span.error(&format!("could not serialize to yaml: {}", err)))?;
+
+    Ok(Value::String(serialized.into()))
 }
 
 #[cfg(feature = "yaml")]

--- a/src/builtins/objects.rs
+++ b/src/builtins/objects.rs
@@ -439,7 +439,8 @@ fn json_match_schema(
     ensure_args_count(span, name, params, args, 2)?;
 
     // The following is expected to succeed.
-    let document: serde_json::Value = serde_json::from_str(&args[0].to_json_str()?)?;
+    let document: serde_json::Value = serde_json::from_str(&args[0].to_json_str()?)
+        .map_err(|err| span.error(&format!("Failed to parse JSON: {}", err)))?;
 
     Ok(Value::from_array(
         match compile_json_schema(&params[1], &args[1]) {

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -25,7 +25,11 @@ fn sleep(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Re
     let dur = time::compat::parse_duration(val.as_ref())
         .map_err(|e| params[0].span().error(&format!("{e}")))?;
 
-    thread::sleep(dur.to_std()?);
+    let std_dur = dur
+        .to_std()
+        .map_err(|err| anyhow::anyhow!("Failed to convert to std::time::Duration: {err}"))?;
+
+    thread::sleep(std_dur);
 
     Ok(Value::Null)
 }

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -158,7 +158,8 @@ fn parse_ns(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> 
     let layout = ensure_string(name, &params[0], &args[0])?;
     let value = ensure_string(name, &params[1], &args[1])?;
 
-    let datetime = compat::parse(layout_with_predefined_formats(&layout), &value)?;
+    let datetime = compat::parse(layout_with_predefined_formats(&layout), &value)
+        .map_err(|err| anyhow::anyhow!("Failed to parse datetime: {}", err))?;
     safe_timestamp_nanos(span, strict, datetime.timestamp_nanos_opt())
 }
 
@@ -173,7 +174,8 @@ fn parse_rfc3339_ns(
 
     let value = ensure_string(name, &params[0], &args[0])?;
 
-    let datetime = DateTime::parse_from_rfc3339(&value)?;
+    let datetime = DateTime::parse_from_rfc3339(&value)
+        .map_err(|err| anyhow::anyhow!("Failed to parse datetime: {}", err))?;
     safe_timestamp_nanos(span, strict, datetime.timestamp_nanos_opt())
 }
 

--- a/src/builtins/time/compat.rs
+++ b/src/builtins/time/compat.rs
@@ -266,7 +266,7 @@ struct GoTimeFormatItems<'a> {
     mode: GoTimeFormatItemsMode,
 }
 
-impl<'a> GoTimeFormatItems<'a> {
+impl GoTimeFormatItems<'_> {
     fn parse(reminder: &str) -> GoTimeFormatItems {
         GoTimeFormatItems {
             reminder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ where
 }
 
 /// Implement clone for a boxed extension using [`Extension::clone_box`].
-impl<'a> Clone for Box<dyn 'a + Extension> {
+impl Clone for Box<dyn '_ + Extension> {
     fn clone(&self) -> Self {
         (**self).clone_box()
     }
@@ -405,7 +405,6 @@ pub mod coverage {
         /// Lines that are not covered are red.
         ///
         /// <img src="https://github.com/microsoft/regorus/blob/main/docs/coverage.png?raw=true">
-
         pub fn to_string_pretty(&self) -> anyhow::Result<String> {
             let mut s = String::default();
             s.push_str("COVERAGE REPORT:\n");

--- a/src/value.rs
+++ b/src/value.rs
@@ -405,7 +405,9 @@ impl Value {
     #[cfg(feature = "yaml")]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
     pub fn from_yaml_str(yaml: &str) -> Result<Value> {
-        Ok(serde_yaml::from_str(yaml)?)
+        let value = serde_yaml::from_str(yaml)
+            .map_err(|err| anyhow::anyhow!("Failed to parse YAML: {}", err))?;
+        Ok(value)
     }
 
     /// Deserialize a value from a file containing YAML.


### PR DESCRIPTION
@anakrish while attempting to run the tests from `main` on a fresh development environment, I was getting several compiler warnings and errors. This intends to be the smallest change to get back to green.

- add missing `--features` flag for `aci rego-extensions` and `kata rego-extensions` commands in `scripts/pre-push`
- I'm not entirely clear on the traits for why `?` wasn't playing well with `anyhow`, maybe it has something to do with `default-features = false` and `no_std` flag option? the fix seems to be `map_err()` calls
- replace unnecessary lifetime references `impl<'a> GoTimeFormatItems<'a>` with `impl GoTimeFormatItems<'_>`, similar for `impl Clone for Box<dyn '_ + Extension> {`

These changes allow me to compile the project and run tests without error or warning output.