### PR TITLE
Use `license` to specify MIT license instead of `license-file` in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "regorus"
 description = "A fast, lightweight Rego (OPA policy language) interpreter"
 version = "0.5.0"
 edition = "2021"
-license-file = "LICENSE"
+license = "MIT"
 repository = "https://github.com/microsoft/regorus"
 keywords = ["interpreter", "no_std", "opa", "policy-as-code", "rego"]
 


### PR DESCRIPTION
Since Regorus is MIT-licensed, it would be better to specify `license = "MIT"` rather than using `licene-file` to point to the MIT license file. Some tools don't support parsing of `license-file`, for example crates.io classifies Regorus' license as "non-standard":

     $ curl -s https://crates.io/api/v1/crates/regorus/0.4.0 | jq .version.license
     "non-standard"

Using `license` would provide better compatibility with various tools.


---

There was a previous discussion regarding using multiple-licenses: https://github.com/microsoft/regorus/pull/105/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R6, @anakrish would be happy to hear your thoughts on whether using `license` would be better here or if you still prefer keeping `license-file`.