### PR TITLE
feat!: Introduce structured destructuring plans for bindings

### DIFF
--- a/docs/destructuring.md
+++ b/docs/destructuring.md
@@ -1,0 +1,260 @@
+# Destructuring Planner
+
+The destructuring planner pre-computes how Rego assignments, function parameters, loop indices, and `some ... in` expressions bind variables. By materializing explicit plans during compilation, the interpreter can execute complex binding patterns without re-inspecting the abstract syntax tree (AST) each time an expression runs.
+
+```
++--------------+      +----------------------------+      +-------------------+
+| AST walker   | ---> | Destructuring planner core | ---> | BindingPlans table |
++--------------+      +----------------------------+      +-------------------+
+        |                        |   ^                              |
+        |                        v   |                              v
+        |                +------------------+            +-------------------+
+        |                | ScopeContext     | <--------> | Planner utilities |
+        |                +------------------+            +-------------------+
+        v
++------------------+
+| Scheduler output |
++------------------+
+
+Downstream compiler passes reuse the same plans:
+
+```
+BindingPlans table
+  |
+  +--> Rego VM compiler (RVM) for bytecode emission
+  +--> Type propagation pass
+  +--> Constant folding and other analyzers
+```
+```
+
+## Planner building blocks
+
+### Scope awareness
+
+The planner relies on `ScopeContext` implementations to answer two questions for every variable candidate:
+
+| Question                                   | Method                         | Why it matters                                                         |
+| :----------------------------------------- | :----------------------------- | :--------------------------------------------------------------------- |
+| "Is this name currently unbound?"         | `is_var_unbound(var, scoping)` | Determines whether a symbol becomes a new binding or should be treated as an equality check. |
+| "Has this scope already introduced the name?" | `has_same_scope_binding(var)` | Blocks same-scope rebinding for `:=` while still permitting shadowing in child scopes. |
+
+The planner uses two scoping modes:
+
+| Scoping mode    | Description                                                                 | Used by                                                     |
+| :-------------- | :-------------------------------------------------------------------------- | :---------------------------------------------------------- |
+| `RespectParent` | Honors existing bindings. Only treats names that are not yet visible as new bindings. | `=` comparisons, loop indices, `some ... in` value/key plans. |
+| `AllowShadowing` | Allows new bindings even if the name is defined in an ancestor scope.       | Function parameters, `:=` LHS, `some ... in` overlay contexts. |
+
+### Plan families
+
+Three layers of plan types describe the complete binding strategy.
+
+#### `DestructuringPlan`
+
+| Variant                               | Purpose                                            | Notes on bindings                                               |
+| :------------------------------------- | :------------------------------------------------- | :-------------------------------------------------------------- |
+| `Var(span)`                            | Bind the complete value to the variable at `span`. | Adds the variable to the current scope.                         |
+| `Ignore`                               | Consume a wildcard (`_`).                          | No bindings emitted.                                            |
+| `EqualityExpr(expr)`                   | Require runtime equality with a dynamic expression. | Used when a candidate variable is already bound.                |
+| `EqualityValue(value)`                 | Require equality with a literal known at compile time. | Enables static structural checks.                               |
+| `Array { element_plans }`              | Destructure arrays element-by-element.             | Recursively nests `DestructuringPlan` values.                   |
+| `Object { field_plans, dynamic_fields }` | Destructure objects. Literal keys use `field_plans`; dynamic keys appear in `dynamic_fields`. | Ensures literal shape compatibility during planning. |
+
+#### `AssignmentPlan`
+
+| Variant           | Triggers                    | Binding behavior                                                                 |
+| :--------------- | :-------------------------- | :-------------------------------------------------------------------------------- |
+| `ColonEquals`     | `:=`                        | Only LHS may introduce bindings; RHS must match structure/literals. Same-scope rebinding raises an error. |
+| `EqualsBindLeft`  | `=` where LHS has free vars | Binds the LHS pattern after structural + literal checks.                          |
+| `EqualsBindRight` | `=` where RHS has free vars | Symmetric to `EqualsBindLeft`.                                                    |
+| `EqualsBothSides` | `=` where both sides have free vars | Flattens matching sub-expressions into `(value_expr, plan)` pairs and orders them using dependency analysis. |
+| `EqualityCheck`   | `=` with no free vars       | Pure equality comparison.                                                         |
+| `WildcardMatch`   | `=` when either side is `_` | Short-circuits to avoid materializing a plan.                                     |
+
+#### `BindingPlan`
+
+| Variant      | Created by                          | Typical consumers                                   |
+| :----------- | :---------------------------------- | :-------------------------------------------------- |
+| `Assignment` | `create_assignment_binding_plan`    | Rule bodies for `:=` and `=`.                       |
+| `LoopIndex`  | `create_loop_index_binding_plan`    | Hoisted loops and comprehensions.                   |
+| `Parameter`  | `create_parameter_binding_plan`     | Functions and rule heads.                           |
+| `SomeIn`     | `create_some_in_binding_plan`       | `some key, value in collection` statements.         |
+
+## Planner workflow
+
+1. **Entry point selection** — The compiler pass decides which helper to call based on the AST node (assignment, comprehension, function parameter, etc.).
+2. **Pattern inspection** — `create_destructuring_plan` walks the candidate pattern and records which names would become new bindings under the selected scoping rules.
+3. **Conflict detection** — The planner asks the context for same-scope bindings and raises `VariableAlreadyDefined` when a duplicate `:=` appears in the same block.
+4. **Structural validation** — Helpers such as `ensure_structural_compatibility` and `ensure_literal_match` verify that literal shapes are consistent.
+5. **Plan assembly** — The resulting `DestructuringPlan`, `AssignmentPlan`, or higher-level `BindingPlan` is stored in the binding lookup table for quick interpreter access.
+
+### Example flow
+
+```
+[Rule body] -- := --> [create_assignment_binding_plan]
+                         |
+                         v
+                [create_destructuring_plan]
+                         |
+                  +------v--------------+
+                  | ScopeContext checks |
+                  +------+--------------+
+                         |
+             +-----------v-----------+
+             | AssignmentPlan::ColonEquals |
+             +-----------+-----------+
+                         |
+               stores in BindingPlans table
+```
+
+## Worked examples
+
+Each example shows the original Rego snippet, the resulting binding plan, and highlights of the emitted bindings.
+
+### 1. Nested `:=` patterns
+
+```rego
+package test
+
+result := {
+  "outer": outer,
+  "inner": inner,
+  "tag": tag,
+} if {
+  [outer, {"meta": {"inner": inner, "tag": tag}}] := [
+    "alpha",
+    {"meta": {"inner": "omega", "tag": "v1"}},
+  ]
+}
+```
+
+Plan overview:
+
+```
+BindingPlan::Assignment
+└── AssignmentPlan::ColonEquals
+    ├── lhs_expr: array pattern
+    └── lhs_plan: DestructuringPlan::Array
+        ├── [0] -> Var("outer")
+        └── [1] -> DestructuringPlan::Object
+            └── key "meta": DestructuringPlan::Object
+                ├── key "inner": Var("inner")
+                └── key "tag": Var("tag")
+```
+
+| New binding | Source span | Notes |
+| --- | --- | --- |
+| `outer` | LHS array index 0 | New symbol in scope. |
+| `inner` | Object field `meta.inner` | Shares scope with `outer`. |
+| `tag` | Object field `meta.tag` | Must not reappear in same `:=` block. |
+
+### 2. Symmetric `=` binding
+
+```rego
+package test
+
+values := [[left_id, right_id, val] |
+  some left, right, left_id, right_id, val
+  data.transitions[_] = [left, right]
+  [{"id": left_id, "next": {"target": right_id}}, {"id": right_id, "payload": {"value": val}}] = [left, right]
+]
+```
+
+Plan fragments:
+
+```
+BindingPlan::Assignment
+└── AssignmentPlan::EqualsBothSides
+    └── element_pairs (ordered)
+        1. value_expr -> rhs[0]
+           plan -> DestructuringPlan::Object
+                 key "id"   -> Var("left_id")
+                 key "next" -> DestructuringPlan::Object { key "target" -> Var("right_id") }
+        2. value_expr -> rhs[1]
+           plan -> DestructuringPlan::Object
+                 key "id"      -> Var("right_id")
+                 key "payload" -> DestructuringPlan::Object { key "value" -> Var("val") }
+```
+
+Dependency ordering ensures `left_id` is available before `right_id`/`val` comparisons run.
+
+### 3. Function parameter destructuring
+
+```rego
+package test
+
+# f([id, payload]) := payload
+f([id, payload]) := result {
+  result := payload
+}
+```
+
+```
+BindingPlan::Parameter
+└── param_expr: array pattern
+    destructuring_plan:
+      Array
+      ├── [0] -> Var("id")
+      └── [1] -> Var("payload")
+```
+
+Both bindings use `ScopingMode::AllowShadowing`, allowing `id` or `payload` to shadow outer names when the function executes.
+
+### 4. `some ... in` loop
+
+```rego
+package test
+
+some user, record in data.users
+record.role == "admin"
+```
+
+Plan summary:
+
+```
+BindingPlan::SomeIn
+├── collection_expr: data.users
+├── key_plan: DestructuringPlan::Var("user")
+└── value_plan: DestructuringPlan::Var("record")
+```
+
+Tables for bindings:
+
+| Element | Plan | New bindings |
+| --- | --- | --- |
+| `key_plan` | `Var("user")` | Introduces `user` if unbound. |
+| `value_plan` | `Var("record")` | Introduces `record`. |
+
+Literal arrays used in `collection_expr` are checked so the planner can report mismatched element shapes upfront.
+
+### 5. Rebinding error detection
+
+```rego
+package test
+
+flag := true if {
+  value := "initial"
+  value := "shadowed"
+}
+```
+
+```
+BindingPlan::Assignment
+└── AssignmentPlan::ColonEquals (lhs := value)
+```
+
+During planning, the second `:=` consults `has_same_scope_binding("value")` which returns `true`. The planner emits `BindingPlannerError::VariableAlreadyDefined` and compilation reports:
+
+```
+error: var `value` used before definition below
+```
+
+## Interpreter handoff
+
+Planned bindings are stored in the same lookup tables as hoisted loops. At runtime the interpreter:
+
+1. Fetches the `BindingPlan` using `(module_id, expr_idx)`.
+2. Executes the plan, binding or validating values without re-walking the AST.
+3. Falls back to legacy evaluation if a plan is missing (useful for incremental compilation or mixed modules).
+
+This division keeps the hot execution path small while letting the compiler perform aggressive validation and error reporting ahead of time.

--- a/src/builtins/bitwise.rs
+++ b/src/builtins/bitwise.rs
@@ -3,7 +3,7 @@
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;
-use crate::builtins::utils::{ensure_args_count, ensure_numeric};
+use crate::builtins::utils::{ensure_args_count, ensure_numeric, validate_integer_arg};
 
 use crate::lexer::Span;
 use crate::value::Value;
@@ -19,12 +19,18 @@ pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn
     m.insert("bits.xor", (xor, 2));
 }
 
-fn and(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn and(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let name = "bits.and";
     ensure_args_count(span, name, params, args, 2)?;
 
     let v1 = ensure_numeric(name, &params[0], &args[0])?;
     let v2 = ensure_numeric(name, &params[1], &args[1])?;
+
+    if !validate_integer_arg(name, &params[0], &args[0], &v1, strict, true)?
+        || !validate_integer_arg(name, &params[1], &args[1], &v2, strict, true)?
+    {
+        return Ok(Value::Undefined);
+    }
 
     Ok(match v1.and(&v2) {
         Some(v) => Value::from(v),
@@ -32,12 +38,18 @@ fn and(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Resu
     })
 }
 
-fn lsh(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn lsh(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let name = "bits.lsh";
     ensure_args_count(span, name, params, args, 2)?;
 
     let v1 = ensure_numeric(name, &params[0], &args[0])?;
     let v2 = ensure_numeric(name, &params[1], &args[1])?;
+
+    if !validate_integer_arg(name, &params[0], &args[0], &v1, strict, true)?
+        || !validate_integer_arg(name, &params[1], &args[1], &v2, strict, false)?
+    {
+        return Ok(Value::Undefined);
+    }
 
     Ok(match v1.lsh(&v2) {
         Some(v) => Value::from(v),
@@ -45,11 +57,15 @@ fn lsh(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Resu
     })
 }
 
-fn negate(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn negate(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let name = "bits.negate";
     ensure_args_count(span, name, params, args, 1)?;
 
     let v = ensure_numeric(name, &params[0], &args[0])?;
+
+    if !validate_integer_arg(name, &params[0], &args[0], &v, strict, true)? {
+        return Ok(Value::Undefined);
+    }
 
     Ok(match v.neg() {
         Some(v) => Value::from(v),
@@ -57,12 +73,18 @@ fn negate(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> R
     })
 }
 
-fn or(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn or(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let name = "bits.or";
     ensure_args_count(span, name, params, args, 2)?;
 
     let v1 = ensure_numeric(name, &params[0], &args[0])?;
     let v2 = ensure_numeric(name, &params[1], &args[1])?;
+
+    if !validate_integer_arg(name, &params[0], &args[0], &v1, strict, true)?
+        || !validate_integer_arg(name, &params[1], &args[1], &v2, strict, true)?
+    {
+        return Ok(Value::Undefined);
+    }
 
     Ok(match v1.or(&v2) {
         Some(v) => Value::from(v),
@@ -70,12 +92,18 @@ fn or(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Resul
     })
 }
 
-fn rsh(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn rsh(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let name = "bits.rsh";
     ensure_args_count(span, name, params, args, 2)?;
 
     let v1 = ensure_numeric(name, &params[0], &args[0])?;
     let v2 = ensure_numeric(name, &params[1], &args[1])?;
+
+    if !validate_integer_arg(name, &params[0], &args[0], &v1, strict, true)?
+        || !validate_integer_arg(name, &params[1], &args[1], &v2, strict, false)?
+    {
+        return Ok(Value::Undefined);
+    }
 
     Ok(match v1.rsh(&v2) {
         Some(v) => Value::from(v),
@@ -83,12 +111,18 @@ fn rsh(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Resu
     })
 }
 
-fn xor(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+fn xor(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) -> Result<Value> {
     let name = "bits.xor";
     ensure_args_count(span, name, params, args, 2)?;
 
     let v1 = ensure_numeric(name, &params[0], &args[0])?;
     let v2 = ensure_numeric(name, &params[1], &args[1])?;
+
+    if !validate_integer_arg(name, &params[0], &args[0], &v1, strict, true)?
+        || !validate_integer_arg(name, &params[1], &args[1], &v2, strict, true)?
+    {
+        return Ok(Value::Undefined);
+    }
 
     Ok(match v1.xor(&v2) {
         Some(v) => Value::from(v),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -7,4 +7,5 @@
 //! the compilation phase to prepare policies for efficient execution.
 
 pub mod context;
+pub mod destructuring_planner;
 pub mod hoist;

--- a/src/compiler/destructuring_planner/assignment.rs
+++ b/src/compiler/destructuring_planner/assignment.rs
@@ -1,0 +1,401 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Assignment-specific planning utilities.
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::ast::{AssignOp, Expr, ExprRef};
+use crate::compiler::destructuring_planner::create_destructuring_plan;
+use crate::compiler::destructuring_planner::destructuring::create_destructuring_plan_with_tracking;
+use crate::compiler::destructuring_planner::utils::{
+    collect_plan_var_spans, ensure_literal_match, ensure_structural_compatibility,
+    extract_literal_key, format_literal_key_for_error, plan_only_if_binds,
+};
+use crate::compiler::destructuring_planner::{
+    AssignmentPlan, BindingPlan, BindingPlannerError, DestructuringPlan, Result, ScopingMode,
+    VariableBindingContext, WildcardSide,
+};
+use crate::lexer::Span;
+use crate::query::traversal::collect_expr_dependencies;
+use crate::value::Value;
+
+/// Convenience function for assignment expressions with specific := and = rules.
+pub fn create_assignment_binding_plan<T: VariableBindingContext>(
+    op: AssignOp,
+    lhs_expr: &ExprRef,
+    rhs_expr: &ExprRef,
+    context: &T,
+) -> Result<BindingPlan> {
+    let assignment_plan = match op {
+        AssignOp::ColEq => {
+            // For :=, only LHS can be destructured
+            if let Some(lhs_plan) = plan_only_if_binds(create_destructuring_plan(
+                lhs_expr,
+                context,
+                ScopingMode::AllowShadowing,
+            )) {
+                let mut var_spans = Vec::new();
+                collect_plan_var_spans(&lhs_plan, &mut var_spans);
+                let mut lhs_scope_bindings = BTreeSet::new();
+                for span in var_spans {
+                    let name = span.text().to_string();
+                    let is_duplicate = !lhs_scope_bindings.insert(name.clone());
+                    let has_same_scope_binding = context.has_same_scope_binding(&name);
+
+                    if is_duplicate || has_same_scope_binding {
+                        return Err(BindingPlannerError::VariableAlreadyDefined {
+                            var: name,
+                            span,
+                        });
+                    }
+                }
+
+                ensure_structural_compatibility(lhs_expr, rhs_expr)?;
+                ensure_literal_match(&lhs_plan, rhs_expr)?;
+                AssignmentPlan::ColonEquals {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    lhs_plan,
+                }
+            } else {
+                return Err(BindingPlannerError::ColonEqualsRequiresBindableLeft {
+                    span: lhs_expr.span().clone(),
+                });
+            }
+        }
+
+        AssignOp::Eq => {
+            let lhs_struct_plan =
+                create_destructuring_plan(lhs_expr, context, ScopingMode::RespectParent);
+            let rhs_struct_plan =
+                create_destructuring_plan(rhs_expr, context, ScopingMode::RespectParent);
+
+            let lhs_plan = plan_only_if_binds(lhs_struct_plan.clone());
+            let rhs_plan = plan_only_if_binds(rhs_struct_plan.clone());
+
+            let lhs_is_wildcard =
+                matches!(lhs_expr.as_ref(), Expr::Var { span, .. } if span.text() == "_");
+            let rhs_is_wildcard =
+                matches!(rhs_expr.as_ref(), Expr::Var { span, .. } if span.text() == "_");
+
+            if lhs_is_wildcard || rhs_is_wildcard {
+                let wildcard_side = match (lhs_is_wildcard, rhs_is_wildcard) {
+                    (true, true) => WildcardSide::Both,
+                    (true, false) => WildcardSide::Lhs,
+                    (false, true) => WildcardSide::Rhs,
+                    (false, false) => unreachable!(),
+                };
+
+                AssignmentPlan::WildcardMatch {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    wildcard_side,
+                }
+            } else if lhs_plan.is_some() && rhs_plan.is_some() {
+                // Both sides have unbound vars - recursively flatten all nested structures
+                let mut element_pairs = Vec::new();
+                let mut newly_bound = BTreeSet::new();
+                flatten_assignment_pairs(
+                    lhs_expr,
+                    rhs_expr,
+                    context,
+                    &mut newly_bound,
+                    &mut element_pairs,
+                )?;
+                order_element_pairs(&mut element_pairs, context);
+
+                AssignmentPlan::EqualsBothSides {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    element_pairs,
+                }
+            } else if lhs_plan.is_none() && rhs_plan.is_none() {
+                AssignmentPlan::EqualityCheck {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                }
+            } else if let Some(lhs) = lhs_plan {
+                ensure_structural_compatibility(lhs_expr, rhs_expr)?;
+                ensure_literal_match(&lhs, rhs_expr)?;
+
+                AssignmentPlan::EqualsBindLeft {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    lhs_plan: lhs,
+                }
+            } else if let Some(rhs) = rhs_plan {
+                ensure_structural_compatibility(rhs_expr, lhs_expr)?;
+                ensure_literal_match(&rhs, lhs_expr)?;
+
+                AssignmentPlan::EqualsBindRight {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    rhs_plan: rhs,
+                }
+            } else if let Some(lhs) = lhs_struct_plan {
+                ensure_structural_compatibility(lhs_expr, rhs_expr)?;
+                ensure_literal_match(&lhs, rhs_expr)?;
+
+                AssignmentPlan::EqualsBindLeft {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    lhs_plan: lhs,
+                }
+            } else if let Some(rhs) = rhs_struct_plan {
+                ensure_structural_compatibility(rhs_expr, lhs_expr)?;
+                ensure_literal_match(&rhs, lhs_expr)?;
+
+                AssignmentPlan::EqualsBindRight {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                    rhs_plan: rhs,
+                }
+            } else {
+                AssignmentPlan::EqualityCheck {
+                    lhs_expr: lhs_expr.clone(),
+                    rhs_expr: rhs_expr.clone(),
+                }
+            }
+        }
+    };
+
+    Ok(BindingPlan::Assignment {
+        plan: assignment_plan,
+    })
+}
+
+/// Recursively flatten assignment destructuring into (value_expr, pattern_plan) pairs.
+fn flatten_assignment_pairs<T: VariableBindingContext>(
+    lhs_expr: &ExprRef,
+    rhs_expr: &ExprRef,
+    context: &T,
+    newly_bound: &mut BTreeSet<String>,
+    pairs: &mut Vec<(ExprRef, DestructuringPlan)>,
+) -> Result<()> {
+    let (lhs_plan, lhs_delta) =
+        preview_binding_plan(lhs_expr, context, ScopingMode::RespectParent, newly_bound);
+    let (rhs_plan, rhs_delta) =
+        preview_binding_plan(rhs_expr, context, ScopingMode::RespectParent, newly_bound);
+
+    if lhs_plan.is_none() && rhs_plan.is_none() {
+        pairs.push((
+            rhs_expr.clone(),
+            DestructuringPlan::EqualityExpr(lhs_expr.clone()),
+        ));
+        return Ok(());
+    }
+
+    let lhs_is_array = matches!(lhs_expr.as_ref(), Expr::Array { .. });
+    let rhs_is_array = matches!(rhs_expr.as_ref(), Expr::Array { .. });
+    let lhs_is_object = matches!(lhs_expr.as_ref(), Expr::Object { .. });
+    let rhs_is_object = matches!(rhs_expr.as_ref(), Expr::Object { .. });
+
+    if (lhs_is_array && rhs_is_object) || (lhs_is_object && rhs_is_array) {
+        return Err(BindingPlannerError::IncompatibleDestructuringPatterns {
+            span: lhs_expr.span().clone(),
+        });
+    }
+
+    if lhs_is_array && rhs_is_array {
+        for (lhs_item, rhs_item) in collect_array_pairs(lhs_expr, rhs_expr)? {
+            flatten_assignment_pairs(&lhs_item, &rhs_item, context, newly_bound, pairs)?;
+        }
+        return Ok(());
+    }
+
+    if lhs_is_object && rhs_is_object {
+        if let Some(object_pairs) = collect_object_pairs(lhs_expr, rhs_expr)? {
+            for (lhs_value, rhs_value) in object_pairs {
+                flatten_assignment_pairs(&lhs_value, &rhs_value, context, newly_bound, pairs)?;
+            }
+            return Ok(());
+        }
+    }
+
+    match (lhs_plan, rhs_plan, lhs_expr.as_ref(), rhs_expr.as_ref()) {
+        // Case 1: LHS has pattern, RHS is value - add pair
+        (Some(lhs_pattern), None, _, _) => {
+            newly_bound.extend(lhs_delta);
+            pairs.push((rhs_expr.clone(), lhs_pattern));
+        }
+        // Case 2: RHS has pattern, LHS is value - add pair
+        (None, Some(rhs_pattern), _, _) => {
+            newly_bound.extend(rhs_delta);
+            pairs.push((lhs_expr.clone(), rhs_pattern));
+        }
+        // Case 5: Both have patterns but incompatible structures
+        (Some(_), Some(_), _, _) => {
+            return Err(BindingPlannerError::IncompatibleDestructuringPatterns {
+                span: lhs_expr.span().clone(),
+            });
+        }
+        // Remaining cases are handled by earlier match arms and guard
+        (None, None, _, _) => {
+            unreachable!("handled by equality guard above");
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_array_pairs(lhs_expr: &ExprRef, rhs_expr: &ExprRef) -> Result<Vec<(ExprRef, ExprRef)>> {
+    let lhs_items = match lhs_expr.as_ref() {
+        Expr::Array { items, .. } => items,
+        _ => unreachable!(),
+    };
+    let rhs_items = match rhs_expr.as_ref() {
+        Expr::Array { items, .. } => items,
+        _ => unreachable!(),
+    };
+
+    if lhs_items.len() != rhs_items.len() {
+        return Err(BindingPlannerError::ArraySizeMismatch {
+            left_size: lhs_items.len(),
+            right_size: rhs_items.len(),
+            span: lhs_expr.span().clone(),
+        });
+    }
+
+    Ok(lhs_items
+        .iter()
+        .cloned()
+        .zip(rhs_items.iter().cloned())
+        .collect())
+}
+
+fn order_element_pairs<T: VariableBindingContext>(
+    element_pairs: &mut Vec<(ExprRef, DestructuringPlan)>,
+    context: &T,
+) {
+    if element_pairs.len() <= 1 {
+        return;
+    }
+
+    let mut remaining: Vec<_> = element_pairs
+        .drain(..)
+        .map(|(value_expr, plan)| {
+            let binds = plan.bound_vars().into_iter().collect::<BTreeSet<_>>();
+            let deps = collect_expr_dependencies(&value_expr);
+            (value_expr, plan, deps, binds)
+        })
+        .collect();
+
+    if remaining.iter().any(|(_, _, deps, _)| deps.is_none()) {
+        *element_pairs = remaining
+            .into_iter()
+            .map(|(value_expr, plan, _, _)| (value_expr, plan))
+            .collect();
+        return;
+    }
+
+    let mut scheduled = BTreeSet::new();
+    let mut ordered = Vec::with_capacity(remaining.len());
+
+    while !remaining.is_empty() {
+        let mut progress = false;
+
+        for idx in 0..remaining.len() {
+            let (_, _, deps, _) = &remaining[idx];
+            let deps = deps.as_ref().expect("checked above");
+            let ready = deps.iter().all(|var| {
+                scheduled.contains(var) || !context.is_var_unbound(var, ScopingMode::RespectParent)
+            });
+
+            if ready {
+                let (value_expr, plan, _deps, binds) = remaining.remove(idx);
+                scheduled.extend(binds.into_iter());
+                ordered.push((value_expr, plan));
+                progress = true;
+                break;
+            }
+        }
+
+        if !progress {
+            ordered.extend(
+                remaining
+                    .into_iter()
+                    .map(|(value_expr, plan, _, _)| (value_expr, plan)),
+            );
+            break;
+        }
+    }
+
+    *element_pairs = ordered;
+}
+
+fn collect_object_pairs(
+    lhs_expr: &ExprRef,
+    rhs_expr: &ExprRef,
+) -> Result<Option<Vec<(ExprRef, ExprRef)>>> {
+    let lhs_fields = match lhs_expr.as_ref() {
+        Expr::Object { fields, .. } => fields,
+        _ => unreachable!(),
+    };
+    let rhs_fields = match rhs_expr.as_ref() {
+        Expr::Object { fields, .. } => fields,
+        _ => unreachable!(),
+    };
+
+    let mut lhs_map: BTreeMap<Value, ExprRef> = BTreeMap::new();
+    for (_, key_expr, val_expr) in lhs_fields {
+        if let Some(key_value) = extract_literal_key(key_expr) {
+            lhs_map.insert(key_value, val_expr.clone());
+        } else {
+            return Ok(None);
+        }
+    }
+
+    let mut pairs = Vec::with_capacity(lhs_map.len());
+    let mut rhs_literal_count = 0;
+    let mut missing_literal_key: Option<(String, Span)> = None;
+
+    for (_, key_expr, val_expr) in rhs_fields {
+        if let Some(key_value) = extract_literal_key(key_expr) {
+            rhs_literal_count += 1;
+
+            if let Some(lhs_value_expr) = lhs_map.get(&key_value) {
+                pairs.push((lhs_value_expr.clone(), val_expr.clone()));
+            } else if missing_literal_key.is_none() {
+                missing_literal_key = Some((
+                    format_literal_key_for_error(&key_value),
+                    key_expr.span().clone(),
+                ));
+            }
+        } else {
+            return Ok(None);
+        }
+    }
+
+    if rhs_literal_count != lhs_map.len() {
+        return Err(BindingPlannerError::ObjectFieldCountMismatch {
+            left_count: lhs_map.len(),
+            right_count: rhs_literal_count,
+            span: lhs_expr.span().clone(),
+        });
+    }
+
+    if let Some((key, span)) = missing_literal_key {
+        return Err(BindingPlannerError::ObjectKeyNotFound { key, span });
+    }
+
+    Ok(Some(pairs))
+}
+
+fn preview_binding_plan<T: VariableBindingContext>(
+    expr: &ExprRef,
+    context: &T,
+    scoping: ScopingMode,
+    already_bound: &BTreeSet<String>,
+) -> (Option<DestructuringPlan>, BTreeSet<String>) {
+    let mut scratch = already_bound.clone();
+    let plan = create_destructuring_plan_with_tracking(expr, context, scoping, &mut scratch);
+    let mut delta: BTreeSet<String> = scratch.difference(already_bound).cloned().collect();
+    let plan = plan_only_if_binds(plan);
+    if plan.is_none() {
+        delta.clear();
+    }
+    (plan, delta)
+}

--- a/src/compiler/destructuring_planner/context.rs
+++ b/src/compiler/destructuring_planner/context.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Context traits shared across planner submodules.
+
+use alloc::collections::BTreeSet;
+use alloc::string::String;
+
+/// Scoping mode for variable binding decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopingMode {
+    /// Respect existing bindings from parent scopes (normal scoping).
+    RespectParent,
+    /// Allow shadowing of parent scope bindings (local scoping).
+    AllowShadowing,
+}
+
+/// Trait for determining variable binding status within a scope context.
+pub trait VariableBindingContext {
+    /// Check if a variable is unbound in this context.
+    ///
+    /// # Arguments
+    /// * `var_name` - The name of the variable to check
+    /// * `scoping` - Whether to respect parent scopes or allow shadowing
+    fn is_var_unbound(&self, var_name: &str, scoping: ScopingMode) -> bool;
+
+    /// Determine whether the current scope already bound this variable.
+    ///
+    /// This is used to detect same-scope rebinding conflicts when the planner
+    /// encounters `:=` assignments, while still allowing shadowing in nested scopes.
+    fn has_same_scope_binding(&self, var_name: &str) -> bool;
+}
+
+/// Context overlay that tracks newly bound variables on top of an existing context.
+pub(crate) struct OverlayBindingContext<'a, T: VariableBindingContext> {
+    pub(crate) base: &'a T,
+    pub(crate) newly_bound: &'a BTreeSet<String>,
+}
+
+impl<'a, T: VariableBindingContext> VariableBindingContext for OverlayBindingContext<'a, T> {
+    fn is_var_unbound(&self, var_name: &str, scoping: ScopingMode) -> bool {
+        if self.newly_bound.contains(var_name) {
+            return false;
+        }
+
+        self.base.is_var_unbound(var_name, scoping)
+    }
+
+    fn has_same_scope_binding(&self, var_name: &str) -> bool {
+        if self.newly_bound.contains(var_name) {
+            return true;
+        }
+
+        self.base.has_same_scope_binding(var_name)
+    }
+}

--- a/src/compiler/destructuring_planner/destructuring.rs
+++ b/src/compiler/destructuring_planner/destructuring.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Functions responsible for building destructuring plans.
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::ast::{Expr, ExprRef};
+use crate::compiler::destructuring_planner::context::OverlayBindingContext;
+use crate::compiler::destructuring_planner::utils::extract_literal_key;
+use crate::compiler::destructuring_planner::{
+    DestructuringPlan, ScopingMode, VariableBindingContext,
+};
+
+/// Create a destructuring plan for an expression using a variable binding context.
+pub fn create_destructuring_plan<T: VariableBindingContext>(
+    expr: &ExprRef,
+    context: &T,
+    scoping: ScopingMode,
+) -> Option<DestructuringPlan> {
+    let mut newly_bound = BTreeSet::new();
+    create_destructuring_plan_with_tracking(expr, context, scoping, &mut newly_bound)
+}
+
+/// Create a destructuring plan while tracking newly bound variables.
+pub(crate) fn create_destructuring_plan_with_tracking<T: VariableBindingContext>(
+    expr: &ExprRef,
+    context: &T,
+    scoping: ScopingMode,
+    newly_bound: &mut BTreeSet<String>,
+) -> Option<DestructuringPlan> {
+    let overlay = OverlayBindingContext {
+        base: context,
+        newly_bound,
+    };
+
+    match expr.as_ref() {
+        // Variable binding
+        Expr::Var { span: name, .. } => {
+            if name.text() == "_" {
+                return Some(DestructuringPlan::Ignore);
+            }
+            if overlay.is_var_unbound(name.text(), scoping) {
+                newly_bound.insert(name.text().to_string());
+                Some(DestructuringPlan::Var(name.clone()))
+            } else {
+                // Already bound - treat as equality check
+                Some(DestructuringPlan::EqualityExpr(expr.clone()))
+            }
+        }
+
+        Expr::String { value, .. }
+        | Expr::RawString { value, .. }
+        | Expr::Number { value, .. }
+        | Expr::Bool { value, .. }
+        | Expr::Null { value, .. } => Some(DestructuringPlan::EqualityValue(value.clone())),
+
+        // Array destructuring
+        Expr::Array { items, .. } => {
+            let mut element_plans = Vec::new();
+            for item in items {
+                if let Some(plan) =
+                    create_destructuring_plan_with_tracking(item, context, scoping, newly_bound)
+                {
+                    element_plans.push(plan);
+                } else {
+                    // If any element can't be destructured, fail the whole array
+                    return None;
+                }
+            }
+            Some(DestructuringPlan::Array { element_plans })
+        }
+
+        // Object destructuring
+        Expr::Object { fields, .. } => {
+            let mut field_plans = BTreeMap::new();
+            let mut dynamic_fields = Vec::new();
+            for (_, key_expr, value_expr) in fields {
+                if let Some(value_plan) = create_destructuring_plan_with_tracking(
+                    value_expr,
+                    context,
+                    scoping,
+                    newly_bound,
+                ) {
+                    if let Some(key_value) = extract_literal_key(key_expr) {
+                        field_plans.insert(key_value, value_plan);
+                    } else {
+                        dynamic_fields.push((key_expr.clone(), value_plan));
+                    }
+                } else {
+                    return None;
+                }
+            }
+
+            Some(DestructuringPlan::Object {
+                field_plans,
+                dynamic_fields,
+            })
+        }
+
+        // For all others, treat as equality checks
+        _ => Some(DestructuringPlan::EqualityExpr(expr.clone())),
+    }
+}

--- a/src/compiler/destructuring_planner/error.rs
+++ b/src/compiler/destructuring_planner/error.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Error definitions for the destructuring planner.
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use anyhow::Error;
+use core::error::Error as CoreError;
+use core::fmt;
+
+use crate::lexer::Span;
+
+/// Errors produced while building binding plans.
+#[derive(Debug)]
+pub enum BindingPlannerError {
+    /// Assignment operator := requires left-hand side to have bindable variables.
+    ColonEqualsRequiresBindableLeft { span: Span },
+    /// Array size mismatch in assignment destructuring.
+    ArraySizeMismatch {
+        left_size: usize,
+        right_size: usize,
+        span: Span,
+    },
+    /// Array length mismatch detected while planning evaluation (no assignments).
+    ArrayLengthMismatch {
+        expected: usize,
+        actual: usize,
+        span: Span,
+    },
+    /// Object literal keys mismatch detected while planning evaluation (no assignments).
+    ObjectLiteralKeysMismatch {
+        expected: Vec<String>,
+        actual: Vec<String>,
+        span: Span,
+    },
+    /// Object field count mismatch in assignment destructuring.
+    ObjectFieldCountMismatch {
+        left_count: usize,
+        right_count: usize,
+        span: Span,
+    },
+    /// Object key not found in destructuring.
+    ObjectKeyNotFound { key: String, span: Span },
+    /// Variable reuse detected when a new binding is required.
+    VariableAlreadyDefined { var: String, span: Span },
+    /// Incompatible destructuring patterns.
+    IncompatibleDestructuringPatterns { span: Span },
+    /// Failed to create destructuring plan.
+    FailedToCreateDestructuringPlan { plan_type: String, span: Span },
+}
+
+/// Result alias used throughout the binding planner.
+pub type Result<T> = core::result::Result<T, BindingPlannerError>;
+
+/// Convert planner errors into diagnostic-rich anyhow errors for compiler callers.
+pub fn map_binding_error(err: BindingPlannerError) -> Error {
+    match err {
+		BindingPlannerError::ColonEqualsRequiresBindableLeft { span } => span
+			.error("assignment operator := requires left-hand side to have bindable variables"),
+		BindingPlannerError::ArraySizeMismatch { span, .. }
+		| BindingPlannerError::ArrayLengthMismatch { span, .. } => {
+			span.error("mismatch in number of array elements")
+		}
+		BindingPlannerError::ObjectLiteralKeysMismatch {
+			expected,
+			actual,
+			span,
+		} => span.error(&format!(
+			"object literal keys mismatch. Expected keys {:?} got {:?}.",
+			expected, actual
+		)),
+		BindingPlannerError::ObjectFieldCountMismatch {
+			left_count,
+			right_count,
+			span,
+		} => span.error(&format!(
+			"object field count mismatch in assignment: left has {left_count} fields, right has {right_count} fields"
+		)),
+		BindingPlannerError::ObjectKeyNotFound { key, span } => span
+			.error(&format!("key \"{key}\" not found in left-hand side object during destructuring")),
+		BindingPlannerError::VariableAlreadyDefined { var, span } => {
+			span.error(&format!("var `{var}` used before definition below"))
+		}
+		BindingPlannerError::IncompatibleDestructuringPatterns { span } => span.error(
+			"incompatible destructuring patterns: both sides must be arrays or objects with matching structure",
+		),
+		BindingPlannerError::FailedToCreateDestructuringPlan { plan_type, span } => {
+			span.error(&format!("failed to create {plan_type} destructuring plan"))
+		}
+	}
+}
+
+impl BindingPlannerError {
+    pub(crate) fn to_span_message(&self) -> String {
+        match self {
+			BindingPlannerError::ColonEqualsRequiresBindableLeft { span } => span
+				.message(
+					"error",
+					"assignment operator := requires left-hand side to have bindable variables",
+				),
+			BindingPlannerError::ArraySizeMismatch {
+				left_size,
+				right_size,
+				span,
+			} => {
+				let detail = format!(
+					"mismatch in number of array elements (left has {left_size}, right has {right_size})"
+				);
+				span.message("error", detail.as_str())
+			}
+			BindingPlannerError::ArrayLengthMismatch {
+				expected,
+				actual,
+				span,
+			} => {
+				let detail = format!(
+					"array length mismatch. Expected {expected} got {actual}."
+				);
+				span.message("error", detail.as_str())
+			}
+			BindingPlannerError::ObjectLiteralKeysMismatch {
+				expected,
+				actual,
+				span,
+			} => {
+				let detail = format!(
+					"object literal keys mismatch. Expected keys {:?} got {:?}.",
+					expected, actual
+				);
+				span.message("error", detail.as_str())
+			}
+			BindingPlannerError::ObjectFieldCountMismatch {
+				left_count,
+				right_count,
+				span,
+			} => {
+				let detail = format!(
+					"object field count mismatch in assignment: left has {left_count} fields, right has {right_count} fields"
+				);
+				span.message("error", detail.as_str())
+			}
+			BindingPlannerError::ObjectKeyNotFound { key, span } => {
+				let detail = format!(
+					"key \"{key}\" not found in left-hand side object during destructuring"
+				);
+				span.message("error", detail.as_str())
+			}
+			BindingPlannerError::VariableAlreadyDefined { var, span } => {
+				let detail = format!("var `{var}` used before definition below");
+				span.message("error", detail.as_str())
+			}
+			BindingPlannerError::IncompatibleDestructuringPatterns { span } => span
+				.message(
+					"error",
+					"incompatible destructuring patterns: both sides must be arrays or objects with matching structure",
+				),
+			BindingPlannerError::FailedToCreateDestructuringPlan { plan_type, span } => {
+				let detail = format!("failed to create {plan_type} destructuring plan");
+				span.message("error", detail.as_str())
+			}
+		}
+    }
+}
+
+impl fmt::Display for BindingPlannerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_span_message())
+    }
+}
+
+impl CoreError for BindingPlannerError {}

--- a/src/compiler/destructuring_planner/mod.rs
+++ b/src/compiler/destructuring_planner/mod.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Destructuring and binding planner utilities.
+//!
+//! This module hierarchy reorganizes the binding planner into smaller components
+//! so the compiler can evolve without ambiguity with FFI bindings. Submodules
+//! will be filled in as code is migrated from the legacy `bindings` module.
+
+pub mod assignment;
+pub mod context;
+pub mod destructuring;
+pub mod error;
+pub mod parameters;
+pub mod plans;
+pub mod some_in;
+pub mod utils;
+
+pub use assignment::create_assignment_binding_plan;
+pub use context::{ScopingMode, VariableBindingContext};
+pub use destructuring::create_destructuring_plan;
+pub use error::{map_binding_error, BindingPlannerError, Result};
+pub use parameters::{create_loop_index_binding_plan, create_parameter_binding_plan};
+pub use plans::{AssignmentPlan, BindingPlan, DestructuringPlan, WildcardSide};
+pub use some_in::create_some_in_binding_plan;

--- a/src/compiler/destructuring_planner/parameters.rs
+++ b/src/compiler/destructuring_planner/parameters.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Planner helpers for function parameters and loop indices.
+
+use alloc::collections::BTreeSet;
+use alloc::string::ToString;
+
+use crate::ast::ExprRef;
+use crate::compiler::destructuring_planner::create_destructuring_plan;
+use crate::compiler::destructuring_planner::destructuring::create_destructuring_plan_with_tracking;
+use crate::compiler::destructuring_planner::utils::validate_pattern_bindings;
+use crate::compiler::destructuring_planner::{
+    BindingPlan, BindingPlannerError, Result, ScopingMode, VariableBindingContext,
+};
+
+/// Convenience function for loop index expressions (respects parent scope).
+pub fn create_loop_index_binding_plan<T: VariableBindingContext>(
+    index_expr: &ExprRef,
+    context: &T,
+) -> Result<BindingPlan> {
+    let destructuring_plan =
+        create_destructuring_plan(index_expr, context, ScopingMode::RespectParent).ok_or_else(
+            || BindingPlannerError::FailedToCreateDestructuringPlan {
+                plan_type: "loop index".to_string(),
+                span: index_expr.span().clone(),
+            },
+        )?;
+
+    Ok(BindingPlan::LoopIndex {
+        index_expr: index_expr.clone(),
+        destructuring_plan,
+    })
+}
+
+/// Convenience function for function parameters (always allow shadowing).
+pub fn create_parameter_binding_plan<T: VariableBindingContext>(
+    param_expr: &ExprRef,
+    context: &T,
+) -> Result<BindingPlan> {
+    let mut newly_bound = BTreeSet::new();
+    let destructuring_plan = create_destructuring_plan_with_tracking(
+        param_expr,
+        context,
+        ScopingMode::AllowShadowing,
+        &mut newly_bound,
+    )
+    .ok_or_else(|| BindingPlannerError::FailedToCreateDestructuringPlan {
+        plan_type: "parameter".to_string(),
+        span: param_expr.span().clone(),
+    })?;
+
+    validate_pattern_bindings(param_expr, &newly_bound, context)?;
+
+    Ok(BindingPlan::Parameter {
+        param_expr: param_expr.clone(),
+        destructuring_plan,
+    })
+}

--- a/src/compiler/destructuring_planner/plans.rs
+++ b/src/compiler/destructuring_planner/plans.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Core data structures used by the destructuring planner.
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::ast::ExprRef;
+use crate::lexer::Span;
+use crate::value::Value;
+
+/// Strategy for how to destructure an expression.
+#[derive(Debug, Clone)]
+pub enum DestructuringPlan {
+    /// Bind the entire value to a variable.
+    Var(Span),
+
+    /// Ignore the value completely.
+    Ignore,
+
+    /// Check equality with the value of the dynamic expression.
+    EqualityExpr(ExprRef),
+
+    /// Check equality against a literal value captured at planning time.
+    EqualityValue(Value),
+
+    /// Destructure an array.
+    Array {
+        element_plans: Vec<DestructuringPlan>,
+    },
+
+    /// Destructure an object.
+    Object {
+        field_plans: BTreeMap<Value, DestructuringPlan>,
+        dynamic_fields: Vec<(ExprRef, DestructuringPlan)>,
+    },
+}
+
+impl DestructuringPlan {
+    fn collect_bound_vars(&self, vars: &mut Vec<String>) {
+        match self {
+            DestructuringPlan::Var(name) => vars.push(name.text().to_string()),
+            DestructuringPlan::Array { element_plans } => {
+                for element in element_plans {
+                    element.collect_bound_vars(vars);
+                }
+            }
+            DestructuringPlan::Object {
+                field_plans,
+                dynamic_fields,
+            } => {
+                for plan in field_plans.values() {
+                    plan.collect_bound_vars(vars);
+                }
+                for (_, plan) in dynamic_fields {
+                    plan.collect_bound_vars(vars);
+                }
+            }
+            DestructuringPlan::Ignore
+            | DestructuringPlan::EqualityExpr(_)
+            | DestructuringPlan::EqualityValue(_) => {}
+        }
+    }
+
+    pub(crate) fn contains_wildcards(&self) -> bool {
+        match self {
+            DestructuringPlan::Ignore => true,
+            DestructuringPlan::Array { element_plans } => element_plans
+                .iter()
+                .any(DestructuringPlan::contains_wildcards),
+            DestructuringPlan::Object {
+                field_plans,
+                dynamic_fields,
+            } => {
+                field_plans
+                    .values()
+                    .any(DestructuringPlan::contains_wildcards)
+                    || dynamic_fields
+                        .iter()
+                        .any(|(_, plan)| plan.contains_wildcards())
+            }
+            DestructuringPlan::Var(_)
+            | DestructuringPlan::EqualityExpr(_)
+            | DestructuringPlan::EqualityValue(_) => false,
+        }
+    }
+
+    pub(crate) fn bound_vars(&self) -> Vec<String> {
+        let mut vars = Vec::new();
+        self.collect_bound_vars(&mut vars);
+        vars
+    }
+
+    pub(crate) fn introduces_binding(&self) -> bool {
+        match self {
+            DestructuringPlan::Var(_) | DestructuringPlan::Ignore => true,
+            DestructuringPlan::Array { element_plans } => element_plans
+                .iter()
+                .any(DestructuringPlan::introduces_binding),
+            DestructuringPlan::Object {
+                field_plans,
+                dynamic_fields,
+            } => {
+                field_plans
+                    .values()
+                    .any(DestructuringPlan::introduces_binding)
+                    || dynamic_fields
+                        .iter()
+                        .any(|(_, plan)| plan.introduces_binding())
+            }
+            DestructuringPlan::EqualityExpr(_) | DestructuringPlan::EqualityValue(_) => false,
+        }
+    }
+}
+
+/// Strategy-based assignment plan with specific rules for := and = operators.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum AssignmentPlan {
+    /// For := (ColEq) - only LHS can have patterns.
+    ColonEquals {
+        lhs_expr: ExprRef,
+        rhs_expr: ExprRef,
+        lhs_plan: DestructuringPlan,
+    },
+
+    /// For = (Eq) - only one side has unbound variables.
+    EqualsBindLeft {
+        lhs_expr: ExprRef,
+        rhs_expr: ExprRef,
+        lhs_plan: DestructuringPlan,
+    },
+
+    /// For = (Eq) - only one side has unbound variables.
+    EqualsBindRight {
+        lhs_expr: ExprRef,
+        rhs_expr: ExprRef,
+        rhs_plan: DestructuringPlan,
+    },
+
+    /// For = (Eq) - both sides have unbound vars, flattened to pairs.
+    /// Each pair is (value_expr, destructuring_plan_for_pattern).
+    EqualsBothSides {
+        lhs_expr: ExprRef,
+        rhs_expr: ExprRef,
+        element_pairs: Vec<(ExprRef, DestructuringPlan)>,
+    },
+
+    /// No variables to bind - simple equality check.
+    EqualityCheck {
+        lhs_expr: ExprRef,
+        rhs_expr: ExprRef,
+    },
+
+    /// No variables to bind and at least one side is a wildcard `_`.
+    WildcardMatch {
+        lhs_expr: ExprRef,
+        rhs_expr: ExprRef,
+        wildcard_side: WildcardSide,
+    },
+}
+
+impl AssignmentPlan {
+    pub(crate) fn bound_vars(&self) -> Vec<String> {
+        match self {
+            AssignmentPlan::ColonEquals { lhs_plan, .. }
+            | AssignmentPlan::EqualsBindLeft { lhs_plan, .. } => lhs_plan.bound_vars(),
+            AssignmentPlan::EqualsBindRight { rhs_plan, .. } => rhs_plan.bound_vars(),
+            AssignmentPlan::EqualsBothSides { element_pairs, .. } => {
+                let mut vars = Vec::new();
+                for (_, plan) in element_pairs {
+                    vars.extend(plan.bound_vars());
+                }
+                vars
+            }
+            AssignmentPlan::EqualityCheck { .. } | AssignmentPlan::WildcardMatch { .. } => {
+                Vec::new()
+            }
+        }
+    }
+}
+
+/// Indicates which side of an equality expression contains a wildcard `_`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum WildcardSide {
+    Lhs,
+    Rhs,
+    Both,
+}
+
+/// High-level plan describing how bindings are produced in various contexts.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum BindingPlan {
+    Assignment {
+        plan: AssignmentPlan,
+    },
+    LoopIndex {
+        index_expr: ExprRef,
+        destructuring_plan: DestructuringPlan,
+    },
+    Parameter {
+        param_expr: ExprRef,
+        destructuring_plan: DestructuringPlan,
+    },
+    SomeIn {
+        collection_expr: ExprRef,
+        key_plan: Option<DestructuringPlan>,
+        value_plan: DestructuringPlan,
+    },
+}
+
+impl BindingPlan {
+    /// Return the set of variables newly bound by this plan.
+    pub fn bound_vars(&self) -> Vec<String> {
+        match self {
+            BindingPlan::Assignment { plan } => plan.bound_vars(),
+            BindingPlan::LoopIndex {
+                destructuring_plan, ..
+            } => destructuring_plan.bound_vars(),
+            BindingPlan::Parameter {
+                destructuring_plan, ..
+            } => destructuring_plan.bound_vars(),
+            BindingPlan::SomeIn {
+                key_plan,
+                value_plan,
+                ..
+            } => {
+                let mut vars = Vec::new();
+                if let Some(key_destructuring) = key_plan {
+                    vars.extend(key_destructuring.bound_vars());
+                }
+                vars.extend(value_plan.bound_vars());
+                vars
+            }
+        }
+    }
+}

--- a/src/compiler/destructuring_planner/some_in.rs
+++ b/src/compiler/destructuring_planner/some_in.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Planner support for `some .. in` expressions.
+
+use alloc::collections::BTreeSet;
+use alloc::string::String;
+
+use crate::ast::{Expr, ExprRef};
+use crate::compiler::destructuring_planner::destructuring::create_destructuring_plan_with_tracking;
+use crate::compiler::destructuring_planner::utils::{
+    check_literal_structure, validate_pattern_bindings, LiteralStructureCheck,
+};
+use crate::compiler::destructuring_planner::{
+    BindingPlan, BindingPlannerError, Result, ScopingMode, VariableBindingContext,
+};
+
+/// Convenience function for some..in expressions (always allow shadowing for new bindings).
+pub fn create_some_in_binding_plan<T: VariableBindingContext>(
+    key_expr: &Option<ExprRef>,
+    value_expr: &ExprRef,
+    collection_expr: &ExprRef,
+    context: &T,
+) -> Result<BindingPlan> {
+    let key_plan = if let Some(key) = key_expr {
+        let mut newly_bound = BTreeSet::new();
+        let plan = create_destructuring_plan_with_tracking(
+            key,
+            context,
+            ScopingMode::RespectParent,
+            &mut newly_bound,
+        );
+        if let Some(plan) = plan {
+            validate_pattern_bindings(key, &newly_bound, context)?;
+            Some(plan)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let mut newly_bound_value = BTreeSet::new();
+    let value_plan = create_destructuring_plan_with_tracking(
+        value_expr,
+        context,
+        ScopingMode::RespectParent,
+        &mut newly_bound_value,
+    )
+    .ok_or_else(|| BindingPlannerError::FailedToCreateDestructuringPlan {
+        plan_type: String::from("some-in value"),
+        span: value_expr.span().clone(),
+    })?;
+
+    validate_pattern_bindings(value_expr, &newly_bound_value, context)?;
+
+    if let Expr::Array { items, .. } = collection_expr.as_ref() {
+        let mut found_match = false;
+        let mut mismatch_error: Option<BindingPlannerError> = None;
+        let mut saw_unknown = false;
+
+        for collection_item in items {
+            match check_literal_structure(&value_plan, collection_item) {
+                LiteralStructureCheck::Match => {
+                    found_match = true;
+                }
+                LiteralStructureCheck::Unknown => {
+                    saw_unknown = true;
+                }
+                mismatch => {
+                    if let Some(err) = mismatch.into_error() {
+                        if mismatch_error.is_none() {
+                            mismatch_error = Some(err);
+                        }
+                    }
+                }
+            }
+        }
+
+        if !found_match && !saw_unknown {
+            if let Some(err) = mismatch_error {
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(BindingPlan::SomeIn {
+        collection_expr: collection_expr.clone(),
+        key_plan,
+        value_plan,
+    })
+}

--- a/src/compiler/destructuring_planner/utils.rs
+++ b/src/compiler/destructuring_planner/utils.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared helper routines for the destructuring planner modules.
+
+use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use crate::ast::{Expr, ExprRef};
+use crate::compiler::destructuring_planner::{
+    BindingPlannerError, DestructuringPlan, Result, ScopingMode, VariableBindingContext,
+};
+use crate::lexer::Span;
+use crate::value::Value;
+
+/// Result of statically comparing a destructuring plan with a literal expression.
+pub(crate) enum LiteralStructureCheck {
+    Match,
+    Unknown,
+    ArrayMismatch {
+        expected: usize,
+        actual: usize,
+        span: Span,
+    },
+    ObjectMismatch {
+        expected: Vec<String>,
+        actual: Vec<String>,
+        span: Span,
+    },
+}
+
+impl LiteralStructureCheck {
+    pub(crate) fn into_error(self) -> Option<BindingPlannerError> {
+        match self {
+            LiteralStructureCheck::Match | LiteralStructureCheck::Unknown => None,
+            LiteralStructureCheck::ArrayMismatch {
+                expected,
+                actual,
+                span,
+            } => Some(BindingPlannerError::ArrayLengthMismatch {
+                expected,
+                actual,
+                span,
+            }),
+            LiteralStructureCheck::ObjectMismatch {
+                expected,
+                actual,
+                span,
+            } => Some(BindingPlannerError::ObjectLiteralKeysMismatch {
+                expected,
+                actual,
+                span,
+            }),
+        }
+    }
+}
+
+/// Compare a destructuring plan against a literal expression.
+pub(crate) fn check_literal_structure(
+    plan: &DestructuringPlan,
+    expr: &ExprRef,
+) -> LiteralStructureCheck {
+    match (plan, expr.as_ref()) {
+        (DestructuringPlan::Array { element_plans }, Expr::Array { items, .. }) => {
+            if items.len() != element_plans.len() {
+                return LiteralStructureCheck::ArrayMismatch {
+                    expected: element_plans.len(),
+                    actual: items.len(),
+                    span: expr.span().clone(),
+                };
+            }
+
+            for (nested_plan, nested_expr) in element_plans.iter().zip(items.iter()) {
+                match check_literal_structure(nested_plan, nested_expr) {
+                    LiteralStructureCheck::Match => {}
+                    LiteralStructureCheck::Unknown => return LiteralStructureCheck::Unknown,
+                    mismatch => return mismatch,
+                }
+            }
+
+            LiteralStructureCheck::Match
+        }
+        (
+            DestructuringPlan::Object {
+                field_plans,
+                dynamic_fields,
+            },
+            Expr::Object { fields, .. },
+        ) => {
+            if field_plans.is_empty() && dynamic_fields.is_empty() {
+                return LiteralStructureCheck::Match;
+            }
+
+            if !field_plans.is_empty() {
+                let expected_keys: Vec<String> = field_plans
+                    .keys()
+                    .map(format_literal_key_for_error)
+                    .collect();
+
+                let mut literal_fields: Vec<(Value, &ExprRef)> = Vec::new();
+                let mut actual_keys: Vec<String> = Vec::new();
+                for (_, key_expr, value_expr) in fields {
+                    if let Some(key_value) = extract_literal_key(key_expr) {
+                        actual_keys.push(format_literal_key_for_error(&key_value));
+                        literal_fields.push((key_value, value_expr));
+                    }
+                }
+
+                let mut expected_sorted = expected_keys.clone();
+                expected_sorted.sort();
+                let mut actual_sorted = actual_keys.clone();
+                actual_sorted.sort();
+
+                if expected_sorted != actual_sorted {
+                    return LiteralStructureCheck::ObjectMismatch {
+                        expected: expected_keys,
+                        actual: actual_keys,
+                        span: expr.span().clone(),
+                    };
+                }
+
+                for (key_value, value_expr) in literal_fields {
+                    if let Some(field_plan) = field_plans.get(&key_value) {
+                        match check_literal_structure(field_plan, value_expr) {
+                            LiteralStructureCheck::Match => {}
+                            LiteralStructureCheck::Unknown => {
+                                return LiteralStructureCheck::Unknown
+                            }
+                            mismatch => return mismatch,
+                        }
+                    }
+                }
+
+                if dynamic_fields.is_empty() {
+                    return LiteralStructureCheck::Match;
+                }
+            }
+
+            LiteralStructureCheck::Unknown
+        }
+        _ => LiteralStructureCheck::Unknown,
+    }
+}
+
+pub(crate) fn ensure_literal_match(plan: &DestructuringPlan, expr: &ExprRef) -> Result<()> {
+    match check_literal_structure(plan, expr).into_error() {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+pub(crate) fn collect_pattern_var_spans(expr: &ExprRef, spans: &mut Vec<Span>) {
+    match expr.as_ref() {
+        Expr::Var { span, .. } => {
+            let name = span.text();
+            if name != "_" && name != "input" && name != "data" {
+                spans.push(span.clone());
+            }
+        }
+        Expr::Array { items, .. } => {
+            for item in items {
+                collect_pattern_var_spans(item, spans);
+            }
+        }
+        Expr::Set { items, .. } => {
+            for item in items {
+                collect_pattern_var_spans(item, spans);
+            }
+        }
+        Expr::Object { fields, .. } => {
+            for (_, _, value_expr) in fields {
+                collect_pattern_var_spans(value_expr, spans);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn validate_pattern_bindings<T: VariableBindingContext>(
+    expr: &ExprRef,
+    newly_bound: &BTreeSet<String>,
+    context: &T,
+) -> Result<()> {
+    let mut candidate_vars = Vec::new();
+    collect_pattern_var_spans(expr, &mut candidate_vars);
+
+    for span in candidate_vars {
+        let name = span.text().to_string();
+        if newly_bound.contains(&name) {
+            continue;
+        }
+        if !context.is_var_unbound(&name, ScopingMode::RespectParent) {
+            return Err(BindingPlannerError::VariableAlreadyDefined { var: name, span });
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn collect_plan_var_spans(plan: &DestructuringPlan, spans: &mut Vec<Span>) {
+    match plan {
+        DestructuringPlan::Var(span) => spans.push(span.clone()),
+        DestructuringPlan::Array { element_plans } => {
+            for nested in element_plans {
+                collect_plan_var_spans(nested, spans);
+            }
+        }
+        DestructuringPlan::Object {
+            field_plans,
+            dynamic_fields,
+        } => {
+            for nested in field_plans.values() {
+                collect_plan_var_spans(nested, spans);
+            }
+            for (_, nested) in dynamic_fields {
+                collect_plan_var_spans(nested, spans);
+            }
+        }
+        DestructuringPlan::Ignore
+        | DestructuringPlan::EqualityExpr(_)
+        | DestructuringPlan::EqualityValue(_) => {}
+    }
+}
+
+pub(crate) fn ensure_structural_compatibility(
+    lhs_expr: &ExprRef,
+    rhs_expr: &ExprRef,
+) -> Result<()> {
+    let lhs_is_array = matches!(lhs_expr.as_ref(), Expr::Array { .. });
+    let rhs_is_array = matches!(rhs_expr.as_ref(), Expr::Array { .. });
+    let lhs_is_object = matches!(lhs_expr.as_ref(), Expr::Object { .. });
+    let rhs_is_object = matches!(rhs_expr.as_ref(), Expr::Object { .. });
+
+    if (lhs_is_array && rhs_is_object) || (lhs_is_object && rhs_is_array) {
+        return Err(BindingPlannerError::IncompatibleDestructuringPatterns {
+            span: lhs_expr.span().clone(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Helper that discards destructuring plans which do not bind any variables.
+pub(crate) fn plan_only_if_binds(plan: Option<DestructuringPlan>) -> Option<DestructuringPlan> {
+    plan.and_then(|plan| {
+        if plan.introduces_binding() || plan.contains_wildcards() {
+            Some(plan)
+        } else {
+            None
+        }
+    })
+}
+
+pub(crate) fn extract_literal_key(expr: &ExprRef) -> Option<Value> {
+    match expr.as_ref() {
+        Expr::String { value, .. } => Some(value.clone()),
+        Expr::RawString { value, .. } => Some(value.clone()),
+        Expr::Number { value, .. } => Some(value.clone()),
+        Expr::Bool { value, .. } => Some(value.clone()),
+        Expr::Null { .. } => Some(Value::Null),
+        _ => None,
+    }
+}
+
+pub(crate) fn format_literal_key_for_error(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.as_ref().to_string(),
+        _ => value.to_string(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod lookup;
 mod number;
 mod parser;
 mod policy_info;
+mod query;
 #[cfg(feature = "azure_policy")]
 pub mod registry;
 mod scheduler;

--- a/src/number.rs
+++ b/src/number.rs
@@ -489,4 +489,15 @@ mod test {
         let n = Number::from(123456f64);
         assert_eq!(format!("{}", n.format_decimal()), "123456");
     }
+
+    #[test]
+    fn division_matches_high_precision_decimal() {
+        let one = Number::from(1u64);
+        let three = Number::from(3u64);
+        let div = one.divide(&three).unwrap();
+        let from_str: Number = "0.3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333"
+            .parse()
+            .unwrap();
+        assert_eq!(div, from_str);
+    }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,1 @@
+pub mod traversal;

--- a/src/query/traversal.rs
+++ b/src/query/traversal.rs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::{String, ToString};
+
+use anyhow::Result;
+
+use crate::ast::Expr::{self, *};
+use crate::ast::{AssignOp, ExprRef};
+use crate::lexer::{SourceStr, Span};
+use crate::value::Value;
+
+#[derive(Clone, Default, Debug)]
+pub struct Scope {
+    pub locals: BTreeMap<SourceStr, Span>,
+    pub unscoped: BTreeSet<SourceStr>,
+    pub inputs: BTreeSet<SourceStr>,
+    pub uses_input: bool,
+}
+
+pub fn traverse(expr: &ExprRef, f: &mut dyn FnMut(&ExprRef) -> Result<bool>) -> Result<()> {
+    if !f(expr)? {
+        return Ok(());
+    }
+
+    match expr.as_ref() {
+        Expr::String { .. }
+        | RawString { .. }
+        | Number { .. }
+        | Bool { .. }
+        | Null { .. }
+        | Var { .. } => (),
+
+        Array { items, .. } | Set { items, .. } => {
+            for item in items {
+                traverse(item, f)?;
+            }
+        }
+        Object { fields, .. } => {
+            for (_, key, value) in fields {
+                traverse(key, f)?;
+                traverse(value, f)?;
+            }
+        }
+
+        ArrayCompr { .. } | SetCompr { .. } | ObjectCompr { .. } => (),
+
+        Call { params, .. } => {
+            for param in params {
+                traverse(param, f)?;
+            }
+        }
+
+        UnaryExpr { expr, .. } => traverse(expr, f)?,
+
+        RefDot { refr, .. } => traverse(refr, f)?,
+
+        RefBrack { refr, index, .. } => {
+            traverse(refr, f)?;
+            traverse(index, f)?;
+        }
+
+        BinExpr { lhs, rhs, .. }
+        | BoolExpr { lhs, rhs, .. }
+        | ArithExpr { lhs, rhs, .. }
+        | AssignExpr { lhs, rhs, .. } => {
+            traverse(lhs, f)?;
+            traverse(rhs, f)?;
+        }
+
+        #[cfg(feature = "rego-extensions")]
+        OrExpr { lhs, rhs, .. } => {
+            traverse(lhs, f)?;
+            traverse(rhs, f)?;
+        }
+
+        Membership {
+            key,
+            value,
+            collection,
+            ..
+        } => {
+            if let Some(key) = key.as_ref() {
+                traverse(key, f)?;
+            }
+            traverse(value, f)?;
+            traverse(collection, f)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn var_exists(var: &Span, parent_scopes: &[Scope]) -> bool {
+    let name = var.source_str();
+
+    for scope in parent_scopes.iter().rev() {
+        if scope.unscoped.contains(&name) {
+            return true;
+        }
+
+        if let Some(span) = scope.locals.get(&name) {
+            if span.line <= var.line {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+pub fn gather_assigned_vars(
+    expr: &ExprRef,
+    can_shadow: bool,
+    parent_scopes: &[Scope],
+    scope: &mut Scope,
+) -> Result<()> {
+    traverse(expr, &mut |node| match node.as_ref() {
+        Var { span, .. } if matches!(span.text(), "_" | "input" | "data") => {
+            if span.text() == "input" {
+                scope.uses_input = true;
+            }
+            Ok(false)
+        }
+        Var { span, .. } if can_shadow => {
+            scope.locals.insert(span.source_str(), span.clone());
+            Ok(false)
+        }
+        Var { span, .. } if var_exists(span, parent_scopes) => {
+            scope.inputs.insert(span.source_str());
+            Ok(false)
+        }
+        Var { span, .. } => {
+            scope.unscoped.insert(span.source_str());
+            Ok(false)
+        }
+        Array { .. } | Object { .. } => Ok(true),
+        _ => Ok(false),
+    })
+}
+
+pub fn gather_input_vars(expr: &ExprRef, parent_scopes: &[Scope], scope: &mut Scope) -> Result<()> {
+    traverse(expr, &mut |node| match node.as_ref() {
+        Var { span, .. } => {
+            let name = span.source_str();
+            if name.text() == "input" {
+                scope.uses_input = true;
+            } else if !scope.unscoped.contains(&name) && var_exists(span, parent_scopes) {
+                scope.inputs.insert(name);
+            }
+            Ok(false)
+        }
+        _ => Ok(true),
+    })
+}
+
+pub fn gather_loop_vars(expr: &ExprRef, parent_scopes: &[Scope], scope: &mut Scope) -> Result<()> {
+    traverse(expr, &mut |node| match node.as_ref() {
+        Var { span, .. } if span.text() == "input" => {
+            scope.uses_input = true;
+            Ok(false)
+        }
+        RefBrack { index, .. } => {
+            gather_assigned_vars(index, false, parent_scopes, scope)?;
+            Ok(true)
+        }
+        _ => Ok(true),
+    })
+}
+
+pub fn gather_vars(
+    expr: &ExprRef,
+    can_shadow: bool,
+    parent_scopes: &[Scope],
+    scope: &mut Scope,
+) -> Result<()> {
+    if let AssignExpr { op, lhs, rhs, .. } = expr.as_ref() {
+        gather_assigned_vars(lhs, *op == AssignOp::ColEq, parent_scopes, scope)?;
+        gather_assigned_vars(rhs, false, parent_scopes, scope)?;
+    } else {
+        gather_assigned_vars(expr, can_shadow, parent_scopes, scope)?;
+    }
+
+    gather_input_vars(expr, parent_scopes, scope)?;
+    gather_loop_vars(expr, parent_scopes, scope)
+}
+
+pub fn collect_expr_dependencies(expr: &ExprRef) -> Option<BTreeSet<String>> {
+    let mut deps = BTreeSet::new();
+    let mut valid = true;
+
+    if traverse(expr, &mut |node| match node.as_ref() {
+        Var { value, .. } => {
+            if let Value::String(name) = value {
+                let var = name.as_ref();
+                if var != "_" {
+                    deps.insert(var.to_string());
+                }
+            }
+            Ok(false)
+        }
+        ArrayCompr { .. } | SetCompr { .. } | ObjectCompr { .. } => {
+            valid = false;
+            Ok(false)
+        }
+        #[cfg(feature = "rego-extensions")]
+        OrExpr { .. } => {
+            valid = false;
+            Ok(false)
+        }
+        _ => Ok(true),
+    })
+    .is_err()
+    {
+        return None;
+    }
+
+    if valid {
+        Some(deps)
+    } else {
+        None
+    }
+}

--- a/tests/interpreter/cases/binding/bindings.yaml
+++ b/tests/interpreter/cases/binding/bindings.yaml
@@ -1,0 +1,432 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: assignment-colonequals-nested-pattern
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := {"outer": outer, "inner": inner, "tag": tag} if {
+          [outer, {"meta": {"inner": inner, "tag": tag}}] := ["alpha", {"meta": {"inner": "omega", "tag": "v1"}}]
+        }
+    query: data.test.result
+    want_result:
+      outer: "alpha"
+      inner: "omega"
+      tag: "v1"
+
+  - note: assignment-colonequals-cannot-rebind
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          value := "initial"
+          value := "shadowed"
+        }
+    query: data.test.result
+    error: "ar `value` used before definition below"
+
+  - note: assignment-colonequals-requires-bindable-left
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          1 := value
+          value = 1
+        }
+    query: data.test.result
+    error: "assignment operator := requires left-hand side to have bindable variables"
+
+  - note: equals-binds-left-nested-literal
+    data: {}
+    modules:
+      - |
+        package test
+        import future.keywords
+
+        result := {"first": first, "second": second, "deep": deep} if {
+          [first, {"details": [second, deep]}] = ["foo", {"details": ["bar", "baz"]}]
+        }
+    query: data.test.result
+    want_result:
+      first: "foo"
+      second: "bar"
+      deep: "baz"
+
+  - note: equals-binds-right-nested-literal
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := {"first": first, "second": second, "deep": deep} if {
+          payload := ["foo", {"details": ["bar", "baz"]}]
+          payload = [first, {"details": [second, deep]}]
+        }
+    query: data.test.result
+    want_result:
+      first: "foo"
+      second: "bar"
+      deep: "baz"
+
+  - note: equals-both-sides-nested-dependent-order
+    data:
+      transitions:
+        - [{"id": 1, "next": {"target": 2}}, {"id": 2, "payload": {"value": "beta"}}]
+        - [{"id": 2, "next": {"target": 3}}, {"id": 3, "payload": {"value": "gamma"}}]
+    modules:
+      - |
+        package test
+
+        result := [[left_id, right_id, value] |
+          some left, right, left_id, right_id, value
+          data.transitions[_] = [left, right]
+          [{"id": left_id, "next": {"target": right_id}}, {"id": right_id, "payload": {"value": value}}] = [left, right]
+        ]
+    query: data.test.result
+    want_result: [[1, 2, "beta"], [2, 3, "gamma"]]
+
+  - note: equals-non-shadowing-success
+    data: {}
+    modules:
+      - |
+        package test
+
+        default result = false
+
+        result = true if {
+          user_id := "user-1"
+          [user_id, role] = ["user-1", "admin"]
+          role = "admin"
+        }
+    query: data.test.result
+    want_result: true
+
+  - note: equals-non-shadowing-mismatch
+    data: {}
+    modules:
+      - |
+        package test
+
+        default result = false
+
+        result = true if {
+          user_id := "user-1"
+          [user_id, role] = ["user-2", "admin"]
+        }
+    query: data.test.result
+    want_result: false
+
+  - note: colon-equals-shadowing-allowed
+    data: {}
+    modules:
+      - |
+        package test
+
+        x := 10
+
+        y if {
+          x := 5
+        }
+    query: data.test.y
+    want_result: true
+
+  - note: equals-wildcard-both-sides
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          [_, _] = [1, 2]
+        }
+    query: data.test.result
+    want_result: true
+
+  - note: equals-incompatible-patterns-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          [x] = {"key": 1}
+        }
+    query: data.test.result
+    error: "incompatible destructuring patterns: both sides must be arrays or objects with matching structure"
+
+  - note: equals-array-size-mismatch-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          some a, b, c
+          [x, y] = [a, b, c]
+        }
+    query: data.test.result
+    error: "mismatch in number of array elements"
+
+  - note: equals-array-literal-length-mismatch-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          [x, y] = [1, 2, 3]
+        }
+    query: data.test.result
+    error: "mismatch in number of array elements"
+
+  - note: equals-object-literal-keys-mismatch-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if{
+          {"a": first, "b": second} = {"a": 1, "c": 2}
+        }
+    query: data.test.result
+    error: "object literal keys mismatch. Expected keys [\"a\", \"b\"] got [\"a\", \"c\"]."
+
+  - note: equals-object-key-not-found-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          some value
+          {"a": first, "b": second} = {"a": 1, "c": value}
+        }
+    query: data.test.result
+    error: "key \"c\" not found in left-hand side object during destructuring"
+
+  - note: equals-object-field-count-mismatch-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          some a, b
+          {"a": first} = {"a": a, "b": b}
+        }
+    query: data.test.result
+    error: "object field count mismatch in assignment: left has 1 fields, right has 2 fields"
+
+  - note: dynamic-object-field-binding
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := {"target": target, "captured": captured} if {
+          source := {"target": {"value": {"inner": 1}}, "alt": {"value": {"inner": 2}}}
+          {"target": {"value": {"inner": target}}, chosen: {"value": {"inner": captured}}} = source
+          chosen = "alt"
+        }
+    query: data.test.result
+    want_result:
+      target: 1
+      captured: 2
+
+  - note: some-in-nested-binding
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := {
+          [letter, code] |
+            some letter, detail in {"a": {"info": {"code": 1}}, "b": {"info": {"code": 2}}}
+            detail.info.code = code
+        }
+    query: data.test.result
+    want_result:
+      set!:
+        - ["a", 1]
+        - ["b", 2]
+
+  - note: some-in-array-length-mismatch-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          some [x, y] in [[1, 2, 3]]
+        }
+    query: data.test.result
+    error: "mismatch in number of array elements"
+
+  - note: some-in-shadowing
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := {"before": before, "after": value} if {
+          value := 0
+          before := value
+          some value in [1, 2]
+          value == 2
+        }
+    query: data.test.result
+    error: "var `value` used before definition below"
+
+  - note: some-in-shadowing-equals
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          value = 0
+          some value in [1, 2]
+        }
+    query: data.test.result
+    error: "var `value` used before definition below"
+
+  - note: some-in-after-shadows
+    data: {}
+    modules:
+      - |
+        package test
+
+        result := true if {
+          some value in [1, 2]
+          value := 1
+        }
+    query: data.test.result
+    error: "var `value` used before definition below"
+
+  - note: comprehension-nested-binding
+    data:
+      records:
+        - {"type": "user", "profile": {"name": "alice", "roles": ["admin", "user"]}}
+        - {"type": "user", "profile": {"name": "bob", "roles": ["user"]}}
+        - {"type": "service", "profile": {"name": "svc"}}
+    modules:
+      - |
+        package test
+
+        result := [[name, role] |
+          some record, role
+          data.records[_] = record
+          record = {"type": "user", "profile": {"name": name, "roles": roles}}
+          roles[_] = role
+          role = "admin"
+        ]
+    query: data.test.result
+    want_result: [["alice", "admin"]]
+
+  - note: comprehension-scalar-filter
+    data:
+      scores:
+        - {"value": 10}
+        - {"value": 20}
+        - {"value": 30}
+    modules:
+      - |
+        package test
+
+        result := [score |
+          some entry, score
+          data.scores[_] = entry
+          entry = {"value": score}
+          score >= 20
+        ]
+    query: data.test.result
+    want_result: [20, 30]
+
+
+  - note: parameter-nested-destructuring
+    data: {}
+    modules:
+      - |
+        package test
+
+        pair([[name, {"primary": role}], {"meta": {"active": active}}]) := [
+          [name, {"primary": role}],
+          {"meta": {"active": active}},
+        ] if {
+          name = "alice"
+          role = "admin"
+          active = true
+        }
+
+        result := {"name": name, "role": role, "active": active} if {
+          [[name, {"primary": role}], {"meta": {"active": active}}] := pair([
+            ["alice", {"primary": "admin"}],
+            {"meta": {"active": true}},
+          ])
+        }
+    query: data.test.result
+    want_result:
+      name: "alice"
+      role: "admin"
+      active: true
+
+  - note: parameter-nested-destructuring-colonequals-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        pair([[name, {"primary": role}], {"meta": {"active": active}}]) if {
+          name := "alice"
+          role := "admin"
+          active := true
+        }
+    query: data.test.pair
+    error: "var `name` used before definition below"
+
+  - note: colon-equals-parameter-rebinding-error
+    data: {}
+    modules:
+      - |
+        package test
+
+        pair([[name, {"primary": role}], {"meta": {"active": active}}]) if {
+          name := "alice"
+          role := "admin"
+          active := true
+        }
+
+        result := true if {
+          pair([
+            ["alice", {"primary": "admin"}],
+            {"meta": {"active": true}},
+          ])
+        }
+    query: data.test.result
+    error: "var `name` used before definition below"
+
+  - note: parameter-shadowing
+    data: {}
+    modules:
+      - |
+        package test
+
+        global_name := "global"
+
+        capture([name, {"role": role}]) if {
+          name := "local"
+          role := "admin"
+        }
+
+        result := {"global": global_name, "param": name, "role": role} if {
+          capture([name, {"role": role}])
+        }
+    query: data.test.result
+    error: "var `name` used before definition below"

--- a/tests/interpreter/cases/binding/walk.yaml
+++ b/tests/interpreter/cases/binding/walk.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+cases:
+  - note: walk-loop-index-destructuring
+    data:
+      doc:
+        team:
+          ops:
+            members: ["alice"]
+          dev:
+            members: ["bob"]
+    modules:
+      - |
+        package test
+
+        result := [[section, role, members] |
+          walk(data.doc, [[section, role], {"members": members}])
+        ]
+    query: data.test.result
+    want_result: [["team", "dev", ["bob"]], ["team", "ops", ["alice"]]]

--- a/tests/interpreter/cases/builtins/numbers/div.yaml
+++ b/tests/interpreter/cases/builtins/numbers/div.yaml
@@ -27,7 +27,6 @@ cases:
     want_result:
       d: 5.1
       e: 3.25
-      z: true
 
   - note: non-numeric
     data: {}

--- a/tests/interpreter/cases/some/tests.yaml
+++ b/tests/interpreter/cases/some/tests.yaml
@@ -76,7 +76,7 @@ cases:
         import future.keywords
         x { some [1] in [[1, 2]] }
     query: data.test
-    error: "array length mismatch. Expected 1 got 2."
+    error: "mismatch in number of array elements"
 
   - note: array-length-mismatch-skipped
     data: {}


### PR DESCRIPTION
- add a dedicated `compiler/destructuring_planner` feature that precomputes binding plans for assignments, parameters, and `some in` expressions
- enrich `ScopeContext` with same-scope tracking, local scheduling hints, and module globals so the planner enforces := shadowing rules without blocking parent scopes
- wire the planner through compiler, hoist, interpreter, and engine paths while updating binding plan variants and adding query traversal helpers for dependency analysis
- document the new planner architecture and ship interpreter regressions that exercise nested destructuring, shadowing, and error reporting