### PR TITLE
feat: Implement efficient node lookup table using node indices

### DIFF
--- a/src/interpreter/loops.rs
+++ b/src/interpreter/loops.rs
@@ -1,0 +1,204 @@
+use crate::ast::*;
+use crate::interpreter::Interpreter;
+use crate::lexer::*;
+use crate::scheduler::traverse;
+use crate::utils::get_path_string;
+use crate::value::Value;
+use crate::*;
+
+#[derive(Debug)]
+pub enum LoopExpr {
+    Loop {
+        span: Span,
+        expr: Ref<Expr>,
+        value: Ref<Expr>,
+        index: Ref<Expr>,
+    },
+    Walk {
+        span: Span,
+        expr: Ref<Expr>,
+    },
+}
+
+impl LoopExpr {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Loop { span, .. } => span.clone(),
+            Self::Walk { span, .. } => span.clone(),
+        }
+    }
+
+    pub fn value(&self) -> Ref<Expr> {
+        match self {
+            Self::Loop { value, .. } => value.clone(),
+            Self::Walk { expr, .. } => expr.clone(),
+        }
+    }
+
+    pub fn expr(&self) -> Ref<Expr> {
+        match self {
+            Self::Loop { expr, .. } => expr.clone(),
+            Self::Walk { expr, .. } => expr.clone(),
+        }
+    }
+
+    pub fn index(&self) -> Option<Ref<Expr>> {
+        match self {
+            Self::Loop { index, .. } => Some(index.clone()),
+            Self::Walk { .. } => None,
+        }
+    }
+}
+
+impl Interpreter {
+    pub(super) fn hoist_loops_impl(&self, expr: &ExprRef, loops: &mut Vec<LoopExpr>) {
+        use Expr::*;
+        match expr.as_ref() {
+            RefBrack {
+                refr, index, span, ..
+            } => {
+                // First hoist any loops in refr
+                self.hoist_loops_impl(refr, loops);
+
+                // hoist any loops in index expression.
+                self.hoist_loops_impl(index, loops);
+
+                // Then hoist the current bracket operation.
+                let mut indices = Vec::with_capacity(1);
+                let _ = traverse(index, &mut |e| match e.as_ref() {
+                    Var { span: ident, .. } if self.is_loop_index_var(&ident.source_str()) => {
+                        indices.push(ident.source_str());
+                        Ok(false)
+                    }
+                    Array { .. } | Object { .. } => Ok(true),
+                    _ => Ok(false),
+                });
+                if !indices.is_empty() {
+                    loops.push(LoopExpr::Loop {
+                        span: span.clone(),
+                        expr: expr.clone(),
+                        value: refr.clone(),
+                        index: index.clone(),
+                    })
+                }
+            }
+
+            // Primitives
+            String { .. }
+            | RawString { .. }
+            | Number { .. }
+            | Bool { .. }
+            | Null { .. }
+            | Var { .. } => (),
+
+            // Recurse into expressions in other variants.
+            Array { items, .. } | Set { items, .. } | Call { params: items, .. } => {
+                for item in items {
+                    self.hoist_loops_impl(item, loops);
+                }
+
+                // Handle walk builtin which acts as a generator.
+                // TODO: Handle with modifier on the walk builtin.
+                if let Expr::Call { fcn, .. } = expr.as_ref() {
+                    if let Ok(fcn_path) = get_path_string(fcn, None) {
+                        if fcn_path == "walk" {
+                            // TODO: Use an enum for LoopExpr to handle walk
+                            loops.push(LoopExpr::Walk {
+                                span: expr.span().clone(),
+                                expr: expr.clone(),
+                            })
+                        }
+                    }
+                }
+            }
+
+            Object { fields, .. } => {
+                for (_, key, value) in fields {
+                    self.hoist_loops_impl(key, loops);
+                    self.hoist_loops_impl(value, loops);
+                }
+            }
+
+            RefDot { refr: expr, .. } | UnaryExpr { expr, .. } => {
+                self.hoist_loops_impl(expr, loops)
+            }
+
+            BinExpr { lhs, rhs, .. }
+            | BoolExpr { lhs, rhs, .. }
+            | ArithExpr { lhs, rhs, .. }
+            | AssignExpr { lhs, rhs, .. } => {
+                self.hoist_loops_impl(lhs, loops);
+                self.hoist_loops_impl(rhs, loops);
+            }
+
+            #[cfg(feature = "rego-extensions")]
+            OrExpr { lhs, rhs, .. } => {
+                self.hoist_loops_impl(lhs, loops);
+                self.hoist_loops_impl(rhs, loops);
+            }
+
+            Membership {
+                key,
+                value,
+                collection,
+                ..
+            } => {
+                if let Some(key) = key.as_ref() {
+                    self.hoist_loops_impl(key, loops);
+                }
+                self.hoist_loops_impl(value, loops);
+                self.hoist_loops_impl(collection, loops);
+            }
+
+            // The output expressions of comprehensions must be subject to hoisting
+            // only after evaluating the body of the comprehensions since the output
+            // expressions may depend on variables defined within the body.
+            ArrayCompr { .. } | SetCompr { .. } | ObjectCompr { .. } => (),
+        }
+    }
+
+    pub(super) fn hoist_loops(&self, literal: &Literal) -> Vec<LoopExpr> {
+        let mut loops = vec![];
+        use Literal::*;
+        match literal {
+            SomeVars { .. } => (),
+            SomeIn {
+                key,
+                value,
+                collection,
+                ..
+            } => {
+                if let Some(key) = key {
+                    self.hoist_loops_impl(key, &mut loops);
+                }
+                self.hoist_loops_impl(value, &mut loops);
+                self.hoist_loops_impl(collection, &mut loops);
+            }
+            Every {
+                domain: collection, ..
+            } => self.hoist_loops_impl(collection, &mut loops),
+            Expr { expr, .. } | NotExpr { expr, .. } => self.hoist_loops_impl(expr, &mut loops),
+        }
+        loops
+    }
+
+    pub(super) fn is_loop_index_var(&self, ident: &SourceStr) -> bool {
+        // TODO: check for vars that are declared using some-vars
+        match ident.text() {
+            "_" => true,
+            _ => match self.lookup_local_var(ident) {
+                // Vars declared using `some v` can be loop vars.
+                // They are initialized to undefined.
+                Some(Value::Undefined) => true,
+                // If ident is a local var (in current or parent scopes),
+                // then it is not a loop var.
+                Some(_) => false,
+                None => {
+                    // Check if ident is a rule.
+                    let path = self.current_module_path.clone() + "." + ident.text();
+                    !self.compiled_policy.rules.contains_key(&path)
+                }
+            },
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod engine;
 mod indexchecker;
 mod interpreter;
 mod lexer;
+mod lookup;
 mod number;
 mod parser;
 mod policy_info;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Lookup table for associating data structures with AST nodes.
+//!
+//! This module provides efficient lookup tables for associating custom data
+//! with expressions, queries, and statements using their respective indices.
+
+use crate::*;
+
+/// Generic lookup table that stores data indexed by module and node indices.
+#[derive(Debug, Clone)]
+pub struct Lookup<T: Clone> {
+    /// Array of slots indexed by node index within each module
+    slots: Vec<Vec<Option<T>>>,
+}
+
+impl<T: Clone> Default for Lookup<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Clone> Lookup<T> {
+    /// Create a new lookup table.
+    pub fn new() -> Self {
+        Self { slots: Vec::new() }
+    }
+
+    /// Ensure the lookup table has capacity for the given module and node index.
+    pub fn ensure_capacity(&mut self, module_idx: u32, node_idx: u32) {
+        let module_idx = module_idx as usize;
+        let node_idx = node_idx as usize;
+
+        // Ensure we have enough modules
+        if self.slots.len() <= module_idx {
+            self.slots.resize(module_idx + 1, Vec::new());
+        }
+
+        // Ensure the module has enough capacity for this node index
+        if self.slots[module_idx].len() <= node_idx {
+            self.slots[module_idx].resize(node_idx + 1, None);
+        }
+    }
+
+    /// Set data using direct indices (bounds assumed to be ensured).
+    pub fn set(&mut self, module_idx: u32, node_idx: u32, value: T) {
+        *self.get_mut(module_idx, node_idx) = Some(value);
+    }
+
+    /// Get data using direct indices (bounds assumed to be ensured).
+    pub fn get(&self, module_idx: u32, node_idx: u32) -> Option<&T> {
+        self.slots[module_idx as usize][node_idx as usize].as_ref()
+    }
+
+    /// Get mutable reference to data using direct indices (bounds assumed to be ensured).
+    pub fn get_mut(&mut self, module_idx: u32, node_idx: u32) -> &mut Option<T> {
+        &mut self.slots[module_idx as usize][node_idx as usize]
+    }
+
+    /// Clear data at the given indices by setting it to None.
+    pub fn clear(&mut self, module_idx: u32, node_idx: u32) {
+        if (module_idx as usize) < self.slots.len()
+            && (node_idx as usize) < self.slots[module_idx as usize].len()
+        {
+            self.slots[module_idx as usize][node_idx as usize] = None;
+        }
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1972,4 +1972,14 @@ impl<'source> Parser<'source> {
         }
         Ok(query)
     }
+
+    pub fn num_expressions(&self) -> u32 {
+        self.eidx
+    }
+    pub fn num_statements(&self) -> u32 {
+        self.sidx
+    }
+    pub fn num_queries(&self) -> u32 {
+        self.qidx
+    }
 }


### PR DESCRIPTION
Major Changes:
- Add generic Lookup<T> structure for efficient O(1) module-level data access
- Combine separate scope and order lookups into unified QuerySchedule structure
- Add query_schedule field to Interpreter for dedicated user query scheduling
- Refactor loop hoising to separate module
- Use efficient lookup for loop vars
- Added more tests for loops

Key Concept:
- Ensure module context and indexing stay synchronized during function calls

Testing:
- All scheduler and interpreter tests passing
- 
Signed-off-by: Anand Krishnamoorthi <anakrish@microsoft.com>