### PR TITLE
feat!: Indexes for nodes in the AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -63,33 +63,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -104,9 +104,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -153,15 +153,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cast"
@@ -171,18 +171,18 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -270,27 +270,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -376,7 +376,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "litemap"
@@ -731,9 +731,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -747,9 +747,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "msvc_spectre_libs"
@@ -870,19 +870,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
-name = "pad"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -890,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1002,12 +993,11 @@ dependencies = [
 
 [[package]]
 name = "prettydiff"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0668e945d7caa9b3e3a4cb360d7dd1f2613d62233f8846dbfb7ea3c3df0910"
+checksum = "b9a475bdea0881b8c65eb81f91fe53187b8522352a701b919c5a2c8a2f262808"
 dependencies = [
  "owo-colors",
- "pad",
 ]
 
 [[package]]
@@ -1048,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1118,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1142,7 +1132,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1255,7 +1245,7 @@ checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1287,7 +1277,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1329,9 +1319,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spin"
@@ -1364,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
@@ -1381,7 +1371,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1423,12 +1413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,12 +1449,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
  "rand 0.9.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1537,7 +1523,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1559,7 +1545,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1613,7 +1599,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1624,14 +1610,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1759,28 +1745,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1800,7 +1786,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -1834,5 +1820,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2 1.0.95",
  "quote 1.0.40",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]

--- a/bindings/ffi/Cargo.lock
+++ b/bindings/ffi/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,37 +57,37 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -98,9 +98,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -147,15 +147,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cbindgen"
@@ -178,18 +178,18 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -228,18 +228,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -249,15 +249,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation-sys"
@@ -309,12 +309,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -597,9 +597,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -615,9 +615,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -631,9 +631,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "msvc_spectre_libs"
@@ -743,9 +743,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -753,15 +753,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1019,7 +1019,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1100,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1134,9 +1134,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1152,9 +1152,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1182,7 +1182,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1209,18 +1209,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -1232,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -1273,12 +1273,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
  "rand 0.9.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1408,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1436,7 +1438,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -1445,14 +1456,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1462,10 +1489,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1474,10 +1513,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1486,10 +1537,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1498,16 +1561,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -1553,18 +1628,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindings/java/Cargo.lock
+++ b/bindings/java/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -97,15 +97,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -115,9 +115,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -130,9 +130,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "iana-time-zone"
@@ -501,9 +501,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "litemap"
@@ -513,9 +513,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -529,9 +529,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "msvc_spectre_libs"
@@ -635,9 +635,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1012,9 +1012,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1024,9 +1024,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1105,12 +1105,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
  "rand 0.9.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1259,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1461,18 +1463,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -97,30 +97,30 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -469,9 +469,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "litemap"
@@ -481,9 +481,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -497,9 +497,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -621,9 +621,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1060,9 +1060,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1072,9 +1072,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1145,12 +1145,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
  "rand 0.9.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1280,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1407,18 +1409,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindings/ruby/Cargo.lock
+++ b/bindings/ruby/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -117,21 +117,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "iana-time-zone"
@@ -524,18 +524,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -546,9 +546,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -585,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minimal-lexical"
@@ -707,9 +707,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -869,18 +869,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ca6726be0eca74687047fed7dcbc2d509571f3962e190c343ac1eb40e482b3"
+checksum = "7059846f68396df83155779c75336ca24567741cb95256e6308c9fcc370e8dad"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2390cfc87b7513656656faad6567291e581542d3ec41dd0a2bf381896e0880"
+checksum = "ac217510df41b9ffc041573e68d7a02aaff770c49943c7494441c4b224b0ecd0"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -899,9 +899,9 @@ checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1134,9 +1134,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1146,9 +1146,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1213,12 +1213,14 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom",
+ "js-sys",
  "rand 0.9.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1348,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1388,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -1539,18 +1541,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindings/wasm/Cargo.lock
+++ b/bindings/wasm/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -97,30 +97,30 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -245,7 +245,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "iana-time-zone"
@@ -472,9 +472,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "litemap"
@@ -484,9 +484,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -500,9 +500,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "minicov"
@@ -616,9 +616,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -996,9 +996,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1008,9 +1008,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1069,9 +1069,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -1414,18 +1414,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/build.rs
+++ b/build.rs
@@ -26,5 +26,7 @@ fn main() -> Result<()> {
         println!("cargo:rustc-env=GIT_HASH={}", git_hash);
     }
 
+    // Rerun only if build.rs changes.
+    println!("cargo:rerun-if-changed=build.rs");
     Ok(())
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -106,29 +106,60 @@ pub type Ref<T> = NodeRef<T>;
 #[cfg_attr(feature = "ast", derive(serde::Serialize))]
 pub enum Expr {
     // Simple items that only have a span as content.
-    String((Span, Value)),
-    RawString((Span, Value)),
-    Number((Span, Value)),
-    True(Span),
-    False(Span),
-    Null(Span),
-    Var((Span, Value)),
+    String {
+        span: Span,
+        value: Value,
+        eidx: u32,
+    },
+
+    RawString {
+        span: Span,
+        value: Value,
+        eidx: u32,
+    },
+
+    Number {
+        span: Span,
+        value: Value,
+        eidx: u32,
+    },
+
+    Bool {
+        span: Span,
+        value: Value,
+        eidx: u32,
+    },
+
+    Null {
+        span: Span,
+        value: Value,
+        eidx: u32,
+    },
+
+    Var {
+        span: Span,
+        value: Value,
+        eidx: u32,
+    },
 
     // array
     Array {
         span: Span,
         items: Vec<Ref<Expr>>,
+        eidx: u32,
     },
 
     // set
     Set {
         span: Span,
         items: Vec<Ref<Expr>>,
+        eidx: u32,
     },
 
     Object {
         span: Span,
         fields: Vec<(Span, Ref<Expr>, Ref<Expr>)>,
+        eidx: u32,
     },
 
     // Comprehensions
@@ -136,12 +167,14 @@ pub enum Expr {
         span: Span,
         term: Ref<Expr>,
         query: Ref<Query>,
+        eidx: u32,
     },
 
     SetCompr {
         span: Span,
         term: Ref<Expr>,
         query: Ref<Query>,
+        eidx: u32,
     },
 
     ObjectCompr {
@@ -149,17 +182,20 @@ pub enum Expr {
         key: Ref<Expr>,
         value: Ref<Expr>,
         query: Ref<Query>,
+        eidx: u32,
     },
 
     Call {
         span: Span,
         fcn: Ref<Expr>,
         params: Vec<Ref<Expr>>,
+        eidx: u32,
     },
 
     UnaryExpr {
         span: Span,
         expr: Ref<Expr>,
+        eidx: u32,
     },
 
     // ref
@@ -167,12 +203,14 @@ pub enum Expr {
         span: Span,
         refr: Ref<Expr>,
         field: (Span, Value),
+        eidx: u32,
     },
 
     RefBrack {
         span: Span,
         refr: Ref<Expr>,
         index: Ref<Expr>,
+        eidx: u32,
     },
 
     // Infix expressions
@@ -181,12 +219,15 @@ pub enum Expr {
         op: BinOp,
         lhs: Ref<Expr>,
         rhs: Ref<Expr>,
+        eidx: u32,
     },
+
     BoolExpr {
         span: Span,
         op: BoolOp,
         lhs: Ref<Expr>,
         rhs: Ref<Expr>,
+        eidx: u32,
     },
 
     ArithExpr {
@@ -194,6 +235,7 @@ pub enum Expr {
         op: ArithOp,
         lhs: Ref<Expr>,
         rhs: Ref<Expr>,
+        eidx: u32,
     },
 
     AssignExpr {
@@ -201,6 +243,7 @@ pub enum Expr {
         op: AssignOp,
         lhs: Ref<Expr>,
         rhs: Ref<Expr>,
+        eidx: u32,
     },
 
     Membership {
@@ -208,6 +251,7 @@ pub enum Expr {
         key: Option<Ref<Expr>>,
         value: Ref<Expr>,
         collection: Ref<Expr>,
+        eidx: u32,
     },
 
     #[cfg(feature = "rego-extensions")]
@@ -215,6 +259,7 @@ pub enum Expr {
         span: Span,
         lhs: Ref<Expr>,
         rhs: Ref<Expr>,
+        eidx: u32,
     },
 }
 
@@ -222,9 +267,13 @@ impl Expr {
     pub fn span(&self) -> &Span {
         use Expr::*;
         match self {
-            String(s) | RawString(s) | Number(s) | Var(s) => &s.0,
-            True(s) | False(s) | Null(s) => s,
-            Array { span, .. }
+            String { span, .. }
+            | RawString { span, .. }
+            | Number { span, .. }
+            | Bool { span, .. }
+            | Null { span, .. }
+            | Var { span, .. }
+            | Array { span, .. }
             | Set { span, .. }
             | Object { span, .. }
             | ArrayCompr { span, .. }
@@ -241,6 +290,35 @@ impl Expr {
             | Membership { span, .. } => span,
             #[cfg(feature = "rego-extensions")]
             OrExpr { span, .. } => span,
+        }
+    }
+
+    pub fn eidx(&self) -> u32 {
+        use Expr::*;
+        match self {
+            String { eidx, .. }
+            | RawString { eidx, .. }
+            | Number { eidx, .. }
+            | Bool { eidx, .. }
+            | Null { eidx, .. }
+            | Var { eidx, .. }
+            | Array { eidx, .. }
+            | Set { eidx, .. }
+            | Object { eidx, .. }
+            | ArrayCompr { eidx, .. }
+            | SetCompr { eidx, .. }
+            | ObjectCompr { eidx, .. }
+            | Call { eidx, .. }
+            | UnaryExpr { eidx, .. }
+            | RefDot { eidx, .. }
+            | RefBrack { eidx, .. }
+            | BinExpr { eidx, .. }
+            | BoolExpr { eidx, .. }
+            | ArithExpr { eidx, .. }
+            | AssignExpr { eidx, .. }
+            | Membership { eidx, .. } => *eidx,
+            #[cfg(feature = "rego-extensions")]
+            OrExpr { eidx, .. } => *eidx,
         }
     }
 }
@@ -290,6 +368,7 @@ pub struct LiteralStmt {
     pub literal: Literal,
     #[cfg_attr(feature = "ast", serde(skip_serializing_if = "Vec::is_empty"))]
     pub with_mods: Vec<WithModifier>,
+    pub sidx: u32,
 }
 
 #[derive(Debug)]
@@ -297,6 +376,7 @@ pub struct LiteralStmt {
 pub struct Query {
     pub span: Span,
     pub stmts: Vec<LiteralStmt>,
+    pub qidx: u32,
 }
 
 #[derive(Debug)]
@@ -385,6 +465,12 @@ pub struct Module {
     #[cfg_attr(feature = "ast", serde(rename(serialize = "rules")))]
     pub policy: Vec<Ref<Rule>>,
     pub rego_v1: bool,
+    // Number of expressions in the module.
+    pub num_expressions: u32,
+    // Number of statements in the module.
+    pub num_statements: u32,
+    // Number of queries in the module.
+    pub num_queries: u32,
 }
 
 pub type ExprRef = Ref<Expr>;

--- a/src/indexchecker.rs
+++ b/src/indexchecker.rs
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(debug_assertions)]
+
+use crate::ast::*;
+use alloc::collections::BTreeSet;
+use alloc::format;
+use anyhow::{bail, Result};
+
+// Ensures that indexes are unique and continuous, starting from 0.
+#[derive(Default)]
+pub struct IndexChecker {
+    eidx: BTreeSet<u32>,
+    sidx: BTreeSet<u32>,
+    qidx: BTreeSet<u32>,
+}
+
+#[cfg(debug_assertions)]
+impl IndexChecker {
+    fn check_query(&mut self, query: &Query) -> Result<()> {
+        let qidx = query.qidx;
+        if !self.qidx.insert(qidx) {
+            bail!(query
+                .span
+                .error(format!("query with qidx {qidx} already exists").as_str()));
+        }
+
+        for stmt in &query.stmts {
+            if !self.sidx.insert(stmt.sidx) {
+                bail!(stmt
+                    .span
+                    .error(format!("statement with sidx {} already exists", stmt.sidx).as_str()));
+            }
+            match &stmt.literal {
+                Literal::Every { domain, query, .. } => {
+                    self.check_eidx(domain)?;
+                    self.check_query(query.as_ref())?;
+                }
+                Literal::SomeVars { .. } => (),
+                Literal::Expr { expr, .. } => self.check_eidx(expr.as_ref())?,
+                Literal::SomeIn {
+                    key,
+                    value,
+                    collection,
+                    ..
+                } => {
+                    if let Some(key) = key {
+                        self.check_eidx(key.as_ref())?;
+                    }
+                    self.check_eidx(value.as_ref())?;
+                    self.check_eidx(collection.as_ref())?;
+                }
+                Literal::NotExpr { expr, .. } => {
+                    self.check_eidx(expr.as_ref())?;
+                }
+            }
+            for with_mod in &stmt.with_mods {
+                self.check_eidx(with_mod.refr.as_ref())?;
+                self.check_eidx(with_mod.r#as.as_ref())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_eidx(&mut self, expr: &Expr) -> Result<()> {
+        use Expr::*;
+        let eidx = expr.eidx();
+        if !self.eidx.insert(eidx) {
+            bail!(expr
+                .span()
+                .error(format!("expression with eidx {eidx} already exists").as_str()));
+        }
+
+        match expr {
+            String { .. }
+            | RawString { .. }
+            | Number { .. }
+            | Bool { .. }
+            | Null { .. }
+            | Var { .. } => (),
+
+            Array { items, .. } => {
+                for elem in items {
+                    self.check_eidx(elem.as_ref())?;
+                }
+            }
+            Set { items, .. } => {
+                for elem in items {
+                    self.check_eidx(elem.as_ref())?;
+                }
+            }
+
+            Object { fields, .. } => {
+                for pair in fields {
+                    self.check_eidx(pair.1.as_ref())?;
+                    self.check_eidx(pair.2.as_ref())?;
+                }
+            }
+
+            ArrayCompr { term, query, .. } => {
+                self.check_eidx(term.as_ref())?;
+                self.check_query(query.as_ref())?;
+            }
+
+            SetCompr { term, query, .. } => {
+                self.check_eidx(term.as_ref())?;
+                self.check_query(query.as_ref())?;
+            }
+
+            ObjectCompr {
+                key, value, query, ..
+            } => {
+                self.check_eidx(key.as_ref())?;
+                self.check_eidx(value.as_ref())?;
+                self.check_query(query.as_ref())?;
+            }
+
+            Call { fcn, params, .. } => {
+                self.check_eidx(fcn.as_ref())?;
+                for param in params {
+                    self.check_eidx(param.as_ref())?;
+                }
+            }
+
+            UnaryExpr { expr, .. } => {
+                self.check_eidx(expr.as_ref())?;
+            }
+
+            RefBrack { refr, index, .. } => {
+                self.check_eidx(refr.as_ref())?;
+                self.check_eidx(index.as_ref())?;
+            }
+            RefDot { refr, .. } => {
+                self.check_eidx(refr.as_ref())?;
+            }
+
+            BinExpr { lhs, rhs, .. }
+            | BoolExpr { lhs, rhs, .. }
+            | ArithExpr { lhs, rhs, .. }
+            | AssignExpr { lhs, rhs, .. } => {
+                self.check_eidx(lhs.as_ref())?;
+                self.check_eidx(rhs.as_ref())?;
+            }
+
+            Membership {
+                key,
+                value,
+                collection,
+                ..
+            } => {
+                if let Some(key) = key {
+                    self.check_eidx(key.as_ref())?;
+                }
+                self.check_eidx(value.as_ref())?;
+                self.check_eidx(collection.as_ref())?;
+            }
+
+            #[cfg(feature = "rego-extensions")]
+            OrExpr { lhs, rhs, .. } => {
+                self.check_eidx(lhs.as_ref())?;
+                self.check_eidx(rhs.as_ref())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_rule_assign(&mut self, assign: &RuleAssign) -> Result<()> {
+        self.check_eidx(&assign.value)
+    }
+
+    fn check_rule_body(&mut self, body: &RuleBody) -> Result<()> {
+        if let Some(assign) = &body.assign {
+            self.check_rule_assign(assign)?;
+        }
+        self.check_query(&body.query)
+    }
+
+    fn check_rule_heade(&mut self, head: &RuleHead) -> Result<()> {
+        match head {
+            RuleHead::Compr { refr, assign, .. } => {
+                self.check_eidx(refr.as_ref())?;
+                if let Some(assign) = assign {
+                    self.check_rule_assign(assign)?;
+                }
+            }
+            RuleHead::Func {
+                refr, args, assign, ..
+            } => {
+                self.check_eidx(refr.as_ref())?;
+                if let Some(assign) = assign {
+                    self.check_rule_assign(assign)?;
+                }
+                for arg in args {
+                    self.check_eidx(arg.as_ref())?;
+                }
+            }
+
+            RuleHead::Set { refr, key, .. } => {
+                self.check_eidx(refr.as_ref())?;
+                if let Some(key) = key {
+                    self.check_eidx(key.as_ref())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_gathered_indexes(
+        &self,
+        num_idx: u32,
+        idx_set: &BTreeSet<u32>,
+        idx_type: &str,
+    ) -> Result<()> {
+        if num_idx == 0 {
+            if !idx_set.is_empty() {
+                bail!("no {idx_type} indexes should be collected when num_{idx_type}s is 0");
+            }
+            return Ok(());
+        }
+
+        if idx_set
+            .first()
+            .unwrap_or_else(|| panic!("no {idx_type} indexes collected"))
+            != &0
+        {
+            bail!("start {idx_type} index must be 0");
+        }
+
+        let last_idx = idx_set
+            .last()
+            .unwrap_or_else(|| panic!("no {idx_type} indexes collected"));
+        if last_idx != &(num_idx - 1) {
+            bail!(
+                "last {idx_type} index must be {} got {last_idx} instead",
+                num_idx - 1
+            );
+        }
+
+        Ok(())
+    }
+    pub fn check_module(&mut self, module: &Module) -> Result<()> {
+        self.check_eidx(module.package.refr.as_ref())?;
+        for import in &module.imports {
+            self.check_eidx(import.refr.as_ref())?;
+        }
+
+        for rule in &module.policy {
+            match rule.as_ref() {
+                Rule::Spec { head, bodies, .. } => {
+                    self.check_rule_heade(head)?;
+                    for body in bodies {
+                        self.check_rule_body(body)?;
+                    }
+                }
+                Rule::Default {
+                    refr, args, value, ..
+                } => {
+                    self.check_eidx(refr.as_ref())?;
+                    for arg in args {
+                        self.check_eidx(arg.as_ref())?;
+                    }
+                    self.check_eidx(value.as_ref())?;
+                }
+            }
+        }
+
+        if module.num_expressions == 0 {
+            bail!("module must have at least one expression");
+        }
+
+        self.check_gathered_indexes(module.num_expressions, &self.eidx, "expression")?;
+        self.check_gathered_indexes(module.num_statements, &self.sidx, "statement")?;
+        self.check_gathered_indexes(module.num_queries, &self.qidx, "query")?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate std;
 mod ast;
 mod builtins;
 mod engine;
+mod indexchecker;
 mod interpreter;
 mod lexer;
 mod number;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,13 +19,13 @@ pub fn get_path_string(refr: &Expr, document: Option<&str>) -> Result<String> {
                 expr = Some(refr);
             }
             Some(Expr::RefBrack { refr, index, .. }) => {
-                if let Expr::String(s) = index.as_ref() {
-                    comps.push(s.0.text());
+                if let Expr::String { span: s, .. } = index.as_ref() {
+                    comps.push(s.text());
                 }
                 expr = Some(refr);
             }
-            Some(Expr::Var(v)) => {
-                comps.push(v.0.text());
+            Some(Expr::Var { span: v, .. }) => {
+                comps.push(v.text());
                 expr = None;
             }
             _ => bail!("internal error: not a simple ref {expr:?}"),
@@ -112,7 +112,7 @@ pub fn get_root_var(mut expr: &Expr) -> Result<SourceStr> {
     let empty = expr.span().source_str().clone_empty();
     loop {
         match expr {
-            Expr::Var(v) => return Ok(v.0.source_str()),
+            Expr::Var { span: v, .. } => return Ok(v.source_str()),
             Expr::RefDot { refr, .. } | Expr::RefBrack { refr, .. } => expr = refr,
             _ => return Ok(empty),
         }

--- a/tests/parser/cases/every/every.yaml
+++ b/tests/parser/cases/every/every.yaml
@@ -3,7 +3,7 @@
 
 cases:
   - note: basic
-    rego: |      
+    rego: |
       package test
       import future.keywords
 
@@ -13,48 +13,69 @@ cases:
           every a, b in vals { check(a) }
         }
       }
+    num_expressions: 14
+    num_queries: 3
+    num_statements: 4
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: y
+                eidx: 3
               assign:
                 op: "="
                 value:
                   number: 8
+                  eidx: 4
           bodies:
             - query:
+                qidx: 2
                 stmts:
-                  - literal:
+                  - sidx: 3
+                    literal:
                       every:
                         value: x
                         domain:
                           array:
                             - number: 2
+                              eidx: 5
+                          eidx: 6
                         query:
+                          qidx: 1
                           stmts:
-                            - literal:
+                            - sidx: 0
+                              literal:
                                 expr:
                                   boolexpr:
                                     op: ">"
                                     lhs:
                                       var: x
+                                      eidx: 7
                                     rhs:
                                       number: 0
-                            - literal:
+                                      eidx: 8
+                                  eidx: 9
+                            - sidx: 2
+                              literal:
                                 every:
                                   key: a
                                   value: b
                                   domain:
                                     var: vals
+                                    eidx: 10
                                   query:
+                                    qidx: 0
                                     stmts:
-                                      - literal:
+                                      - sidx: 1
+                                        literal:
                                           expr:
                                             call:
                                               fcn:
                                                 var: check
+                                                eidx: 11
                                               params:
                                                 - var: a
-                            
+                                                  eidx: 12
+                                            eidx: 13
+

--- a/tests/parser/cases/expressions/arithmetic.yaml
+++ b/tests/parser/cases/expressions/arithmetic.yaml
@@ -7,12 +7,16 @@ cases:
       package test
 
       x = 1 - 2 * 3 / 4 + 2
+    num_expressions: 11
+    num_queries: 0
+    num_statements: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: =
                 value:
@@ -23,6 +27,7 @@ cases:
                         op: "-"
                         lhs:
                           number: 1
+                          eidx: 2
                         rhs:
                           arithexpr:
                             op: "/"
@@ -31,10 +36,18 @@ cases:
                                 op: "*"
                                 lhs:
                                   number: 2
+                                  eidx: 3
                                 rhs:
                                   number: 3
+                                  eidx: 4
+                              eidx: 5
                             rhs:
                               number: 4
+                              eidx: 6
+                          eidx: 7
+                      eidx: 8
                     rhs:
                       number: 2
+                      eidx: 9
+                  eidx: 10
           bodies: []

--- a/tests/parser/cases/expressions/array-compr.yaml
+++ b/tests/parser/cases/expressions/array-compr.yaml
@@ -8,6 +8,9 @@ cases:
       x = {1}
       y = {2}
       z = [ x | y ] #, 5] # in {5}, 6]
+    num_expressions: 11
+    num_queries: 1
+    num_statements: 1
     policy:
       - --skip--
       - --skip--
@@ -16,18 +19,24 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 7
               assign:
                 op: =
                 value:
                   arraycompr:
                     term:
                       var: x
+                      eidx: 8
                     query:
+                      qidx: 0
                       stmts:
                         - span: y
                           literal:
                             expr:
                               var: y
+                              eidx: 9
+                          sidx: 0
+                  eidx: 10
           bodies: []
 
   - note: case2-array
@@ -36,6 +45,9 @@ cases:
       x = {1}
       y = {2}
       z = [ x | y, 5] # in {5}, 6]
+    num_expressions: 13
+    num_queries: 0
+    num_statements: 0
     policy:
       - --skip--
       - --skip--
@@ -44,6 +56,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 7
               assign:
                 op: =
                 value:
@@ -52,9 +65,14 @@ cases:
                         op: "|"
                         lhs:
                           var: x
+                          eidx: 8
                         rhs:
                           var: y
+                          eidx: 9
+                      eidx: 10
                     - number: 5
+                      eidx: 11
+                  eidx: 12
           bodies: []
 
   - note: case3-compr
@@ -64,6 +82,9 @@ cases:
       x = {1}
       y = {2}
       z = [ x | y, 5 in {5}] #, 6]
+    num_expressions: 18
+    num_queries: 1
+    num_statements: 1
     policy:
       - --skip--
       - --skip--
@@ -72,25 +93,36 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
                   arraycompr:
                     term:
                       var: x
+                      eidx: 11
                     query:
+                      qidx: 0
                       stmts:
                         - span: y, 5 in {5}
+                          sidx: 0
                           literal:
                             expr:
                               inexpr:
                                 key:
                                   var: y
+                                  eidx: 12
                                 value:
                                   number: 5
+                                  eidx: 13
                                 collection:
                                   set:
                                     - number: 5
+                                      eidx: 14
+                                  eidx: 15
+                              eidx: 16
+                            eidx: 15
+                  eidx: 17
           bodies: []
 
   - note: case4-array
@@ -100,6 +132,9 @@ cases:
       x = {1}
       y = {2}
       z = [ x | y, 5 in {5}, 6]
+    num_expressions: 20
+    num_queries: 0
+    num_statements: 0
     policy:
       - --skip--
       - --skip--
@@ -108,6 +143,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -116,15 +152,24 @@ cases:
                         op: "|"
                         lhs:
                           var: x
+                          eidx: 11
                         rhs:
                           var: y
+                          eidx: 12
+                      eidx: 13
                     - inexpr:
                         value:
                           number: 5
+                          eidx: 14
                         collection:
                           set:
                             - number: 5
+                              eidx: 15
+                          eidx: 16
+                      eidx: 17
                     - number: 6
+                      eidx: 18
+                  eidx: 19
           bodies: []
 
   - note: case5-array
@@ -134,6 +179,9 @@ cases:
       x = {1}
       y = {2}
       z = [ x - {10} | y, 5 in {5}] #, 6]
+    num_expressions: 22
+    num_queries: 0
+    num_statements: 0
     policy:
       - --skip--
       - --skip--
@@ -142,6 +190,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -153,17 +202,28 @@ cases:
                             op: "-"
                             lhs:
                               var: x
+                              eidx: 11
                             rhs:
                               set:
                                 - number: 10
+                                  eidx: 12
+                              eidx: 13
+                          eidx: 14
                         rhs:
                           var: y
+                          eidx: 15
+                      eidx: 16
                     - inexpr:
                         value:
                           number: 5
+                          eidx: 17
                         collection:
                           set:
                             - number: 5
+                              eidx: 18
+                          eidx: 19
+                      eidx: 20
+                  eidx: 21
           bodies: []
 
   - note: case6-compr
@@ -173,6 +233,9 @@ cases:
       x = {1}
       y = {2}
       z = [ (x - {10}) | y, 5 in {5}] #, 6]
+    num_expressions: 21
+    num_queries: 1
+    num_statements: 1
     policy:
       - --skip--
       - --skip--
@@ -181,6 +244,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -190,19 +254,31 @@ cases:
                         op: "-"
                         lhs:
                           var: x
+                          eidx: 11
                         rhs:
                           set:
                             - number: 10
+                              eidx: 12
+                          eidx: 13
+                      eidx: 14
                     query:
+                      qidx: 0
                       stmts:
-                        - literal:
+                        - sidx: 0
+                          literal:
                             expr:
                               inexpr:
                                 key:
                                   var: y
+                                  eidx: 15
                                 value:
                                   number: 5
+                                  eidx: 16
                                 collection:
                                   set:
                                     - number: 5
+                                      eidx: 17
+                                  eidx: 18
+                              eidx: 19
+                  eidx: 20
           bodies: []

--- a/tests/parser/cases/expressions/array.yaml
+++ b/tests/parser/cases/expressions/array.yaml
@@ -17,19 +17,24 @@ cases:
           # Nested empty
           [[[[[]]]]]
       ]
-
+    num_expressions: 17
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 span: = {1}
                 op: "="
                 value:
                   set:
                     - number: 1
+                      eidx: 2
+                  eidx: 3
           bodies: --skip--
 
       - spec:
@@ -37,21 +42,34 @@ cases:
             compr:
               refr:
                 var: y
+                eidx: 4
               assign:
                 op: "="
                 value:
                   array:
                     - number: 2.5
+                      eidx: 5
                     - string: abc
+                      eidx: 6
                     - array:
                         - number: 4
+                          eidx: 7
                         - rawstring: raw
+                          eidx: 8
+                      eidx: 9
                     - array: []
+                      eidx: 10
                     - array:
                         - array:
                             - array:
                               - array:
                                 - array: []
+                                  eidx: 11
+                                eidx: 12
+                              eidx: 13
+                          eidx: 14
+                      eidx: 15
+                  eidx: 16
           bodies: []
 
   - note: trailing-comma
@@ -60,12 +78,16 @@ cases:
       x = [1,]
       y = [1,2
       ,]
+    num_expressions: 8
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: "="
                 value:
@@ -73,12 +95,15 @@ cases:
                     span: "[1,]"
                     values:
                       - number: 1
+                        eidx: 2
+                  eidx: 3
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: y
+                eidx: 4
               assign:
                 op: "="
                 value:
@@ -86,7 +111,10 @@ cases:
                     span: "[1,2\n,]"
                     values:
                       - number: 1
+                        eidx: 5
                       - number: 2
+                        eidx: 6
+                  eidx: 7
           bodies: []
 
   - note: no-comma

--- a/tests/parser/cases/expressions/bin.yaml
+++ b/tests/parser/cases/expressions/bin.yaml
@@ -10,12 +10,16 @@ cases:
       # If not the following expressions would evaluate to empty set.
       x = {1, 2, 3} | {2} & {4}
       y = {2} & {4} | {1, 2, 3}
+    num_expressions: 23
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: =
                 value:
@@ -24,23 +28,34 @@ cases:
                     lhs:
                       set:
                         - number: 1
+                          eidx: 2
                         - number: 2
+                          eidx: 3
                         - number: 3
+                          eidx: 4
+                      eidx: 5
                     rhs:
                       binexpr:
                         op: "&"
                         lhs:
                           set:
                             - number: 2
+                              eidx: 6
+                          eidx: 7
                         rhs:
                           set:
                             - number: 4
+                              eidx: 8
+                          eidx: 9
+                      eidx: 10
+                  eidx: 11
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: y
+                eidx: 12
               assign:
                 op: =
                 value:
@@ -49,16 +64,26 @@ cases:
                     rhs:
                       set:
                         - number: 1
+                          eidx: 18
                         - number: 2
+                          eidx: 19
                         - number: 3
+                          eidx: 20
+                      eidx: 21
                     lhs:
                       binexpr:
                         op: "&"
                         lhs:
                           set:
                             - number: 2
+                              eidx: 13
+                          eidx: 14
                         rhs:
                           set:
                             - number: 4
+                              eidx: 15
+                          eidx: 16
+                      eidx: 17
+                  eidx: 22
           bodies: []
-    
+

--- a/tests/parser/cases/expressions/bool.yaml
+++ b/tests/parser/cases/expressions/bool.yaml
@@ -13,13 +13,16 @@ cases:
       # different types against object
       # different types against set
       # strings etc
-      
+    num_expressions: 9
+    num_queries: 0
+    num_statements: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: =
                 value:
@@ -29,15 +32,22 @@ cases:
                       arithexpr:
                         op: "+"
                         lhs:
-                          number: 1
+                            number: 1
+                            eidx: 2
                         rhs:
                           number: 2
+                          eidx: 3
+                      eidx: 4
                     rhs:
                       arithexpr:
                         op: "-"
                         lhs:
                           number: 3
+                          eidx: 5
                         rhs:
                           number: 2
-                    
+                          eidx: 6
+                      eidx: 7
+                  eidx: 8
+
           bodies: []

--- a/tests/parser/cases/expressions/call.yaml
+++ b/tests/parser/cases/expressions/call.yaml
@@ -11,6 +11,9 @@ cases:
 
       # Trailing comma
       x = inc(5,)
+    num_expressions: 13
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           head:
@@ -19,30 +22,42 @@ cases:
                 refbrack:
                   refr:
                     var: deny
+                    eidx: 1
                   index:
                     call:
                       fcn:
                         var: sprintf
+                        eidx: 2
                       params:
                         - string: "Hello %v"
+                          eidx: 3
                         - array:
                             - string: "world"
+                              eidx: 4
+                          eidx: 5
+                    eidx: 6
+                eidx: 7
               assign:
                 op: =
                 value:
                   number: 1
+                  eidx: 8
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 9
               assign:
                 op: "="
                 value:
                   call:
                     fcn:
                       var: inc
+                      eidx: 10
                     params:
                       - number: 5
+                        eidx: 11
+                  eidx: 12
           bodies: []

--- a/tests/parser/cases/expressions/in.yaml
+++ b/tests/parser/cases/expressions/in.yaml
@@ -13,29 +13,38 @@ cases:
       # The following will be parsed as
       # (5 in [4, 5]) in (set() | {true})
       z = 5 in [4, 5] in set() | {true}
-
+    num_expressions: 21
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 4
               assign:
                 op: "="
                 value:
                   inexpr:
                     value:
                       number: 5
+                      eidx: 5
                     collection:
                       array:
                         - number: 4
+                          eidx: 6
                         - number: 5
+                          eidx: 7
+                      eidx: 8
+                  eidx: 9
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: "="
                 value:
@@ -44,16 +53,26 @@ cases:
                       inexpr:
                         value:
                           number: 5
+                          eidx: 11
                         collection:
                           array:
                             - number: 4
+                              eidx: 12
                             - number: 5
+                              eidx: 13
+                          eidx: 14
+                      eidx: 15
                     collection:
                       binexpr:
                         op: "|"
                         lhs:
                           set: []
+                          eidx: 16
                         rhs:
                           set:
-                            - true
+                            - bool: true
+                              eidx: 17
+                          eidx: 18
+                      eidx: 19
+                  eidx: 20
           bodies: []

--- a/tests/parser/cases/expressions/membership.yaml
+++ b/tests/parser/cases/expressions/membership.yaml
@@ -12,29 +12,37 @@ cases:
 
       # Chained in-exprs
       y = 0, 5 in c in d
+    num_expressions: 17
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 4
               assign:
                 op: "="
                 value:
                   inexpr:
                     key:
                       number: 0
+                      eidx: 5
                     value:
                       number: 5
+                      eidx: 6
                     collection:
                       array:
                         - number: 5
+                          eidx: 7
+                      eidx: 8
+                  eidx: 9
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: y
+                eidx: 10
               assign:
                 op: "="
                 value:
@@ -43,10 +51,16 @@ cases:
                       inexpr:
                         key:
                           number: 0
+                          eidx: 11
                         value:
                           number: 5
+                          eidx: 12
                         collection:
                           var: c
+                          eidx: 13
+                      eidx: 14
                     collection:
                       var: d
+                      eidx: 15
+                  eidx: 16
           bodies: []

--- a/tests/parser/cases/expressions/object.yaml
+++ b/tests/parser/cases/expressions/object.yaml
@@ -47,6 +47,9 @@ cases:
         "p" : "q", "r" in "d" : "e"
 
       }
+    num_expressions: 54
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           span: x = {}
@@ -55,18 +58,21 @@ cases:
               span: x = {}
               refr:
                 var: x
+                eidx: 4
               assign:
                 span: = {}
                 op: =
                 value:
                   object:
                     fields: []
+                  eidx: 5
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: y
+                eidx: 6
               assign:
                 op: =
                 value:
@@ -74,14 +80,18 @@ cases:
                     fields:
                       - key:
                           string: a
+                          eidx: 7
                         value:
                           number: 5
+                          eidx: 8
+                  eidx: 9
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -89,75 +99,121 @@ cases:
                     fields:
                       - key:
                           string: a
+                          eidx: 11
                         value:
                           number: 5
+                          eidx: 12
                       - key:
                           string: b
+                          eidx: 13
                         value:
                           array:
                             - number: 1
+                              eidx: 14
                             - number: 2
+                              eidx: 15
                             - number: 3
+                              eidx: 16
+                          eidx: 17
                       - key:
                           string: c
+                          eidx: 18
                         value:
                           set:
                             - number: 4
+                              eidx: 19
                             - number: 5
+                              eidx: 20
                             - number : 6
+                              eidx: 21
+                          eidx: 22
                       - key:
                           string: d
+                          eidx: 23
                         value:
                           object:
                             fields:
                               - key:
                                   string: a
+                                  eidx: 24
                                 value:
                                   number: 5
+                                  eidx: 25
                               - key:
                                   string: b
+                                  eidx: 26
                                 value:
                                   set: []
+                                  eidx: 27
+                          eidx: 28
                       - key:
                           array:
                             - number: 1
+                              eidx: 29
                             - number: 2
+                              eidx: 30
                             - number: 3
+                              eidx: 31
+                          eidx: 32
                         value:
                           number: 4
+                          eidx: 33
                       - key:
                           set:
                             - number: 1
+                              eidx: 34
+                          eidx: 35
                         value:
                           number: 2
+                          eidx: 36
                       - key:
                           object:
                             fields:
                               - key:
                                   string: a
+                                  eidx: 37
                                 value:
                                   number: 1
+                                  eidx: 38
                               - key:
                                   string: b
+                                  eidx: 39
                                 value:
                                   number: 2
+                                  eidx: 40
+                          eidx: 41
                         value:
                           rawstring: "hello,\n  world"
-                      - key: null
-                        value: false
-                      - key: true
-                        value: true
+                          eidx: 42
+                      - key:
+                          "null": null
+                          eidx: 43
+                        value:
+                          bool: false
+                          eidx: 44
+                      - key:
+                          bool: true
+                          eidx: 45
+                        value:
+                          bool: true
+                          eidx: 46
                       - key:
                           string: p
+                          eidx: 47
                         value:
                           string: q
+                          eidx: 48
                       - key:
                           inexpr:
                             value:
                               string: r
+                              eidx: 49
                             collection:
                               string: d
+                              eidx: 50
+                          eidx: 51
                         value:
                           string: e
-
+                          eidx: 52
+                  eidx: 53
           bodies: []

--- a/tests/parser/cases/expressions/set-compr.yaml
+++ b/tests/parser/cases/expressions/set-compr.yaml
@@ -8,6 +8,9 @@ cases:
       x = {1}
       y = {2}
       z = { x | y } #, 5} # in {5}, 6}
+    num_expressions: 11
+    num_statements: 1
+    num_queries: 1
     policy:
       - --skip--
       - --skip--
@@ -16,18 +19,24 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 7
               assign:
                 op: =
                 value:
                   setcompr:
                     term:
                       var: x
+                      eidx: 8
                     query:
+                      qidx: 0
                       stmts:
                         - span: y
+                          sidx: 0
                           literal:
                             expr:
                               var: y
+                              eidx: 9
+                  eidx: 10
           bodies: []
 
   - note: case2-set
@@ -36,6 +45,9 @@ cases:
       x = {1}
       y = {2}
       z = { x | y, 5} # in {5}, 6}
+    num_expressions: 13
+    num_statements: 0
+    num_queries: 0
     policy:
       - --skip--
       - --skip--
@@ -44,6 +56,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 7
               assign:
                 op: =
                 value:
@@ -52,9 +65,14 @@ cases:
                         op: "|"
                         lhs:
                           var: x
+                          eidx: 8
                         rhs:
                           var: y
+                          eidx: 9
+                      eidx: 10
                     - number: 5
+                      eidx: 11
+                  eidx: 12
           bodies: []
 
   - note: case3-compr
@@ -64,6 +82,9 @@ cases:
       x = {1}
       y = {2}
       z = { x | y, 5 in {5}} #, 6}
+    num_expressions: 18
+    num_statements: 1
+    num_queries: 1
     policy:
       - --skip--
       - --skip--
@@ -72,25 +93,35 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
                   setcompr:
                     term:
                       var: x
+                      eidx: 11
                     query:
+                      qidx: 0
                       stmts:
                         - span: y, 5 in {5}
+                          sidx: 0
                           literal:
                             expr:
                               inexpr:
                                 key:
-                                  var: y
+                                 var: y
+                                 eidx: 12
                                 value:
                                   number: 5
+                                  eidx: 13
                                 collection:
                                   set:
                                     - number: 5
+                                      eidx: 14
+                                  eidx: 15
+                              eidx: 16
+                  eidx: 17
           bodies: []
 
   - note: case4-set
@@ -100,6 +131,9 @@ cases:
       x = {1}
       y = {2}
       z = { x | y, 5 in {5}, 6}
+    num_expressions: 20
+    num_statements: 0
+    num_queries: 0
     policy:
       - --skip--
       - --skip--
@@ -108,6 +142,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -116,15 +151,24 @@ cases:
                         op: "|"
                         lhs:
                           var: x
+                          eidx: 11
                         rhs:
                           var: y
+                          eidx: 12
+                      eidx: 13
                     - inexpr:
                         value:
                           number: 5
+                          eidx: 14
                         collection:
                           set:
                             - number: 5
+                              eidx: 15
+                          eidx: 16
+                      eidx: 17
                     - number: 6
+                      eidx: 18
+                  eidx: 19
           bodies: []
 
   - note: case5-set
@@ -134,6 +178,9 @@ cases:
       x = {1}
       y = {2}
       z = { x - {10} | y, 5 in {5}} #, 6}
+    num_expressions: 22
+    num_statements: 0
+    num_queries: 0
     policy:
       - --skip--
       - --skip--
@@ -142,6 +189,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -153,17 +201,28 @@ cases:
                             op: "-"
                             lhs:
                               var: x
+                              eidx: 11
                             rhs:
                               set:
                                 - number: 10
+                                  eidx: 12
+                              eidx: 13
+                          eidx: 14
                         rhs:
                           var: y
+                          eidx: 15
+                      eidx: 16
                     - inexpr:
                         value:
                           number: 5
+                          eidx: 17
                         collection:
                           set:
                             - number: 5
+                              eidx: 18
+                          eidx: 19
+                      eidx: 20
+                  eidx: 21
           bodies: []
 
   - note: case6-compr
@@ -173,6 +232,9 @@ cases:
       x = {1}
       y = {2}
       z = { (x - {10}) | y, 5 in {5}} #, 6}
+    num_expressions: 21
+    num_statements: 1
+    num_queries: 1
     policy:
       - --skip--
       - --skip--
@@ -181,6 +243,7 @@ cases:
             compr:
               refr:
                 var: z
+                eidx: 10
               assign:
                 op: =
                 value:
@@ -190,19 +253,31 @@ cases:
                         op: "-"
                         lhs:
                           var: x
+                          eidx: 11
                         rhs:
                           set:
                             - number: 10
+                              eidx: 12
+                          eidx: 13
+                      eidx: 14
                     query:
+                      qidx: 0
                       stmts:
-                        - literal:
+                        - sidx: 0
+                          literal:
                             expr:
                               inexpr:
                                 key:
                                   var: y
+                                  eidx: 15
                                 value:
                                   number: 5
+                                  eidx: 16
                                 collection:
                                   set:
                                     - number: 5
+                                      eidx: 17
+                                  eidx: 18
+                              eidx: 19
+                  eidx: 20
           bodies: []

--- a/tests/parser/cases/expressions/set.yaml
+++ b/tests/parser/cases/expressions/set.yaml
@@ -17,19 +17,24 @@ cases:
           # Nested empty
           {{{{{}}}}}
       }
-
+    num_expressions: 17
+    num_statements: 0
+    num_queries: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 span: = {1}
                 op: "="
                 value:
                   set:
                     - number: 1
+                      eidx: 2
+                  eidx: 3
           bodies: --skip--
 
       - spec:
@@ -37,16 +42,23 @@ cases:
             compr:
               refr:
                 var: y
+                eidx: 4
               assign:
                 op: "="
                 value:
                   set:
                     - number: 2.5
+                      eidx: 5
                     - string: abc
+                      eidx: 6
                     - set:
                         - number: 4
+                          eidx: 7
                         - rawstring: raw
+                          eidx: 8
+                      eidx: 9
                     - set: []
+                      eidx: 10
                     - set:
                         - set:
                             - set:
@@ -54,6 +66,12 @@ cases:
                                 - object:
                                     span: "{}"
                                     fields: []
+                                  eidx: 11
+                                eidx: 12
+                              eidx: 13
+                          eidx: 14
+                      eidx: 15
+                  eidx: 16
           bodies: []
 
   - note: trailing-comma
@@ -62,12 +80,16 @@ cases:
       x = {1,}
       y = {1,2
       ,}
+    num_expressions: 8
+    num_queries: 0
+    num_statements: 0
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: "="
                 value:
@@ -75,12 +97,15 @@ cases:
                     span: "{1,}"
                     values:
                       - number: 1
+                        eidx: 2
+                  eidx: 3
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: y
+                eidx: 4
               assign:
                 op: "="
                 value:
@@ -88,16 +113,19 @@ cases:
                     span: "{1,2\n,}"
                     values:
                       - number: 1
+                        eidx: 5
                       - number: 2
+                        eidx: 6
+                  eidx: 7
           bodies: []
-          
+
 
   - note: no-comma
     rego: |
       package test
       x = {1 2}
     error: expecting `}` while parsing set
-    
+
   - note: two-trailing-commas
     rego: |
       package test

--- a/tests/parser/cases/import/future.yaml
+++ b/tests/parser/cases/import/future.yaml
@@ -6,6 +6,7 @@ cases:
     rego: |
       package test
       import future.keywords
+    num_expressions: 3
     imports:
       - span: import future.keywords
         refr:
@@ -13,7 +14,9 @@ cases:
             span: future.keywords
             refr:
               var: future
+              eidx: 1
             field: keywords
+          eidx: 2
 
   - note: all
     rego: |
@@ -22,6 +25,7 @@ cases:
       import              future.keywords.if
       import
       future.keywords.in
+    num_expressions: 13
     imports:
       - span: import              future.keywords.contains
         refr:
@@ -32,8 +36,11 @@ cases:
                 span: future.keywords
                 refr:
                   var: future
+                  eidx: 1
                 field: keywords
+              eidx: 2
             field: contains
+          eidx: 3
       - span: import future.keywords.every
         refr:
           refdot:
@@ -43,8 +50,11 @@ cases:
                 span: future.keywords
                 refr:
                   var: future
+                  eidx: 4
                 field: keywords
+              eidx: 5
             field: every
+          eidx: 6
       - span: import              future.keywords.if
         refr:
           refdot:
@@ -54,8 +64,11 @@ cases:
                 span: future.keywords
                 refr:
                   var: future
+                  eidx: 7
                 field: keywords
+              eidx: 8
             field: if
+          eidx: 9
       - span: "import\nfuture.keywords.in"
         refr:
           refdot:
@@ -65,8 +78,11 @@ cases:
                 span: future.keywords
                 refr:
                   var: future
+                  eidx: 10
                 field: keywords
+              eidx: 11
             field: in
+          eidx: 12
 
   - note: bracket
     rego: |
@@ -74,6 +90,9 @@ cases:
       import              future["keywords"]["contains"] import future.keywords["every"]
       import
       future["keywords"].if
+    num_expressions: 14
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import              future["keywords"]["contains"]
         refr:
@@ -84,10 +103,15 @@ cases:
                 span: future["keywords"]
                 refr:
                   var: future
+                  eidx: 1
                 index:
                   string: keywords
+                  eidx: 2
+              eidx: 3
             index:
               string: contains
+              eidx: 4
+          eidx: 5
       - span: import future.keywords["every"]
         refr:
           refbrack:
@@ -97,9 +121,13 @@ cases:
                 span: future.keywords
                 refr:
                   var: future
+                  eidx: 6
                 field: keywords
+              eidx: 7
             index:
               string: every
+              eidx: 8
+          eidx: 9
       - span: "import\nfuture[\"keywords\"].if"
         refr:
           refdot:
@@ -109,9 +137,13 @@ cases:
                 span: future["keywords"]
                 refr:
                   var: future
+                  eidx: 10
                 index:
                   string: keywords
+                  eidx: 11
+              eidx: 12
             field: if
+          eidx: 13
 
   - note: as
     rego: |
@@ -126,6 +158,9 @@ cases:
       import future["keywords"]
     #error: "this import shadows previous import of `contains`"
     query: data.test
+    num_expressions: 6
+    num_queries: 0
+    num_statements: 0
     want_result: {}
 
   - note: shadow/1
@@ -134,6 +169,9 @@ cases:
       import future.keywords
       import future.keywords.if
     #error: "this import shadows previous import of `if`"
+    num_expressions: 6
+    num_queries: 0
+    num_statements: 0
     query: data.test
     want_result: {}
 
@@ -144,6 +182,9 @@ cases:
       import future.keywords
     #error: "this import shadows previous import of `if`"
     query: data.test
+    num_expressions: 6
+    num_queries: 0
+    num_statements: 0
     want_result: {}
 
   - note: in-as-var
@@ -151,6 +192,9 @@ cases:
       package test
       import future.keywords.if
       in = 5
+    num_expressions: 6
+    num_queries: 0
+    num_statements: 0
 
   - note: in-as-var-imported
     rego: |

--- a/tests/parser/cases/import/import.yaml
+++ b/tests/parser/cases/import/import.yaml
@@ -7,68 +7,96 @@ cases:
       package test
       import data
       import input
+    num_expressions: 3
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import data
         refr:
           var: data
+          eidx: 1
       - span: import input
         refr:
           var: input
+          eidx: 2
 
   - note: input
     rego: |
       package test
       import input
+    num_expressions: 2
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import input
         refr:
           var: input
+          eidx: 1
 
   - note: dot
     rego: |
       package test
       import input.a
       import data.b
+    num_expressions: 5
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import input.a
         refr:
           refdot:
             refr:
               var: input
+              eidx: 1
             field: a
+          eidx: 2
       - span: import data.b
         refr:
           refdot:
             refr:
               var: data
+              eidx: 3
             field: b
+          eidx: 4
 
   - note: bracket
     rego: |
       package test
       import input["a"]
       import data["b"]
+    num_expressions: 7
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import input["a"]
         refr:
           refbrack:
             refr:
               var: input
+              eidx: 1
             index:
               string: a
+              eidx: 2
+          eidx: 3
       - span: import data["b"]
         refr:
           refbrack:
             refr:
               var: data
+              eidx: 4
             index:
               string: b
+              eidx: 5
+          eidx: 6
 
   - note: multi-dot
     rego: |
       package test
       import input.a.b
       import data.c.d
+    num_expressions: 7
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import input.a.b
         refr:
@@ -79,8 +107,11 @@ cases:
                 span: input.a
                 refr:
                   var: input
+                  eidx: 1
                 field: a
+              eidx: 2
             field: b
+          eidx: 3
       - span: import data.c.d
         refr:
           refdot:
@@ -90,8 +121,11 @@ cases:
                 span: data.c
                 refr:
                   var: data
+                  eidx: 4
                 field: c
+              eidx: 5
             field: d
+          eidx: 6
     policy: []
 
 
@@ -100,6 +134,9 @@ cases:
       package test
       import    input["b.c"].d["e.f"].g
       import      data.a["b.c"].d["e.f"]
+    num_expressions: 15
+    num_statements: 0
+    num_queries: 0
     package: --skip--
     imports:
       - span: import    input["b.c"].d["e.f"].g
@@ -117,12 +154,19 @@ cases:
                         span: input["b.c"]
                         refr:
                           var: input
+                          eidx: 1
                         index:
                           string: b.c
+                          eidx: 2
+                      eidx: 3
                     field: d
+                  eidx: 4
                 index:
                   string: e.f
+                  eidx: 5
+              eidx: 6
             field: g
+          eidx: 7
       - span: import      data.a["b.c"].d["e.f"]
         refr:
           refbrack:
@@ -138,12 +182,19 @@ cases:
                         span: data.a
                         refr:
                           var: data
+                          eidx: 8
                         field: a
+                      eidx: 9
                     index:
                       string: b.c
+                      eidx: 10
+                  eidx: 11
                 field: d
+              eidx: 12
             index:
               string: e.f
+              eidx: 13
+          eidx: 14
 
   - note:  same-line
     rego: package test import input.a["b"] import data["c"].d
@@ -151,6 +202,10 @@ cases:
       span: package test
       refr:
         var: test
+        eidx: 0
+    num_expressions: 9
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import input.a["b"]
         refr:
@@ -161,9 +216,13 @@ cases:
                 span: input.a
                 refr:
                   var: input
+                  eidx: 1
                 field: a
+              eidx: 2
             index:
               string: b
+              eidx: 3
+          eidx: 4
       - span: import data["c"].d
         refr:
           refdot:
@@ -173,14 +232,20 @@ cases:
                 span: data["c"]
                 refr:
                   var: data
+                  eidx: 5
                 index:
                   string: c
+                  eidx: 6
+              eidx: 7
             field: d
-
+          eidx: 8
   - note: as
     rego: |
       package test
       import input.x as y
+    num_expressions: 3
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: import input.x as y
         refr:
@@ -188,7 +253,9 @@ cases:
             span: input.x
             refr:
               var: input
+              eidx: 1
             field: x
+          eidx: 2
         as: y
 
   - note: as/newline
@@ -198,6 +265,9 @@ cases:
       input.x
       as
       y
+    num_expressions: 3
+    num_statements: 0
+    num_queries: 0
     imports:
       - span: "import\ninput.x\nas\ny"
         refr:
@@ -205,7 +275,9 @@ cases:
             span: input.x
             refr:
               var: input
+              eidx: 1
             field: x
+          eidx: 2
         as: y
 
   - note: missing-ref

--- a/tests/parser/cases/package/package.yaml
+++ b/tests/parser/cases/package/package.yaml
@@ -4,20 +4,31 @@
 cases:
   - note: single-char
     rego: package a
+    num_expressions: 1
+    num_statements: 0
+    num_queries: 0
     package:
       span: package a
       refr:
         var: a
+        eidx: 0
 
   - note: simple
     rego: package test
+    num_expressions: 1
+    num_statements: 0
+    num_queries: 0
     package:
       span: package test
       refr:
         var: test
+        eidx: 0
 
   - note: dot
     rego: package a.b
+    num_expressions: 2
+    num_statements: 0
+    num_queries: 0
     package:
       span: package a.b
       refr:
@@ -25,10 +36,15 @@ cases:
           span: a.b
           refr:
             var: a
+            eidx: 0
           field: b
+        eidx: 1
 
   - note: multi-dot
     rego: package a.b.c
+    num_expressions: 3
+    num_statements: 0
+    num_queries: 0
     package:
       span: package a.b.c
       refr:
@@ -39,11 +55,17 @@ cases:
               span: a.b
               refr:
                 var: a
+                eidx: 0
               field: b
+            eidx: 1
           field: c
+        eidx: 2
 
   - note: bracket
     rego: package a["b"]
+    num_expressions: 3
+    num_statements: 0
+    num_queries: 0
     package:
       span: package a["b"]
       refr:
@@ -51,11 +73,17 @@ cases:
           span: a["b"]
           refr:
             var: a
+            eidx: 0
           index:
             string: b
+            eidx: 1
+        eidx: 2
 
   - note: multi-bracket
     rego: package a["b"]["c.d"]
+    num_expressions: 5
+    num_statements: 0
+    num_queries: 0
     package:
       span: package a["b"]["c.d"]
       refr:
@@ -66,35 +94,50 @@ cases:
               span: a["b"]
               refr:
                 var: a
+                eidx: 0
               index:
                 string: b
+                eidx: 1
+            eidx: 2
           index:
             string: c.d
+            eidx: 3
+        eidx: 4
 
   - note: complex
     rego: package a["b.c"].d["e.f"].g
+    num_expressions: 7
+    num_statements: 0
+    num_queries: 0
     package:
       span: package a["b.c"].d["e.f"].g
       refr:
         refdot:
           span: a["b.c"].d["e.f"].g
           refr:
-             refbrack:
-               span: a["b.c"].d["e.f"]
-               refr:
-                 refdot:
-                   span: a["b.c"].d
-                   refr:
-                     refbrack:
-                       span: a["b.c"]
-                       refr:
-                         var: a
-                       index:
-                         string: "b.c"
-                   field: d
-               index:
-                 string: e.f
+            refbrack:
+              span: a["b.c"].d["e.f"]
+              refr:
+                refdot:
+                  span: a["b.c"].d
+                  refr:
+                    refbrack:
+                      span: a["b.c"]
+                      refr:
+                        var: a
+                        eidx: 0
+                      index:
+                        string: "b.c"
+                        eidx: 1
+                    eidx: 2
+                  field: d
+                eidx: 3
+              index:
+                string: e.f
+                eidx: 4
+            eidx: 5
           field: g
+        eidx: 6
 
   - note: missing-package-keyword
     rego: packge a

--- a/tests/parser/cases/rules/basic.yaml
+++ b/tests/parser/cases/rules/basic.yaml
@@ -6,6 +6,9 @@ cases:
     rego: |
       package test
       add(x, y) := 5 sub(x, y) = 5
+    num_expressions: 9
+    num_statements: 0
+    num_queries: 0
     package: --skip--
     imports:
     policy:
@@ -16,14 +19,18 @@ cases:
               span: add(x, y) := 5
               refr:
                 var: add
+                eidx: 1
               args:
                 - var: x
+                  eidx: 2
                 - var: y
+                  eidx: 3
               assign:
                 span: := 5
                 op: :=
                 value:
                   number: 5
+                  eidx: 4
           bodies: []
       - spec:
           span: sub(x, y) = 5
@@ -32,13 +39,17 @@ cases:
               span: sub(x, y) = 5
               refr:
                 var: sub
+                eidx: 5
               args:
                 - var: x
+                  eidx: 6
                 - var: y
+                  eidx: 7
               assign:
                 span: = 5
                 op: =
                 value:
                   number: 5
+                  eidx: 8
           bodies: []
-      
+

--- a/tests/parser/cases/rules/else.yaml
+++ b/tests/parser/cases/rules/else.yaml
@@ -12,6 +12,9 @@ cases:
     error: unexpected keyword `else`
 
   - note: no-query
+    num_expressions: 5
+    num_statements: 2
+    num_queries: 2
     rego: |
       package test
 
@@ -26,21 +29,29 @@ cases:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 2
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        false
+                        bool: false
+                        eidx: 3
+                    sidx: 0
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 4
+                    sidx: 1
 
   - note: no-else
     rego: |
@@ -51,27 +62,38 @@ cases:
       } {
         true
       }
+    num_expressions: 5
+    num_statements: 2
+    num_queries: 2
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 2
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        false
+                        bool: false
+                        eidx: 3
+                    sidx: 0
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 4
+                    sidx: 1
 
   - note: if-no-else
     rego: |
@@ -83,27 +105,38 @@ cases:
       } {
         true
       }
+    num_expressions: 8
+    num_statements: 2
+    num_queries: 2
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 4
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 5
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        false
+                        bool: false
+                        eidx: 6
+                    sidx: 0
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 7
+                    sidx: 1
 
   - note: rule-named-if
     rego: |
@@ -114,33 +147,45 @@ cases:
       } {
         true
       }
+    num_expressions: 6
+    num_statements: 2
+    num_queries: 2
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 2
           bodies: []
       - spec:
           head:
             compr:
               refr:
                 var: if
+                eidx: 3
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        false
+                        bool: false
+                        eidx: 4
+                    sidx: 0
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                         true
+                         bool: true
+                         eidx: 5
+                    sidx: 1
 
   - note: query-else
     rego: |
@@ -151,27 +196,38 @@ cases:
       } else {
         true
       }
+    num_expressions: 5
+    num_queries: 2
+    num_statements: 2
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 1
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 2
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        false
+                        bool: false
+                        eidx: 3
+                    sidx: 0
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 4
+                    sidx: 1
 
   - note: if-literal-else
     rego: |
@@ -181,18 +237,24 @@ cases:
       x = 10 if 1 < 0 else {
         true
       }
+    num_expressions: 10
+    num_statements: 2
+    num_queries: 2
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 4
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 5
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
@@ -200,13 +262,20 @@ cases:
                           op: "<"
                           lhs:
                             number: 1
+                            eidx: 6
                           rhs:
                             number: 0
+                            eidx: 7
+                        eidx: 8
+                    sidx: 0
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 9
+                    sidx: 1
 
   - note: if-literal-else-assign
     rego: |
@@ -217,18 +286,24 @@ cases:
       x = 10 if 1 < 0 else := 20 {
         true
       }
+    num_expressions: 11
+    num_statements: 2
+    num_queries: 2
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x
+                eidx: 4
               assign:
                 op: "="
                 value:
                   number: 10
+                  eidx: 5
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
@@ -236,17 +311,25 @@ cases:
                           op: "<"
                           lhs:
                             number: 1
+                            eidx: 6
                           rhs:
                             number: 0
+                            eidx: 7
+                        eidx: 8
+                    sidx: 0
             - assign:
                 op: ":="
                 value:
                   number: 20
+                  eidx: 9
               query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 10
+                    sidx: 1
 
   - note: contains-else-error
     rego: |

--- a/tests/parser/cases/rules/set.yaml
+++ b/tests/parser/cases/rules/set.yaml
@@ -8,6 +8,9 @@ cases:
       import future.keywords
 
       deny.a contains  0, "bar" in ["bar1"] if true
+    num_expressions: 11
+    num_statements: 1
+    num_queries: 1
     policy:
       - spec:
           head:
@@ -16,27 +19,37 @@ cases:
                 refdot:
                   refr:
                     var: deny
+                    eidx: 3
                   field: a
+                eidx: 4
               key:
                 inexpr:
                   key:
                     number: 0
+                    eidx: 5
                   value:
                     string: bar
+                    eidx: 6
                   collection:
                     array:
                       - string: bar1
+                        eidx: 7
+                    eidx: 8
+                eidx: 9
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 10
+                    sidx: 0
   - note: old-syntax
     rego: |
       package test
       import future.keywords.if
-      
+
       # The following are not sets
       x1 if true
       x2 { true }
@@ -48,31 +61,41 @@ cases:
       # The following are not sets
       z.a if { true }
       z["b"] if { true }
-      
+    num_expressions: 21
+    num_statements: 6
+    num_queries: 6
     policy:
       - spec:
           head:
             compr:
               refr:
                 var: x1
+                eidx: 4
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 5
+                    sidx: 0
       - spec:
           head:
             compr:
               refr:
                 var: x2
+                eidx: 6
           bodies:
             - query:
+                qidx: 1
                 stmts:
                   - literal:
                       expr:
-                        true
-                    
+                        bool: true
+                        eidx: 7
+                    sidx: 1
+
       - spec:
           head:
             set:
@@ -80,27 +103,37 @@ cases:
                 refdot:
                   refr:
                     var: y
+                    eidx: 8
                   field: a
+                eidx: 9
           bodies:
             - query:
+                qidx: 2
                 stmts:
                   - literal:
                       expr:
-                        true
-                        
+                        bool: true
+                        eidx: 10
+                    sidx: 2
+
       - spec:
           head:
             set:
               refr:
                   var: y
+                  eidx: 11
               key:
                 string: b
+                eidx: 12
           bodies:
             - query:
+                qidx: 3
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 13
+                    sidx: 3
 
       - spec:
           head:
@@ -109,13 +142,18 @@ cases:
                 refdot:
                   refr:
                     var: z
+                    eidx: 14
                   field: a
+                eidx: 15
           bodies:
             - query:
+                qidx: 4
                 stmts:
                   - literal:
                       expr:
-                        true
+                        bool: true
+                        eidx: 16
+                    sidx: 4
 
       - spec:
           head:
@@ -124,12 +162,17 @@ cases:
                 refbrack:
                   refr:
                     var: z
+                    eidx: 17
                   index:
                     string: b
+                    eidx: 18
+                eidx: 19
           bodies:
             - query:
+                qidx: 5
                 stmts:
                   - literal:
                       expr:
-                        true
-                        
+                        bool: true
+                        eidx: 20
+                    sidx: 5

--- a/tests/parser/cases/some/some.in.yaml
+++ b/tests/parser/cases/some/some.in.yaml
@@ -24,68 +24,97 @@ cases:
              some a, b in d
           }
       }
-
+    num_expressions: 25
+    num_statements: 6
+    num_queries: 2
     policy:
       - spec:
           head: --skip--
           bodies:
             - query:
+                qidx: 1
                 stmts:
                   - span: some a in {1}
+                    sidx: 0
                     literal:
                       some-decl:
                         value:
                           var: a
+                          eidx: 6
                         collection:
                           set:
                             - number: 1
+                              eidx: 7
+                          eidx: 8
                   - span: "some a\n    , b in r"
+                    sidx: 1
                     literal:
                       some-decl:
                         key:
                           var: a
+                          eidx: 9
                         value:
                           var: b
+                          eidx: 10
                         collection:
                           var: r
+                          eidx: 11
                   - span: "some 5, x in array"
+                    sidx: 2
                     literal:
                       some-decl:
                         key:
                           number: 5
+                          eidx: 12
                         value:
                           var: x
+                          eidx: 13
                         collection:
                           var: array
+                          eidx: 14
                   - span: "some \"hello\", \"world\" in map"
+                    sidx: 3
                     literal:
                       some-decl:
                         key:
                           string: hello
+                          eidx: 15
                         value:
                           string: world
+                          eidx: 16
                         collection:
                           var: map
-                  - literal:
+                          eidx: 17
+                  - sidx: 5
+                    literal:
                       some-decl:
                         key:
                           var: p
+                          eidx: 18
                         value:
                           var: q
+                          eidx: 19
                         collection:
                           setcompr:
                             term:
                               var: r
+                              eidx: 20
                             query:
+                              qidx: 0
                               stmts:
                                 - literal:
                                     some-decl:
                                       key:
                                         var: a
+                                        eidx: 21
                                       value:
                                         var: b
+                                        eidx: 22
                                       collection:
                                         var: d
+                                        eidx: 23
+                                  sidx: 4
+                          eidx: 24
 
 
   - note: unimported-in
@@ -156,6 +185,9 @@ cases:
           [1, 2, 3][a] == 3
           y = a
       }
+    num_expressions: 24
+    num_statements: 4
+    num_queries: 1
     policy:
       - spec:
           head:
@@ -163,10 +195,12 @@ cases:
               span: b := 5
               refr:
                 var: b
+                eidx: 4
               assign:
                 op: :=
                 value:
                   number: 5
+                  eidx: 5
           bodies: []
       - spec:
           head:
@@ -174,28 +208,38 @@ cases:
               span: x = y
               refr:
                 var: x
+                eidx: 6
               assign:
                 op: =
                 value:
                   var: y
+                  eidx: 7
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - literal:
                       some-vars:
                         span: some a
                         vars:
                           - a
+                    sidx: 0
                   - literal:
                       expr:
                         inexpr:
                           span: b in {4, 5}
                           value:
                             var: b
+                            eidx: 8
                           collection:
                             set:
                             - number: 4
+                              eidx: 9
                             - number: 5
+                              eidx: 10
+                            eidx: 11
+                        eidx: 12
+                    sidx: 1
                   - literal:
                       expr:
                         boolexpr:
@@ -207,12 +251,21 @@ cases:
                               refr:
                                 array:
                                   - number: 1
+                                    eidx: 13
                                   - number: 2
+                                    eidx: 14
                                   - number: 3
+                                    eidx: 15
+                                eidx: 16
                               index:
                                 var: a
+                                eidx: 17
+                            eidx: 18
                           rhs:
                             number: 3
+                            eidx: 19
+                        eidx: 20
+                    sidx: 2
                   - literal:
                       expr:
                         assignexpr:
@@ -220,5 +273,9 @@ cases:
                           op: =
                           lhs:
                             var: y
+                            eidx: 21
                           rhs:
                             var: a
+                            eidx: 22
+                        eidx: 23
+                    sidx: 3

--- a/tests/parser/cases/some/some.vars.yaml
+++ b/tests/parser/cases/some/some.vars.yaml
@@ -13,11 +13,15 @@ cases:
          d,e,
          f
       }
+    num_expressions: 3
+    num_statements: 2
+    num_queries: 1
     policy:
       - spec:
           head: --skip--
           bodies:
             - query:
+                qidx: 0
                 stmts:
                   - span: some a
                     literal:
@@ -25,11 +29,13 @@ cases:
                         span: some a
                         vars:
                           - a
+                    sidx: 0
                   - span: "some\n   d,e,\n   f"
                     literal:
                       some-vars:
                         span: "some\n   d,e,\n   f"
                         vars: [d, e, f]
+                    sidx: 1
 
   - note: same-line-error
     rego: |
@@ -58,7 +64,7 @@ cases:
       package test
       some y
     error: unexpected keyword `some`
-    
+
   - note: some-in-set
     rego: |
       package test


### PR DESCRIPTION
Indexes allow associating extra data with nodes in the AST
using an array and then quickly looking up the array to fetch
the extra data.

- Index eidx for expressions
- Index sidx for statements
- Index qidx for queries.

AST nodes are not cloneable. Therefore once a module is created,
it is not possible to accidentally create two nodes with the same
index inadvertently via clone.

Also added IndexChecker in debug builds. When a module is parsed,
 it will assert that indexes have been constructed correctly.

 AST Cleanup
- Make literal expressions (null, val, number, string etc) also structs
   to match all other expressions
- Merge True and False nodes into a single Bool node.

Also update dependencies.