### PR TITLE
fix!: Remove sha1 dependency

### DIFF
--- a/.github/workflows/pr-extensions.yml
+++ b/.github/workflows/pr-extensions.yml
@@ -1,4 +1,4 @@
-name: tests/release
+name: tests/release-extensions
 
 on:
   push:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -18,7 +18,6 @@ jobs:
           
       - uses: actions/setup-go@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
 
       - name: Build ffi
@@ -29,5 +28,5 @@ jobs:
         run: |
           go mod tidy
           go build
-          LD_LIBRARY_PATH=../../target/release ./regorus_test
+          LD_LIBRARY_PATH=../ffi/target/release ./regorus_test
         working-directory: ./bindings/go

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Test jar
         run: |
           javac -cp target/regorus-java-0.2.2.jar Test.java
-          java -Djava.library.path=../../target/release -cp target/regorus-java-0.2.2.jar:. Test
+          java -Djava.library.path=target/release -cp target/regorus-java-0.2.2.jar:. Test
         working-directory: ./bindings/java

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ worktrees/
 # Generated C, C++ headers
 bindings/ffi/regorus.h
 bindings/ffi/regorus.ffi.hpp
+
+bindings/*/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,6 @@
 [workspace]
 
 members = [
-    "bindings/ffi",
-    "bindings/python",
-    "bindings/wasm",
-    "bindings/java",
-    "bindings/ruby/ext/regorusrb",
     "tests/ensure_no_std",
 ]
 
@@ -31,7 +26,7 @@ ast = []
 base64 = ["dep:data-encoding"]
 base64url = ["dep:data-encoding"]
 coverage = []
-crypto = ["dep:constant_time_eq", "dep:hmac", "dep:hex", "dep:md-5", "dep:sha1", "dep:sha2"]
+crypto = ["dep:constant_time_eq", "dep:hmac", "dep:hex", "dep:md-5", "dep:sha2"]
 deprecated = []
 hex = ["dep:data-encoding"]
 http = []
@@ -109,7 +104,6 @@ constant_time_eq = {version = "0.4.0", optional = true, default-features = false
 hmac = {version = "0.12.1", optional = true, default-features = false}
 sha2 = {version= "0.10.8", optional = true, default-features = false }
 hex = {version = "0.4.3", optional = true, default-features = false, features = ["alloc"] }
-sha1 = {version = "0.10.6", optional = true, default-features = false }
 md-5 = {version = "0.10.6", optional = true, default-features = false }
 
 data-encoding = { version = "2.8.0", optional = true, default-features=false, features = ["alloc"] }

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ The following test suites don't pass fully due to missing builtins:
 - `regoparsemodule`
 - `rendertemplate`
 
+Cryptographically insecure `sha1` related builtins are intentionally not supported to discourage their use.
+
 They are captured in the following [github issues](https://github.com/microsoft/regorus/issues?q=is%3Aopen+is%3Aissue+label%3Alib).
 
 

--- a/bindings/c-nostd/CMakeLists.txt
+++ b/bindings/c-nostd/CMakeLists.txt
@@ -7,7 +7,8 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4 # Optionally specify a commit hash, version tag or branch here
+    # Use a tag that has a fix for https://github.com/corrosion-rs/corrosion/issues/590
+    GIT_TAG 6be991bb34c348dfb8344be22f3606288ea5c7fd
 )
 FetchContent_MakeAvailable(Corrosion)
 

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -7,7 +7,8 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4 # Optionally specify a commit hash, version tag or branch here
+    # Use a tag that has a fix for https://github.com/corrosion-rs/corrosion/issues/590
+    GIT_TAG 6be991bb34c348dfb8344be22f3606288ea5c7fd
 )
 FetchContent_MakeAvailable(Corrosion)
 

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -7,7 +7,8 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG v0.4 # Optionally specify a commit hash, version tag or branch here
+    # Use a tag that has a fix for https://github.com/corrosion-rs/corrosion/issues/590
+    GIT_TAG 6be991bb34c348dfb8344be22f3606288ea5c7fd
 )
 FetchContent_MakeAvailable(Corrosion)
 

--- a/bindings/csharp/net40/regorus-test.csproj
+++ b/bindings/csharp/net40/regorus-test.csproj
@@ -4,7 +4,7 @@
     <Exec Command="cargo build -r --manifest-path ../../ffi/Cargo.toml" />
     <Copy SourceFiles="../../ffi/RegorusFFI.g.cs" DestinationFolder="." />
     <ItemGroup>
-        <RegorusDylib Include="..\..\..\target\release\*regorus_ffi*" />
+        <RegorusDylib Include="..\..\ffi\target\release\*regorus_ffi*" />
     </ItemGroup>    
     <Copy SourceFiles="@(RegorusDylib)" DestinationFolder="." />
   </Target>

--- a/bindings/csharp/net8.0/regorus-test.csproj
+++ b/bindings/csharp/net8.0/regorus-test.csproj
@@ -4,7 +4,7 @@
     <Exec Command="cargo build -r --manifest-path ../../ffi/Cargo.toml" />
     <Copy SourceFiles="../../ffi/RegorusFFI.g.cs" DestinationFolder="." />
     <ItemGroup>
-        <RegorusDylib Include="..\..\..\target\release\*regorus_ffi*" />
+        <RegorusDylib Include="..\..\ffi\target\release\*regorus_ffi*" />
     </ItemGroup>    
     <Copy SourceFiles="@(RegorusDylib)" DestinationFolder="." />
   </Target>

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "regorus-ffi"
 version = "0.2.2"

--- a/bindings/go/pkg/regorus/mod.go
+++ b/bindings/go/pkg/regorus/mod.go
@@ -1,6 +1,6 @@
 package regorus
 
-// #cgo LDFLAGS: -L ../../../../target/release -lregorus_ffi
+// #cgo LDFLAGS: -L ../../../ffi/target/release -lregorus_ffi
 // #include "../../../ffi/regorus.h"
 import "C"
 import (
@@ -28,7 +28,7 @@ func (e *Engine) Clone() *Engine {
 	return c
 }
 
-func (e *Engine) SetRegoV0(enable bool) (error) {
+func (e *Engine) SetRegoV0(enable bool) error {
 	result := C.regorus_engine_set_rego_v0(e.e, C.bool(enable))
 	defer C.regorus_result_drop(result)
 
@@ -83,7 +83,6 @@ func (e *Engine) GetPolicies() (string, error) {
 	}
 	return C.GoString(result.output), nil
 }
-
 
 func (e *Engine) AddDataJson(data string) error {
 	data_c := C.CString(data)

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "regorus-java"
 version = "0.3.0"

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -23,7 +23,7 @@ Afterwards, you can build native library for that target using:
 $ cargo build --release --target aarch64-apple-darwin
 ```
 
-You will then have a native library at `../../target/aarch64-apple-darwin/release/libregorus_java.dylib` depending on your target.
+You will then have a native library at `target/aarch64-apple-darwin/release/libregorus_java.dylib` depending on your target.
 
 You then need to build Java bindings using:
 ```bash

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "regoruspy"
 version = "0.3.0"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "regorusjs"
 version = "0.3.0"

--- a/src/builtins/crypto.rs
+++ b/src/builtins/crypto.rs
@@ -11,18 +11,15 @@ use anyhow::{bail, Result};
 use constant_time_eq::constant_time_eq;
 use hmac::{Hmac, Mac};
 use md5::{Digest, Md5};
-use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 
 pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
     m.insert("crypto.hmac.equal", (hmac_equal_fixed_time, 2));
     m.insert("crypto.hmac.md5", (hmac_md5, 2));
-    m.insert("crypto.hmac.sha1", (hmac_sha1, 2));
     m.insert("crypto.hmac.sha256", (hmac_sha256, 2));
     m.insert("crypto.hmac.sha512", (hmac_sha512, 2));
 
     m.insert("crypto.md5", (crypto_md5, 1));
-    m.insert("crypto.sha1", (crypto_sha1, 1));
     m.insert("crypto.sha256", (crypto_sha256, 1));
 }
 
@@ -52,22 +49,6 @@ fn hmac_md5(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) ->
     let key = ensure_string(name, &params[1], &args[1])?;
 
     let mut hmac = Hmac::<Md5>::new_from_slice(key.as_bytes())
-        .or_else(|_| bail!(span.error("failed to create hmac instance")))?;
-
-    hmac.update(x.as_bytes());
-    let result = hmac.finalize();
-
-    Ok(Value::String(hex::encode(result.into_bytes()).into()))
-}
-
-fn hmac_sha1(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
-    let name = "crypto.hmac.sha1";
-    ensure_args_count(span, name, params, args, 2)?;
-
-    let x = ensure_string(name, &params[0], &args[0])?;
-    let key = ensure_string(name, &params[1], &args[1])?;
-
-    let mut hmac = Hmac::<Sha1>::new_from_slice(key.as_bytes())
         .or_else(|_| bail!(span.error("failed to create hmac instance")))?;
 
     hmac.update(x.as_bytes());
@@ -115,20 +96,6 @@ fn crypto_md5(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) 
     let x = ensure_string(name, &params[0], &args[0])?;
 
     let mut h = Md5::new();
-
-    h.update(x.as_bytes());
-    let result = h.finalize();
-
-    Ok(Value::String(hex::encode(result).into()))
-}
-
-fn crypto_sha1(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
-    let name = "crypto.sha1";
-    ensure_args_count(span, name, params, args, 1)?;
-
-    let x = ensure_string(name, &params[0], &args[0])?;
-
-    let mut h = Sha1::new();
 
     h.update(x.as_bytes());
     let result = h.finalize();

--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -22,11 +22,9 @@ v0/comprehensions
 v0/containskeyword
 v0/cryptohmacequal
 v0/cryptohmacmd5
-v0/cryptohmacsha1
 v0/cryptohmacsha256
 v0/cryptohmacsha512
 v0/cryptomd5
-v0/cryptosha1
 v0/cryptosha256
 v0/dataderef
 v0/defaultkeyword
@@ -137,11 +135,9 @@ v1/comprehensions
 v1/containskeyword
 v1/cryptohmacequal
 v1/cryptohmacmd5
-v1/cryptohmacsha1
 v1/cryptohmacsha256
 v1/cryptohmacsha512
 v1/cryptomd5
-v1/cryptosha1
 v1/cryptosha256
 v1/dataderef
 v1/defaultkeyword


### PR DESCRIPTION
Removed cryptographically insecure sha1. This existed only for OPA compatibility.

Also exclude bindings from main workspace