### PR TITLE
build: Python binding portability

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -22,11 +22,19 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - name: Build Python extension
+        run: |
+          cargo fetch
+          cargo clippy --all-targets --no-deps -- -Dwarnings
+          cargo build --release --target ${{ matrix.target }} --frozen
+        working-directory: bindings/python
+
       - name: Build wheels
         uses: PyO3/maturin-action@63b75c597b83e247fbf4fb7719801cc4220ae9f3 # v1.43.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --offline --strip
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -46,11 +54,19 @@ jobs:
         with:
           python-version: '3.10'
           architecture: ${{ matrix.target }}
+
+      - name: Build Python extension
+        run: |
+          cargo fetch
+          cargo clippy --all-targets --no-deps -- -Dwarnings
+          cargo build --release --target ${{ matrix.host.target }} --frozen
+        working-directory: bindings/python
+
       - name: Build wheels
         uses: PyO3/maturin-action@63b75c597b83e247fbf4fb7719801cc4220ae9f3 # v1.43.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --frozen --strip
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -68,28 +84,21 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - name: Build Python extension
+        run: |
+          cargo fetch
+          cargo clippy --all-targets --no-deps -- -Dwarnings
+          cargo build --release --target ${{ matrix.host.target }} --frozen
+        working-directory: bindings/python
+
       - name: Build wheels
         uses: PyO3/maturin-action@63b75c597b83e247fbf4fb7719801cc4220ae9f3 # v1.43.0
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path bindings/python/Cargo.toml
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --offline --strip
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-
-  sdist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build sdist
-        uses: PyO3/maturin-action@63b75c597b83e247fbf4fb7719801cc4220ae9f3 # v1.43.0
-        with:
-          command: sdist
-          args: --out dist --manifest-path bindings/python/Cargo.toml
-      - name: Upload sdist
         uses: actions/upload-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -8,10 +8,17 @@ on:
 
 env:
   PYTHON_VERSION: "3.10"
-    
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        host:
+          - name: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+          - name: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.host.name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,16 +30,60 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
 
-      - name: Build wheels
+      - name: Build Python extension
+        run: |
+          cargo fetch
+          cargo clippy --all-targets --no-deps -- -Dwarnings
+          cargo build --release --target ${{ matrix.host.target }} --frozen
+        working-directory: bindings/python
+
+      - name: Build Wheel
         uses: PyO3/maturin-action@63b75c597b83e247fbf4fb7719801cc4220ae9f3 # v1.43.0
         with:
           target: x86_64
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --offline --strip
           sccache: 'true'
 
-      - name: Test wheel
+      - name: Upload Wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: regorus-wheel-${{ matrix.host.name }}
+          path: dist/regorus-*.whl
+
+  test:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        host:
+          - name: ubuntu-24.04
+            wheel: regorus-0.4.0-cp310-abi3-manylinux_2_34_x86_64.whl
+          - name: ubuntu-22.04
+            wheel: regorus-0.4.0-cp310-abi3-manylinux_2_34_x86_64.whl
+          - name: windows-latest
+            wheel: regorus-0.4.0-cp310-abi3-win_amd64.whl
+
+    needs: build
+    runs-on: ${{ matrix.host.name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Regorus wheel
+        uses: actions/download-artifact@v4
+        with:
+          path: wheels
+          pattern: regorus-wheel-*
+          merge-multiple: true
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+
+      - name: Test Wheel
         run:  |
-          pip3 install dist/regorus-*.whl
-          cd bindings/python
-          cargo clippy --all-targets --no-deps -- -Dwarnings
-          python3 test.py          
+          pip3 install ../../wheels/${{ matrix.host.wheel }}
+          python3 test.py
+        working-directory: bindings/python

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regoruspy"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/python"
 description = "Python bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
@@ -21,7 +21,7 @@ coverage = ["regorus/coverage"]
 [dependencies]
 anyhow = "1.0"
 ordered-float = "5.0.0"
-pyo3 = {version = "0.24.1", features = ["anyhow", "extension-module"] }
+pyo3 = { version = "0.24.1", features = ["abi3-py310", "anyhow", "extension-module"] }
 regorus = { path  = "../..", default-features = false, features = ["arc"] }
 serde_json = "1.0.140"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -13,4 +13,8 @@ classifiers = [
 dynamic = ["version"]
 
 [tool.maturin]
+binding = ["cffi"]
+# See https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#distro-compatibility
+# GLIBC releases: https://www.sourceware.org/glibc/wiki/Glibc%20Timeline
+compatibility = "manylinux_2_34"
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
- Specify compatibility = manylinux_2_34in pyproject.toml to ensure conpatibliy with glibc2.34 and later.
- Use abi-py310 pyo3 feature to ensure compatibility with python 3.10 and later.