### PR TITLE
fix clippy warns for missing () and cfg(wasm_bindgen_unstable_test_coverage)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ semver = {version = "1.0.20", optional = true, default-features = false }
 wax = { version = "0.6.0", features = [], default-features = false, optional = true }
 url = { version = "2.5.0", optional = true }
 uuid = { version = "1.6.1", default-features = false, features = ["v4", "fast-rng"], optional = true }
-jsonschema = { version = "0.28.1", default-features = false, optional = true }
+jsonschema = { version = "0.29.0", default-features = false, optional = true }
 chrono = { version = "0.4.31", optional = true }
 chrono-tz = { version = "0.10.0", optional = true }
 jsonwebtoken = { version = "9.2.0", optional = true }

--- a/bindings/wasm/.cargo/config.toml
+++ b/bindings/wasm/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]
+

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -17,8 +17,11 @@ coverage = ["regorus/coverage"]
 
 [dependencies]
 regorus = { path  = "../..", default-features = false, features = ["arc"] }
-serde_json = "1.0.111"
-wasm-bindgen = "=0.2.93"
+serde_json = "1.0.139"
+wasm-bindgen = "=0.2.100"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.40"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -16,8 +16,10 @@ ast = ["regorus/ast"]
 coverage = ["regorus/coverage"]
 
 [dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 regorus = { path  = "../..", default-features = false, features = ["arc"] }
 serde_json = "1.0.139"
+uuid = { version = "1.14", features = ["rng-getrandom"] }
 wasm-bindgen = "=0.2.100"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -26,5 +26,8 @@ fn main() -> Result<()> {
         println!("cargo:rustc-env=GIT_HASH={}", git_hash);
     }
 
+    // Add this line to force WebAssembly to use the correct random backend
+    println!("cargo:rustc-cfg=getrandom_backend=\"wasm_js\"");
+
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -26,8 +26,5 @@ fn main() -> Result<()> {
         println!("cargo:rustc-env=GIT_HASH={}", git_hash);
     }
 
-    // Add this line to force WebAssembly to use the correct random backend
-    println!("cargo:rustc-cfg=getrandom_backend=\"wasm_js\"");
-
     Ok(())
 }

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -141,7 +141,7 @@ const fn decode_rfc4122_timestamp(uuid: &Uuid) -> (u64, u16) {
         | ((bytes[2] as u64) << 8)
         | (bytes[3] as u64);
 
-    let counter: u16 = ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
+    let counter: u16 = (((bytes[8] & 0x3F) as u16) << 8) | (bytes[9] as u16);
 
     (ticks, counter)
 }

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -132,13 +132,13 @@ fn timestamp(uuid: &Uuid) -> Option<Timestamp> {
 const fn decode_rfc4122_timestamp(uuid: &Uuid) -> (u64, u16) {
     let bytes = uuid.as_bytes();
 
-    let ticks: u64 = ((bytes[6] & 0x0F) as u64) << 56
-        | (bytes[7] as u64) << 48
-        | (bytes[4] as u64) << 40
-        | (bytes[5] as u64) << 32
-        | (bytes[0] as u64) << 24
-        | (bytes[1] as u64) << 16
-        | (bytes[2] as u64) << 8
+    let ticks: u64 = (((bytes[6] & 0x0F) as u64) << 56)
+        | ((bytes[7] as u64) << 48)
+        | ((bytes[4] as u64) << 40)
+        | ((bytes[5] as u64) << 32)
+        | ((bytes[0] as u64) << 24)
+        | ((bytes[1] as u64) << 16)
+        | ((bytes[2] as u64) << 8)
         | (bytes[3] as u64);
 
     let counter: u16 = ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);


### PR DESCRIPTION
I was working on updating the ruby bindings and uncovered some clippy warnings that were messing with CI for main. This should resolve them.