### PR TITLE
Implement methods to extract the package name and parameters defined within a policy from the engine

### DIFF
--- a/.github/workflows/test-csharp.yml
+++ b/.github/workflows/test-csharp.yml
@@ -1,6 +1,7 @@
 name: bindings/csharp
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:
@@ -62,6 +63,10 @@ jobs:
           global-json-file: ./bindings/csharp/global.json
 
       - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
+
+      - name: Set VersionSuffix environment variable
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "VersionSuffix=manualtrigger" >> $GITHUB_ENV
 
       - name: Download regorus ffi shared libraries
         uses: actions/download-artifact@v4

--- a/bindings/csharp/Regorus/Regorus.cs
+++ b/bindings/csharp/Regorus/Regorus.cs
@@ -217,6 +217,16 @@ namespace Regorus
             return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_ast_as_json(E));
         }
 
+        public string? GetPolicyPackageNames()
+        {
+            return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_policy_package_names(E));
+        }
+
+        public string? GetPolicyParameters()
+        {
+            return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_policy_parameters(E));
+        }
+
         string? StringFromUTF8(IntPtr ptr)
         {
 

--- a/bindings/csharp/Regorus/RegorusFFI.cs
+++ b/bindings/csharp/Regorus/RegorusFFI.cs
@@ -194,6 +194,22 @@ namespace Regorus.Internal
         internal static extern RegorusResult regorus_engine_get_ast_as_json(RegorusEngine* engine);
 
         /// <summary>
+        ///  Gets the package names of policies added to the engine.
+        ///
+        ///  See https://docs.rs/regorus/latest/regorus/coverage/struct.Engine.html#method.get_policy_package_names
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "regorus_engine_get_policy_package_names", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusResult regorus_engine_get_policy_package_names(RegorusEngine* engine);
+
+        /// <summary>
+        ///  Gets the parameters defined in each policy added to the engine
+        ///
+        ///  See https://docs.rs/regorus/latest/regorus/coverage/struct.Engine.html#method.get_policy_parameters
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "regorus_engine_get_policy_parameters", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusResult regorus_engine_get_policy_parameters(RegorusEngine* engine);
+
+        /// <summary>
         ///  Enable/disable rego v1.
         ///
         ///  See https://docs.rs/regorus/latest/regorus/struct.Engine.html#method.set_rego_v0

--- a/bindings/csharp/global.json
+++ b/bindings/csharp/global.json
@@ -4,7 +4,7 @@
     },
     "sdk": {
       "allowPrerelease": false,
-      "version": "8.0.408",
+      "version": "8.0.411",
       "rollForward": "disable"
     }
 }

--- a/bindings/ffi/src/lib.rs
+++ b/bindings/ffi/src/lib.rs
@@ -457,6 +457,40 @@ pub extern "C" fn regorus_engine_get_ast_as_json(engine: *mut RegorusEngine) -> 
     }
 }
 
+/// Gets the package names defined in each policy added to the engine.
+///
+/// See https://docs.rs/regorus/latest/regorus/coverage/struct.Engine.html#method.get_policy_package_names
+#[no_mangle]
+#[cfg(feature = "ast")]
+pub extern "C" fn regorus_engine_get_policy_package_names(engine: *mut RegorusEngine) -> RegorusResult {
+    let output = || -> Result<String> { to_ref(&engine)?.engine.get_policy_package_names() }();
+    match output {
+        Ok(out) => RegorusResult {
+            status: RegorusStatus::RegorusStatusOk,
+            output: to_c_str(out),
+            error_message: std::ptr::null_mut(),
+        },
+        Err(e) => to_regorus_result(Err(e)),
+    }
+}
+
+/// Gets the parameters defined in each policy added to the engine.
+///
+/// See https://docs.rs/regorus/latest/regorus/coverage/struct.Engine.html#method.get_policy_parameters
+#[no_mangle]
+#[cfg(feature = "ast")]
+pub extern "C" fn regorus_engine_get_policy_parameters(engine: *mut RegorusEngine) -> RegorusResult {
+    let output = || -> Result<String> { to_ref(&engine)?.engine.get_policy_parameters() }();
+    match output {
+        Ok(out) => RegorusResult {
+            status: RegorusStatus::RegorusStatusOk,
+            output: to_c_str(out),
+            error_message: std::ptr::null_mut(),
+        },
+        Err(e) => to_regorus_result(Err(e)),
+    }
+}
+
 /// Enable/disable rego v1.
 ///
 /// See https://docs.rs/regorus/latest/regorus/struct.Engine.html#method.set_rego_v0


### PR DESCRIPTION
This PR adds methods to the Regorus engine to extract package names and parameters defined within policies that have been added to the engine.

Parameters are defined as any default rule that is prefixed with "parameters" and only contains one segment following that.

Ex.
default parameters.myParameter := 5    => is a parameter
default parameters.myParameter.nested := 5     => is not a parameter
default parameters := {'myParameter': 5}    => is not a parameter