### PR TITLE
feat: Optimize C# binding interop

### DIFF
--- a/bindings/csharp/Regorus/SafeHandles.cs
+++ b/bindings/csharp/Regorus/SafeHandles.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+#nullable enable
+namespace Regorus
+{
+    internal sealed class RegorusEngineHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private RegorusEngineHandle() : base(ownsHandle: true)
+        {
+        }
+
+        internal static RegorusEngineHandle Create()
+        {
+            unsafe
+            {
+                var raw = Internal.API.regorus_engine_new();
+                if (raw is null)
+                {
+                    throw new InvalidOperationException("Failed to create Regorus engine.");
+                }
+
+                var handle = new RegorusEngineHandle();
+                handle.SetHandle((IntPtr)raw);
+                return handle;
+            }
+        }
+
+        internal static RegorusEngineHandle FromPointer(IntPtr pointer)
+        {
+            if (pointer == IntPtr.Zero)
+            {
+                throw new ArgumentException("Pointer cannot be zero.", nameof(pointer));
+            }
+
+            var handle = new RegorusEngineHandle();
+            handle.SetHandle(pointer);
+            return handle;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (!IsInvalid && !IsClosed)
+            {
+                unsafe
+                {
+                    Internal.API.regorus_engine_drop((Internal.RegorusEngine*)handle);
+                }
+                SetHandle(IntPtr.Zero);
+            }
+            return true;
+        }
+    }
+
+    internal sealed class RegorusCompiledPolicyHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private RegorusCompiledPolicyHandle() : base(ownsHandle: true)
+        {
+        }
+
+        internal static RegorusCompiledPolicyHandle FromPointer(IntPtr pointer)
+        {
+            if (pointer == IntPtr.Zero)
+            {
+                throw new ArgumentException("Pointer cannot be zero.", nameof(pointer));
+            }
+
+            var handle = new RegorusCompiledPolicyHandle();
+            handle.SetHandle(pointer);
+            return handle;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (!IsInvalid && !IsClosed)
+            {
+                unsafe
+                {
+                    Internal.API.regorus_compiled_policy_drop((Internal.RegorusCompiledPolicy*)handle);
+                }
+                SetHandle(IntPtr.Zero);
+            }
+            return true;
+        }
+    }
+}

--- a/bindings/csharp/Regorus/SchemaRegistry.cs
+++ b/bindings/csharp/Regorus/SchemaRegistry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using Regorus.Internal;
 
 #nullable enable
 namespace Regorus
@@ -21,14 +22,16 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when schema registration fails</exception>
         public static void RegisterResource(string name, string schemaJson)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            var schemaBytes = Encoding.UTF8.GetBytes(schemaJson + char.MinValue);
-            
-            fixed (byte* namePtr = nameBytes)
-            fixed (byte* schemaPtr = schemaBytes)
+            Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                CheckAndDropResult(Internal.API.regorus_resource_schema_register(namePtr, schemaPtr));
-            }
+                Utf8Marshaller.WithUtf8(schemaJson, schemaPtr =>
+                {
+                    unsafe
+                    {
+                        CheckAndDropResult(Internal.API.regorus_resource_schema_register((byte*)namePtr, (byte*)schemaPtr));
+                    }
+                });
+            });
         }
 
         /// <summary>
@@ -39,12 +42,14 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when the operation fails</exception>
         public static bool ContainsResource(string name)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            fixed (byte* namePtr = nameBytes)
+            return Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                var result = Internal.API.regorus_resource_schema_contains(namePtr);
-                return GetBoolResult(result);
-            }
+                unsafe
+                {
+                    var result = Internal.API.regorus_resource_schema_contains((byte*)namePtr);
+                    return GetBoolResult(result);
+                }
+            });
         }
 
         /// <summary>
@@ -93,12 +98,14 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when the operation fails</exception>
         public static bool RemoveResource(string name)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            fixed (byte* namePtr = nameBytes)
+            return Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                var result = Internal.API.regorus_resource_schema_remove(namePtr);
-                return GetBoolResult(result);
-            }
+                unsafe
+                {
+                    var result = Internal.API.regorus_resource_schema_remove((byte*)namePtr);
+                    return GetBoolResult(result);
+                }
+            });
         }
 
         /// <summary>
@@ -118,14 +125,16 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when schema registration fails</exception>
         public static void RegisterEffect(string name, string schemaJson)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            var schemaBytes = Encoding.UTF8.GetBytes(schemaJson + char.MinValue);
-            
-            fixed (byte* namePtr = nameBytes)
-            fixed (byte* schemaPtr = schemaBytes)
+            Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                CheckAndDropResult(Internal.API.regorus_effect_schema_register(namePtr, schemaPtr));
-            }
+                Utf8Marshaller.WithUtf8(schemaJson, schemaPtr =>
+                {
+                    unsafe
+                    {
+                        CheckAndDropResult(Internal.API.regorus_effect_schema_register((byte*)namePtr, (byte*)schemaPtr));
+                    }
+                });
+            });
         }
 
         /// <summary>
@@ -136,12 +145,14 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when the operation fails</exception>
         public static bool ContainsEffect(string name)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            fixed (byte* namePtr = nameBytes)
+            return Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                var result = Internal.API.regorus_effect_schema_contains(namePtr);
-                return GetBoolResult(result);
-            }
+                unsafe
+                {
+                    var result = Internal.API.regorus_effect_schema_contains((byte*)namePtr);
+                    return GetBoolResult(result);
+                }
+            });
         }
 
         /// <summary>
@@ -190,12 +201,14 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when the operation fails</exception>
         public static bool RemoveEffect(string name)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            fixed (byte* namePtr = nameBytes)
+            return Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                var result = Internal.API.regorus_effect_schema_remove(namePtr);
-                return GetBoolResult(result);
-            }
+                unsafe
+                {
+                    var result = Internal.API.regorus_effect_schema_remove((byte*)namePtr);
+                    return GetBoolResult(result);
+                }
+            });
         }
 
         /// <summary>

--- a/bindings/csharp/Regorus/TargetRegistry.cs
+++ b/bindings/csharp/Regorus/TargetRegistry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using Regorus.Internal;
 
 #nullable enable
 namespace Regorus
@@ -22,11 +23,13 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when target registration fails</exception>
         public static void RegisterFromJson(string targetJson)
         {
-            var targetBytes = Encoding.UTF8.GetBytes(targetJson + char.MinValue);
-            fixed (byte* targetPtr = targetBytes)
+            Utf8Marshaller.WithUtf8(targetJson, targetPtr =>
             {
-                CheckAndDropResult(Internal.API.regorus_register_target_from_json(targetPtr));
-            }
+                unsafe
+                {
+                    CheckAndDropResult(Internal.API.regorus_register_target_from_json((byte*)targetPtr));
+                }
+            });
         }
 
         /// <summary>
@@ -37,12 +40,14 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when the operation fails</exception>
         public static bool Contains(string name)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            fixed (byte* namePtr = nameBytes)
+            return Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                var result = Internal.API.regorus_target_registry_contains(namePtr);
-                return GetBoolResult(result);
-            }
+                unsafe
+                {
+                    var result = Internal.API.regorus_target_registry_contains((byte*)namePtr);
+                    return GetBoolResult(result);
+                }
+            });
         }
 
         /// <summary>
@@ -63,12 +68,14 @@ namespace Regorus
         /// <exception cref="Exception">Thrown when the operation fails</exception>
         public static bool Remove(string name)
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name + char.MinValue);
-            fixed (byte* namePtr = nameBytes)
+            return Utf8Marshaller.WithUtf8(name, namePtr =>
             {
-                var result = Internal.API.regorus_target_registry_remove(namePtr);
-                return GetBoolResult(result);
-            }
+                unsafe
+                {
+                    var result = Internal.API.regorus_target_registry_remove((byte*)namePtr);
+                    return GetBoolResult(result);
+                }
+            });
         }
 
         /// <summary>

--- a/bindings/csharp/Regorus/Utf8Marshaller.cs
+++ b/bindings/csharp/Regorus/Utf8Marshaller.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#nullable enable
+namespace Regorus.Internal
+{
+    /// <summary>
+    /// Helpers for marshaling managed strings to null-terminated UTF-8 buffers.
+    /// Provides stack-based storage for short lived conversions and pooled backing
+    /// for longer lived pinned buffers.
+    /// </summary>
+    internal static class Utf8Marshaller
+    {
+    // Mirrors BCL patterns (e.g., System.Text.Json encoding helpers) by stackalloc'ing
+    // up to 512 bytes to cover common short strings while keeping the stack usage well
+    // below typical per-frame limits; larger payloads fall back to pooled buffers.
+    private const int StackAllocThreshold = 512;
+
+        /// <summary>
+        /// Represents a pooled and pinned UTF-8 buffer suitable for scenarios where
+        /// the pointer must remain stable beyond the immediate call site (for example,
+        /// when referenced by another buffer passed to native code).
+        /// </summary>
+        internal sealed class PinnedUtf8 : IDisposable
+        {
+            private GCHandle _handle;
+            private byte[]? _buffer;
+            private bool _disposed;
+
+            internal unsafe PinnedUtf8(string value)
+            {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                var byteCount = Encoding.UTF8.GetByteCount(value);
+                _buffer = ArrayPool<byte>.Shared.Rent(byteCount + 1);
+
+                try
+                {
+                    var written = Encoding.UTF8.GetBytes(value, 0, value.Length, _buffer, 0);
+                    _buffer[written] = 0;
+
+                    _handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
+                    Pointer = (byte*)_handle.AddrOfPinnedObject();
+                    Length = written + 1;
+                }
+                catch
+                {
+                    ArrayPool<byte>.Shared.Return(_buffer);
+                    _buffer = null;
+                    throw;
+                }
+            }
+
+            internal unsafe byte* Pointer { get; }
+
+            internal int Length { get; }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                if (_handle.IsAllocated)
+                {
+                    _handle.Free();
+                }
+
+                if (_buffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(_buffer);
+                    _buffer = null;
+                }
+
+                _disposed = true;
+            }
+        }
+
+        internal unsafe delegate void Utf8PointerAction(byte* pointer);
+
+        internal static unsafe void WithUtf8(string value, Utf8PointerAction action)
+        {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
+            WithUtf8<object?>(value, ptr =>
+            {
+                action((byte*)ptr);
+                return null;
+            });
+        }
+
+        internal static T WithUtf8<T>(string value, Func<IntPtr, T> func)
+        {
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (func is null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            var required = byteCount + 1;
+
+            if (required <= StackAllocThreshold)
+            {
+                Span<byte> buffer = stackalloc byte[required];
+                return Invoke(value, func, buffer, byteCount);
+            }
+
+            var rented = ArrayPool<byte>.Shared.Rent(required);
+            try
+            {
+                Span<byte> buffer = rented;
+                return Invoke(value, func, buffer, byteCount);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        private static unsafe T Invoke<T>(string value, Func<IntPtr, T> func, Span<byte> buffer, int byteCount)
+        {
+            fixed (char* charPtr = value)
+            fixed (byte* bytePtr = buffer)
+            {
+                var written = Encoding.UTF8.GetBytes(charPtr, value.Length, bytePtr, byteCount);
+                bytePtr[written] = 0;
+                return func((IntPtr)bytePtr);
+            }
+        }
+
+        internal static PinnedUtf8 Pin(string value)
+        {
+            return new PinnedUtf8(value);
+        }
+    }
+}


### PR DESCRIPTION
- Introduce Utf8Marshaller helpers and SafeHandle wrappers so the managed API centralizes UTF-8 conversions and lifetime management for native pointers.
- Update Engine, Compiler, CompiledPolicy, SchemaRegistry, and TargetRegistry to rely on the new marshaller/safe handles, tightening disposal and reducing transient allocations during interop calls.
- Add allocation guard coverage in Regorus.Tests and report bytes/op in the compiled policy benchmark to surface future regressions.