### PR TITLE
Update release-plz GitHub workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,6 +10,8 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/tests/ensure_no_std/Cargo.toml
+++ b/tests/ensure_no_std/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ensure_no_std"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Disable publishing for `ensure_no_std` test crate
- Add write content permissions to release-plz job explicitly, seems like the whole workflow has write permissions but [the template](https://release-plz.dev/docs/github/quickstart#3-setup-the-workflow) from release-plz also added for the job as well. So, that might fix the permission problem. If not, I think https://release-plz.dev/docs/github/quickstart#1-change-github-actions-permissions needs to be followed again to ensure everything is set up correctly

