### PR TITLE
build: Specify optimization flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,8 @@ anyhow = "1.0"
 
 [profile.release]
 debug = true
+lto = true
+codegen-units = 1
 
 [[test]]
 name="opa"


### PR DESCRIPTION
In release profile, enable lto and codgen-units = 1 to enable more optimizations.