### PR TITLE
fix: Tweak release-plz config to handle dirty files.

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,9 +2,22 @@
 git_release_enable = false
 git_tag_enable = false
 changelog_update = false
+dependencies_update = false
+publish = false
+
+# These files show up as modified (dirty) to release-plz:
+#     bindings/ruby/bin/console
+#     bindings/ruby/bin/setup
+# As a result, release-plz fails during update.
+# As a workaround, allow dirty workding directory.
+allow_dirty = true
+# But don't allow release-plz to publish dirty packages.
+publish_allow_dirty = false
+
 
 [[package]]
 name = "regorus"
 git_tag_enable = true
 git_release_enable = true
 changelog_update = true
+publish = true


### PR DESCRIPTION
bindings/ruby/bin/console and bindings/ruby/bin/setup show up as dirty to release-plz and causes it to fail to update.

As a workaround, set allow_dirty to true to enable update. However ensure that no dirty files are published by setting publish_allow_dirty to false.

Also default to not publishing any packages except regorus.