### PR TITLE
build: Run format and clippy during C# binding build

### DIFF
--- a/.github/workflows/test-csharp.yml
+++ b/.github/workflows/test-csharp.yml
@@ -41,6 +41,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      
+      - name: Fetch crates
+        run: cargo fetch
+        working-directory: ./bindings/ffi
+
+      - name: Check Regorus binding formatting
+        run: cargo fmt --check
+        working-directory: ./bindings/ffi
+
+      - name: Check Clippy linting for Regorus binding
+        run: cargo clippy --frozen -- -D warnings
+        working-directory: ./bindings/ffi
 
       - name: Build Regorus binding
         run: cargo build -r --target ${{ matrix.runtime.target }} --locked

--- a/bindings/ffi/src/lib.rs
+++ b/bindings/ffi/src/lib.rs
@@ -462,8 +462,13 @@ pub extern "C" fn regorus_engine_get_ast_as_json(engine: *mut RegorusEngine) -> 
 /// See https://docs.rs/regorus/latest/regorus/coverage/struct.Engine.html#method.get_policy_package_names
 #[no_mangle]
 #[cfg(feature = "azure_policy")]
-pub extern "C" fn regorus_engine_get_policy_package_names(engine: *mut RegorusEngine) -> RegorusResult {
-    let output = || -> Result<String> { serde_json::to_string_pretty(&to_ref(engine)?.engine.get_policy_package_names()?).map_err(anyhow::Error::msg) }();
+pub extern "C" fn regorus_engine_get_policy_package_names(
+    engine: *mut RegorusEngine,
+) -> RegorusResult {
+    let output = || -> Result<String> {
+        serde_json::to_string_pretty(&to_ref(engine)?.engine.get_policy_package_names()?)
+            .map_err(anyhow::Error::msg)
+    }();
     match output {
         Ok(out) => RegorusResult {
             status: RegorusStatus::RegorusStatusOk,
@@ -479,8 +484,13 @@ pub extern "C" fn regorus_engine_get_policy_package_names(engine: *mut RegorusEn
 /// See https://docs.rs/regorus/latest/regorus/coverage/struct.Engine.html#method.get_policy_parameters
 #[no_mangle]
 #[cfg(feature = "azure_policy")]
-pub extern "C" fn regorus_engine_get_policy_parameters(engine: *mut RegorusEngine) -> RegorusResult {
-    let output = || -> Result<String> { serde_json::to_string_pretty(&to_ref(engine)?.engine.get_policy_parameters()?).map_err(anyhow::Error::msg) }();
+pub extern "C" fn regorus_engine_get_policy_parameters(
+    engine: *mut RegorusEngine,
+) -> RegorusResult {
+    let output = || -> Result<String> {
+        serde_json::to_string_pretty(&to_ref(engine)?.engine.get_policy_parameters()?)
+            .map_err(anyhow::Error::msg)
+    }();
     match output {
         Ok(out) => RegorusResult {
             status: RegorusStatus::RegorusStatusOk,


### PR DESCRIPTION
Run format and clippy during C# binding build action. This ensures PR builds will fail if these tools haven't been run.