### PR TITLE
Fix clippy warning for result?

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2970,10 +2970,7 @@ impl Interpreter {
             _ => bail!("internal error: rule's context already popped"),
         };
 
-        let result = match result {
-            Ok(r) => r,
-            Err(e) => return Err(e),
-        };
+        let result = result?;
 
         assert_eq!(self.scopes.len(), n_scopes);
 


### PR DESCRIPTION
A few dependabot PRs (https://github.com/microsoft/regorus/pull/361 , https://github.com/microsoft/regorus/pull/360 , and https://github.com/microsoft/regorus/pull/359 ) are failing with a clippy error when running CI for the java bindings.

This fix is to change the explicit error checking on result to instead use the rust idiomatic `?` operator.

```
error: this `match` expression can be replaced with `?`
    --> src/interpreter.rs:2973:22
     |
2973 |           let result = match result {
     |  ______________________^
2974 | |             Ok(r) => r,
2975 | |             Err(e) => return Err(e),
2976 | |         };
     | |_________^ help: try instead: `result?`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
     = note: `-D clippy::question-mark` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::question_mark)]`

error: could not compile `regorus` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `regorus` (lib test) due to 1 previous error
Error: Process completed with exit code 101.
```