### PR TITLE
fix!: Update ruby json dependency

### DIFF
--- a/bindings/ruby/Gemfile.lock
+++ b/bindings/ruby/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    json (2.10.1)
+    json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     minitest (5.25.4)


### PR DESCRIPTION
Previous version has Out-of-bounds Read in Ruby JSON Parser