### PR TITLE
feat: add json patch support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonschema"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1212,7 @@ dependencies = [
  "criterion",
  "data-encoding",
  "globset",
+ "json-patch",
  "jsonschema",
  "lazy_static",
  "msvc_spectre_libs",
@@ -1384,6 +1407,26 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ http = []
 glob = ["dep:globset"]
 graph = []
 jsonschema = ["dep:jsonschema"]
+jsonpatch = ["dep:json-patch"]
 no_std = ["lazy_static/spin_no_std"]
 opa-runtime = []
 regex = ["dep:regex"]
@@ -49,6 +50,7 @@ full-opa = [
     "hex",
     "http",
     "jsonschema",
+    "jsonpatch",
     "opa-runtime",
     "regex",
     "semver",
@@ -100,6 +102,7 @@ semver = {version = "1.0.25", optional = true, default-features = false }
 url = { version = "2.5.4", optional = true }
 uuid = { version = "1.15.1", default-features = false, features = ["v4", "fast-rng"], optional = true }
 jsonschema = { version = "0.30.0", default-features = false, optional = true }
+json-patch = { version = "4.0.0", default-features = false, optional = true }
 chrono = { version = "0.4.40", optional = true }
 chrono-tz = { version = "0.10.1", optional = true }
 

--- a/tests/interpreter/cases/builtins/objects/json.patch.yaml
+++ b/tests/interpreter/cases/builtins/objects/json.patch.yaml
@@ -1,0 +1,212 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: basic add operation
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1}}
+        patches = [{"op": "add", "path": "/a/bar", "value": 2}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        foo: 1
+        bar: 2
+
+  - note: basic remove operation
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1, "bar": 2}}
+        patches = [{"op": "remove", "path": "/a/bar"}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        foo: 1
+
+  - note: basic replace operation
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1}}
+        patches = [{"op": "replace", "path": "/a/foo", "value": 42}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        foo: 42
+
+  - note: basic move operation
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1}, "b": {}}
+        patches = [{"op": "move", "from": "/a/foo", "path": "/b/foo"}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a: {}
+      b:
+        foo: 1
+
+  - note: basic copy operation
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1}, "b": {}}
+        patches = [{"op": "copy", "from": "/a/foo", "path": "/b/foo"}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        foo: 1
+      b:
+        foo: 1
+
+  - note: basic test operation (successful)
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1}}
+        patches = [{"op": "test", "path": "/a/foo", "value": 1}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        foo: 1
+
+  - note: multiple operations
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"foo": 1}}
+        patches = [
+          {"op": "add", "path": "/a/bar", "value": 2},
+          {"op": "replace", "path": "/a/foo", "value": 42}
+        ]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        foo: 42
+        bar: 2
+
+  - note: array operations - add to array
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"arr": [1, 2, 3]}
+        patches = [{"op": "add", "path": "/arr/1", "value": "inserted"}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      arr: [1, "inserted", 2, 3]
+
+  - note: array operations - add to end of array
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"arr": [1, 2, 3]}
+        patches = [{"op": "add", "path": "/arr/-", "value": 4}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      arr: [1, 2, 3, 4]
+
+  - note: array operations - remove from array
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"arr": [1, 2, 3]}
+        patches = [{"op": "remove", "path": "/arr/1"}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      arr: [1, 3]
+
+  - note: nested object operations
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"a": {"b": {"c": {"d": 1}}}}
+        patches = [{"op": "add", "path": "/a/b/c/e", "value": 2}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      a:
+        b:
+          c:
+            d: 1
+            e: 2
+
+  - note: special characters in keys
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"foo/bar": {"baz~": 1}}
+        patches = [{"op": "add", "path": "/foo~1bar/baz~0test", "value": 2}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      "foo/bar":
+        "baz~": 1
+        "baz~test": 2
+
+  - note: empty object and array handling
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {}
+        patches = [{"op": "add", "path": "/newkey", "value": {"nested": []}}]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      newkey:
+        nested: []
+
+  - note: complex value types
+    data: {}
+    modules:
+      - |
+        package test
+
+        obj = {"data": null}
+        patches = [
+          {"op": "replace", "path": "/data", "value": {"bool": true, "num": 3.14, "str": "hello"}}
+        ]
+        result = json.patch(obj, patches)
+    query: data.test.result
+    want_result:
+      data:
+        bool: true
+        num: 3.14
+        str: "hello"


### PR DESCRIPTION
## Add json.patch builtin support

Fixes: #95 

Implements the `json.patch` builtin function according to the [OPA specification](https://www.openpolicyagent.org/docs/policy-reference/builtins/object#builtin-object-jsonpatch), enabling RFC6902 JSON Patch operations on objects.

### Changes

- **Added dependency**: `json-patch` crate v4.0.0 with optional `jsonpatch` feature
- **New builtin**: `json.patch(object, patches)` function that applies JSON Patch operations atomically
- **Comprehensive tests**: Added test cases covering all patch operations (add, remove, replace, move, copy, test)

### Features

- Supports all RFC6902 patch operations
- Atomic application - if any patch fails, result is undefined
- Works with nested objects, arrays, and special characters in keys
- Proper error handling in both strict and non-strict modes

### Usage

```rego
# Add a new field
json.patch({"a": {"foo": 1}}, [{"op": "add", "path": "/a/bar", "value": 2}])
# Result: {"a": {"foo": 1, "bar": 2}}

# Multiple operations
json.patch(obj, [
  {"op": "add", "path": "/a/bar", "value": 2},
  {"op": "replace", "path": "/a/foo", "value": 42}
])