### PR TITLE
Fix install of regorus_ffi C++ bindings

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -75,7 +75,7 @@ configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/regorus_ffiConfig.cmake.
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/regorus_ffiConfig.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/corrosion/regorus_ffiCorrosion.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/corrosion/regorus_ffi_targetsCorrosion.cmake
   DESTINATION ${regorus_ffi_CONFIGDIR}
 )
 

--- a/bindings/cpp/regorus_ffiConfig.cmake.in
+++ b/bindings/cpp/regorus_ffiConfig.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
 include("${CMAKE_CURRENT_LIST_DIR}/regorus_ffi_targets.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/regorus_ffiCorrosion.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/regorus_ffi_targetsCorrosion.cmake")


### PR DESCRIPTION
When using a clean build dir the install failed as it referenced a non-existing `regorus_ffiCorrosion.cmake` file. I believe I used the shorter `regorus_ffi` as my `EXPORT` in the `corrosion_install` at some point and then later didn't notice that I referenced a stale generated file when I initially handed in this PR. We must make sure that the same identifier is used here too. See also the documentation from `corrosion_install`:

> * **EXPORT**: Creates an export that can be installed with `install(EXPORT)`. <export-name> must be globally unique.
>             Also creates a file at ${CMAKE_BINARY_DIR}/corrosion/<export-name>Corrosion.cmake that must be included in the installed config file.