### PR TITLE
Fix engine reuse with 'with input.x as y' statement

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -316,7 +316,11 @@ impl Interpreter {
     }
 
     pub fn set_input(&mut self, input: Value) {
-        self.input = input;
+        self.input = input.clone();
+        // Update with_document["input"] too, in case if engine is being reused and was already prepared
+        if let Ok(with_input) = Self::make_or_get_value_mut(&mut self.with_document, &["input"]) {
+            *with_input = input;
+        }
     }
 
     pub fn init_with_document(&mut self) -> Result<()> {


### PR DESCRIPTION
This fix is suppose to solve the following issue

Consider the policy which has some 'with input.a as b' statement, if we try to reuse engine with this policy several times but with different input we will have an issue that during second evaluation with new input after interpreting 'with' statement we will overwrite input with input values from first evaluation. The reason is that `self.with_document['input']` is used in interpretation of 'with' statement and it isn't updated in set_input and it isn't cleaned before second evaluation (because it was already prepared), in a result it keep input from first evaluation and each time policy does 'with as' it overwrite its full input.

I am not sure that this is the best way to fix it, it seems to me that it is better to remove 'input' from self.with_document and use only self.input where needed, so we keep it only in one place and also 'input' doesn't seems to be conceptually part of a document. But I just wanted to highlight the issue and provide the minimal fix. 

