### PR TITLE
feat: Constant Folding/Partial Evaluation

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -615,6 +615,7 @@ impl Engine {
                 .set_functions(gather_functions(&self.modules)?);
             self.interpreter.gather_rules()?;
             self.interpreter.process_imports()?;
+            self.interpreter.constant_fold()?;
             self.prepared = true;
         }
 


### PR DESCRIPTION
A special mode of evaluation is introduced in which
- access to input is disallowed
- only those builtin functions that are idempotent are allowed
- extensions are disallowed

Those rules which evaluate to value other than undefined will procduce the same value irrespective of the input. Values of such rules are cached so that in regular evaluation these rules don't have to be evaluated.

TODO:
- Expressions evaluating to values other than undefined can also be cached. But this might consume memory.
  - Even if one expression or statement in a query evaluated to undefined, evaluation can still proceed to evaluate other expressions so that they can be cached if possible.
- Expensive to create objects such as Regexes can also be cached. This will require caching at a lower level than expressions. Impact on memory must also be considered.