### PR TITLE
Initial draft of Regorus extension to invoke C# code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ Cargo.lock
 # vscode files
 .vscode/
 
+# vs files 
+.vs/
+
 # worktrees
 worktrees/
 

--- a/bindings/csharp/Regorus/Regorus.csproj
+++ b/bindings/csharp/Regorus/Regorus.csproj
@@ -10,6 +10,10 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    </ItemGroup>
+
     <!--
         $(RegorusFFIArtifactsDir) is the location where regorus shared libraries have been 
         built for various platforms and copied to. RegorusFFIArtifactsDir is passed in

--- a/bindings/csharp/Regorus/RegorusFFI.cs
+++ b/bindings/csharp/Regorus/RegorusFFI.cs
@@ -10,11 +10,13 @@ using System.Runtime.InteropServices;
 
 namespace Regorus.Internal
 {
+    // Add the callback delegate definition
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal unsafe delegate byte* RegorusCallbackDelegate(byte* payload, void* context);
+    
     internal static unsafe partial class API
     {
         const string __DllName = "regorus_ffi";
-
-
 
         /// <summary>
         ///  Drop a `RegorusResult`.
@@ -192,7 +194,17 @@ namespace Regorus.Internal
         [DllImport(__DllName, EntryPoint = "regorus_engine_set_rego_v0", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern RegorusResult regorus_engine_set_rego_v0(RegorusEngine* engine, [MarshalAs(UnmanagedType.U1)] bool enable);
 
+        /// <summary>
+        /// Register a callback function that can be called from Rego policies
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "regorus_register_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusStatus regorus_register_callback(byte* name, RegorusCallbackDelegate callback, void* context);
 
+        /// <summary>
+        /// Unregister a previously registered callback function
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "regorus_unregister_callback", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusStatus regorus_unregister_callback(byte* name);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/bindings/csharp/scripts/README.md
+++ b/bindings/csharp/scripts/README.md
@@ -1,0 +1,8 @@
+# Steps to run invoke example
+
+1. Install dotnet-script
+1. `dotnet build` in `bindings/csharp/Regorus`
+1. `cargo build` in `bindings/ffi`
+1. Copy `bindings/ffi/target/debug/regorus_ffi.dll` to `bindings/csharp/scripts`
+1. `cd` to `bindings/csharp/scripts`
+1. Run `dotnet script invoke.csx`

--- a/bindings/csharp/scripts/invoke.csx
+++ b/bindings/csharp/scripts/invoke.csx
@@ -1,0 +1,44 @@
+#r "../Regorus/bin/Debug/netstandard2.1/Regorus.dll"
+// No direct reference to regorus_ffi.dll as it's a native DLL
+#r "nuget: Newtonsoft.Json, 13.0.2"
+#r "nuget: System.Data.Common, 4.3.0"
+
+// Create a new engine
+var engine = new Regorus.Engine();
+// Register a callback function
+bool registerResult = engine.RegisterCallback("test_callback", payload => {
+    Console.WriteLine($"Called with payload: {payload}");
+    
+    if (payload is System.Text.Json.JsonElement jsonElement)
+    {
+        // Access properties from JsonElement
+        var testValue = jsonElement.GetProperty("value").GetInt32();
+        
+        // Return a response object that will be serialized to JSON
+        return new Dictionary<string, object>
+        {
+            ["value"] = testValue * 2,
+            ["message"] = "Processing complete"
+        };
+    }
+    
+    return null;
+});
+
+Console.WriteLine($"Callback registration result: {registerResult}");
+
+// Add a policy that uses the callback
+engine.AddPolicy("example.rego", @"
+package example
+
+import future.keywords.if
+
+double_value := invoke(""test_callback"", {""value"": 42}).value
+");
+
+// Evaluate query
+var result = engine.EvalQuery("data.example.double_value");
+Console.WriteLine($"Result: {result}");
+
+// Unregister the callback when done
+engine.UnregisterCallback("test_callback");

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -24,3 +24,6 @@ custom_allocator = []
 [build-dependencies]
 cbindgen = "0.28.0"
 csbindgen = "=1.9.3"
+
+[dev-dependencies]
+csbindgen = "=1.9.3"

--- a/bindings/ffi/src/lib.rs
+++ b/bindings/ffi/src/lib.rs
@@ -4,6 +4,10 @@
 use anyhow::{anyhow, bail, Result};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::os::raw::c_void;
+use std::cell::RefCell;
+use std::thread_local;
+use std::collections::HashMap;
 
 /// Status of a call on `RegorusEngine`.
 #[repr(C)]
@@ -13,6 +17,60 @@ pub enum RegorusStatus {
 
     /// The operation was unsuccessful.
     RegorusStatusError,
+}
+
+// Define callback function type for orchestration to Regorus communication
+pub type RegorusCallbackFn = extern "C" fn(payload: *const c_char, context: *mut c_void) -> *mut c_char;
+
+// RegorusCallbackFn uses context pointer, so it doesn't provide Send/Sync
+// Using thread_local instead of lazy_static to avoid Send/Sync requirements
+// It limits invoke to single-threaded usage
+thread_local! {
+    static CALLBACK_MAP: RefCell<HashMap<String, (RegorusCallbackFn, *mut c_void)>> = RefCell::new(HashMap::new());
+}
+
+// Store a callback function and its context
+#[no_mangle]
+pub extern "C" fn regorus_register_callback(
+    name: *const c_char, 
+    callback: RegorusCallbackFn, 
+    context: *mut c_void
+) -> RegorusStatus {
+    if name.is_null() {
+        return RegorusStatus::RegorusStatusError;
+    }
+    
+    let name_str = match from_c_str("name", name) {
+        Ok(s) => s,
+        Err(_) => return RegorusStatus::RegorusStatusError,
+    };
+    
+    let result = CALLBACK_MAP.with(|callbacks| {
+        callbacks.borrow_mut().insert(name_str, (callback, context));
+        RegorusStatus::RegorusStatusOk
+    });
+    
+    result
+}
+
+// Remove a callback function
+#[no_mangle]
+pub extern "C" fn regorus_unregister_callback(name: *const c_char) -> RegorusStatus {
+    if name.is_null() {
+        return RegorusStatus::RegorusStatusError;
+    }
+    
+    let name_str = match from_c_str("name", name) {
+        Ok(s) => s,
+        Err(_) => return RegorusStatus::RegorusStatusError,
+    };
+    
+    let result = CALLBACK_MAP.with(|callbacks| {
+        callbacks.borrow_mut().remove(&name_str);
+        RegorusStatus::RegorusStatusOk
+    });
+    
+    result
 }
 
 /// Result of a call on `RegorusEngine`.
@@ -105,13 +163,69 @@ pub extern "C" fn regorus_result_drop(r: RegorusResult) {
         }
     }
 }
+// Extension function to invoke callback
+fn invoke_callback(mut params: Vec<::regorus::Value>) -> Result<::regorus::Value> {
+    if params.len() != 2 {
+        bail!("invoke requires exactly two parameters: function_name and payload");
+    }
+    
+    let function_name = match params.remove(0) {
+        ::regorus::Value::String(s) => s.as_ref().to_string(),
+        _ => bail!("function_name must be a string"),
+    };
+    
+    // Serialize the payload to JSON
+    let payload = serde_json::to_string(&params.remove(0))
+        .map_err(|e| anyhow!("Failed to serialize payload: {}", e))?;
+    
+    // Look up the callback function using thread_local storage
+    let callback_option = CALLBACK_MAP.with(|callbacks| {
+        callbacks.borrow().get(&function_name).cloned()
+    });
+    
+    let (callback_fn, context) = match callback_option {
+        Some(cb) => cb,
+        None => bail!("No callback registered with name: {}", function_name),
+    };
+    
+    // Convert payload to C string
+    let payload_c_str = match CString::new(payload) {
+        Ok(cs) => cs,
+        Err(_) => bail!("Failed to convert payload to C string"),
+    };
+    
+    // Call the orchestration function
+    let result_ptr = callback_fn(payload_c_str.as_ptr(), context);
+    
+    if result_ptr.is_null() {
+        return Ok(::regorus::Value::Null);
+    }
+    
+    // Convert the result back to a Value
+    let result_str = unsafe {
+        let result = CStr::from_ptr(result_ptr)
+            .to_str()
+            .map_err(|e| anyhow!("Invalid UTF-8 in callback result: {}", e))?
+            .to_string();
+            
+        // Free the memory allocated by C#
+        let _ = CString::from_raw(result_ptr as *mut c_char);
+        
+        result
+    };
+    
+    // Convert result string to Value
+    ::regorus::Value::from_json_str(&result_str)
+        .map_err(|e| anyhow!("Failed to parse callback result as JSON: {}", e))
+}
 
 #[no_mangle]
 /// Construct a new Engine
 ///
 /// See https://docs.rs/regorus/latest/regorus/struct.Engine.html
 pub extern "C" fn regorus_engine_new() -> *mut RegorusEngine {
-    let engine = ::regorus::Engine::new();
+    let mut engine = ::regorus::Engine::new();
+    let _ = engine.add_extension("invoke".to_string(), 2, Box::new(invoke_callback));
     Box::into_raw(Box::new(RegorusEngine { engine }))
 }
 


### PR DESCRIPTION
It is still early draft that shows invoke of C# sharp code within extension during Rego policy evaluation. Example policy is in `bindings/csharp/scripts/invoke.csx`

TODO:
- [ ] Implement it as a built-in extension, instead of placing it in FFI
- [ ] Decide if not a thread-safe solution to store callbacks mapping is sufficient
- [ ] Validate typing support to callback payload and result