### PR TITLE
feat: JWT verification builtins (#94)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +954,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.44",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1059,12 @@ checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1247,6 +1306,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "num_cpus",
+ "openssl",
  "prettydiff",
  "rand",
  "regex",
@@ -1587,6 +1647,12 @@ dependencies = [
  "uuid",
  "vsimd",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ time = ["dep:chrono", "dep:chrono-tz"]
 uuid = ["dep:uuid"]
 urlquery = ["dep:url"]
 yaml = ["serde_yaml"]
+jwt-openssl = ["openssl"]
 full-opa = [
     "base64",
     "base64url",
@@ -66,8 +67,7 @@ full-opa = [
     "time",
     "uuid",
     "urlquery",
-    "yaml",
-
+    "yaml"
     #"rego-extensions"
 ]
 
@@ -94,6 +94,9 @@ rego-extensions = []
 # This feature enables some testing utils for OPA tests.
 opa-testutil = []
 rand = ["dep:rand"]
+
+# Enable this feature to omit some restrictions in opa test environment
+weak-safety = []
 
 [dependencies]
 anyhow = { version = "1.0.45", default-features = false }
@@ -130,6 +133,8 @@ mimalloc = { package = "regorus-mimalloc", path = "mimalloc", version = "2.2.6",
 indexmap = { version = "2.12.1", default-features = false, features = ["serde"], optional = true }
 bincode = { version = "2.0.1", default-features = false, features = ["alloc", "serde"], optional = true }
 
+openssl = { version = "0.10.73", optional = true}
+
 [dev-dependencies]
 anyhow = "1.0.45"
 cfg-if = "1.0.0"
@@ -144,6 +149,7 @@ num_cpus = "1.16"
 
 [build-dependencies]
 anyhow = "1.0"
+openssl = { version = "0.10.73", optional = true}
 
 [profile.release]
 debug = true

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 anyhow = "1.0"
 regorus = { path  = "../..", default-features = false }
-serde_json = "1.0.140"
+serde_json = "1.0.149"
 parking_lot = { version = "0.12", optional = true }
 
 [profile.release]

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,22 @@ fn main() -> Result<()> {
         println!("cargo:rustc-env=GIT_HASH={git_hash}");
     }
 
+    // Verify OpenSSL version
+    #[cfg(feature = "jwt-openssl")]
+    {
+        use openssl::version;
+        // Minimal OpenSSL version that meets FIPS certification
+        let min_ver_num = 0x30000000i64;
+        let ver = version::version();
+        let ver_num = version::number();
+        if !ver.starts_with("OpenSSL") || ver_num < min_ver_num {
+            panic!(
+                "FATAL: OpenSSL version must be 3.0.0 or higher, found version: {}",
+                ver
+            );
+        }
+    }
+
     // Rerun only if build.rs changes.
     println!("cargo:rerun-if-changed=build.rs");
     Ok(())

--- a/src/builtins/jwt/backend.rs
+++ b/src/builtins/jwt/backend.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::*;
+use anyhow::Result;
+
+pub trait Backend {
+    fn encode_base64url(src: &[u8]) -> String;
+    fn decode_base64url(src: &str) -> Result<Vec<u8>>;
+
+    fn verify_hs256(token: &str, secret: &str) -> Result<bool>;
+    fn verify_hs384(token: &str, secret: &str) -> Result<bool>;
+    fn verify_hs512(token: &str, secret: &str) -> Result<bool>;
+
+    fn verify_rs256(token: &str, certificate: &str) -> Result<bool>;
+    fn verify_rs384(token: &str, certificate: &str) -> Result<bool>;
+    fn verify_rs512(token: &str, certificate: &str) -> Result<bool>;
+
+    fn verify_ps256(token: &str, certificate: &str) -> Result<bool>;
+    fn verify_ps384(token: &str, certificate: &str) -> Result<bool>;
+    fn verify_ps512(token: &str, certificate: &str) -> Result<bool>;
+
+    fn verify_es256(token: &str, certificate: &str) -> Result<bool>;
+    fn verify_es384(token: &str, certificate: &str) -> Result<bool>;
+    fn verify_es512(token: &str, certificate: &str) -> Result<bool>;
+}

--- a/src/builtins/jwt/backends/mod.rs
+++ b/src/builtins/jwt/backends/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(feature = "jwt-openssl")]
+pub mod openssl;

--- a/src/builtins/jwt/backends/openssl.rs
+++ b/src/builtins/jwt/backends/openssl.rs
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::builtins::jwt::backend::Backend;
+use crate::builtins::jwt::utils::split_token;
+use anyhow::{anyhow, Result};
+use openssl::base64;
+use openssl::bn::BigNum;
+use openssl::ec::{EcGroup, EcKey};
+use openssl::ecdsa::EcdsaSig;
+use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
+use openssl::pkey::{PKey, Public};
+use openssl::rsa::{Padding, Rsa};
+use openssl::sign::{Signer, Verifier};
+use openssl::x509::X509;
+use serde::Deserialize;
+
+use crate::*;
+
+#[derive(Deserialize)]
+struct Jwk {
+    kty: String,
+    n: Option<String>,   // for RSA
+    e: Option<String>,   // for RSA
+    crv: Option<String>, // for EC
+    x: Option<String>,   // for EC
+    y: Option<String>,   // for EC
+}
+
+fn verify_hmac(token: &str, secret: &str, hash_fn: MessageDigest) -> Result<bool> {
+    let (header, payload, signature) = split_token(token)?;
+    let sign_payload = &token[..header.len() + 1 + payload.len()];
+
+    let key = PKey::hmac(secret.as_bytes())?;
+    let mut signer = Signer::new(hash_fn, &key)?;
+    signer.update(sign_payload.as_bytes())?;
+
+    let expected_signature = signer.sign_to_vec()?;
+    let encoded_expected_signature = OpensslBackend::encode_base64url(&expected_signature);
+
+    Ok(signature == encoded_expected_signature)
+}
+
+/// Converts JWK json to public key
+fn jwk_to_pkey(jwk_json: &str) -> Result<PKey<Public>> {
+    let jwk: Jwk = serde_json::from_str(jwk_json).map_err(|e| anyhow!("Invalid JWK JSON: {e}"))?;
+
+    match jwk.kty.as_str() {
+        "RSA" => {
+            let n_b64 = jwk
+                .n
+                .ok_or_else(|| anyhow!("Missing 'n' value for RSA JWK"))?;
+            let e_b64 = jwk
+                .e
+                .ok_or_else(|| anyhow!("Missing 'e' value for RSA JWK"))?;
+
+            // Decode base64url modulus and exponent
+            let n_bytes = OpensslBackend::decode_base64url(&n_b64)
+                .map_err(|e| anyhow!("Failed to decode 'n': {e}"))?;
+            let e_bytes = OpensslBackend::decode_base64url(&e_b64)
+                .map_err(|e| anyhow!("Failed to decode 'e': {e}"))?;
+
+            let n = BigNum::from_slice(&n_bytes)?;
+            let e = BigNum::from_slice(&e_bytes)?;
+            let rsa = Rsa::from_public_components(n, e)?;
+            Ok(PKey::from_rsa(rsa)?)
+        }
+        "EC" => {
+            let crv = jwk
+                .crv
+                .ok_or_else(|| anyhow!("Missing 'crv' (curve name) for EC JWK"))?;
+            let x_b64 = jwk
+                .x
+                .ok_or_else(|| anyhow!("Missing 'x' coordinate for EC JWK"))?;
+            let y_b64 = jwk
+                .y
+                .ok_or_else(|| anyhow!("Missing 'y' coordinate for EC JWK"))?;
+
+            // Decode x and y base64url coordinates
+            let x_bytes = OpensslBackend::decode_base64url(&x_b64)
+                .map_err(|e| anyhow!("Failed to decode 'x': {e}"))?;
+            let y_bytes = OpensslBackend::decode_base64url(&y_b64)
+                .map_err(|e| anyhow!("Failed to decode 'y': {e}"))?;
+
+            let x = BigNum::from_slice(&x_bytes)?;
+            let y = BigNum::from_slice(&y_bytes)?;
+
+            // Select curve by `crv`
+            let nid = match crv.as_str() {
+                "P-256" => Nid::X9_62_PRIME256V1,
+                "P-384" => Nid::SECP384R1,
+                "P-521" => Nid::SECP521R1,
+                other => return Err(anyhow!("Unsupported EC curve: {}", other)),
+            };
+
+            // Build EC public key from (x, y)
+            let group = EcGroup::from_curve_name(nid)?;
+            let ec_key = EcKey::from_public_key_affine_coordinates(&group, &x, &y)?;
+            Ok(PKey::from_ec_key(ec_key)?)
+        }
+
+        other => Err(anyhow!("Unsupported key type '{}'", other)),
+    }
+}
+
+fn verify_key_footer(key: &str, footer: &'static str) -> Result<()> {
+    let trimmed = key.trim_end();
+    let expected_footer = format!("-----{}-----", footer.trim());
+
+    if trimmed.ends_with(&expected_footer) {
+        Ok(())
+    } else {
+        Err(anyhow!("Extra data after a PEM certificate block"))
+    }
+}
+
+/// Tries to extract public key from PEM data
+/// PEM data could be:
+/// - PEM encoded certificate
+/// - PEM encoded public key
+/// - JWK key (set) used to verify the signature
+fn extract_key(pem_data: &str) -> Result<PKey<Public>> {
+    // Try parsing PEM encoded certificate
+    if let Ok(cert) = X509::from_pem(pem_data.as_bytes()) {
+        verify_key_footer(pem_data, "END CERTIFICATE")?;
+        return cert.public_key().map_err(|e| anyhow!(e));
+    }
+    // Try parsing PEM encoded public key
+    if let Ok(pubkey) = PKey::public_key_from_pem(pem_data.as_bytes()) {
+        verify_key_footer(pem_data, "END PUBLIC KEY")?;
+        return Ok(pubkey);
+    }
+    // Try parsing JWK key (set)
+    if let Ok(pubkey) = jwk_to_pkey(pem_data) {
+        return Ok(pubkey);
+    }
+    Err(anyhow!("Unsupported PEM format or invalid data"))
+}
+
+fn verify_rsa(
+    token: &str,
+    certificate: &str,
+    hash_fn: MessageDigest,
+    padding: Padding,
+    is_es: bool,
+) -> Result<bool> {
+    let public_key = extract_key(certificate)?;
+
+    let (header, payload, signature) = split_token(token)?;
+    // Payload to sign: header.payload
+    let sign_payload = &token[..header.len() + 1 + payload.len()];
+    let mut decoded_signature = OpensslBackend::decode_base64url(signature)?;
+
+    if is_es {
+        if decoded_signature.len() % 2 != 0 {
+            return Err(anyhow!("Invalid signature length"));
+        }
+        let half_len = decoded_signature.len() / 2;
+        let r = BigNum::from_slice(&decoded_signature[..half_len])?;
+        let s = BigNum::from_slice(&decoded_signature[half_len..])?;
+
+        // Convert to DER encoding
+        let ecdsa_sig = EcdsaSig::from_private_components(r, s)?;
+        decoded_signature = ecdsa_sig.to_der()?;
+    }
+
+    // Create verifier
+    let mut verifier = Verifier::new(hash_fn, &public_key)?;
+    if padding != Padding::NONE {
+        verifier.set_rsa_padding(padding)?;
+    }
+    verifier.update(sign_payload.as_bytes())?;
+
+    // Verify signature
+    Ok(verifier.verify(&decoded_signature)?)
+}
+
+pub struct OpensslBackend;
+
+impl Backend for OpensslBackend {
+    fn encode_base64url(src: &[u8]) -> String {
+        let base64_encoded = base64::encode_block(src);
+        let mut result = String::with_capacity(base64_encoded.len());
+        for c in base64_encoded.chars() {
+            match c {
+                '+' => result.push('-'),
+                '/' => result.push('_'),
+                '=' => {}
+                other => result.push(other),
+            }
+        }
+        result
+    }
+
+    fn decode_base64url(src: &str) -> Result<Vec<u8>> {
+        let mut to_decode = src
+            .chars()
+            .map(|c| match c {
+                '-' => '+',
+                '_' => '/',
+                _ => c,
+            })
+            .collect::<String>();
+
+        let pad_len = 4 - to_decode.len() % 4;
+        if 0 < pad_len && pad_len < 4 {
+            to_decode.push_str(&"=".repeat(pad_len));
+        }
+
+        let result = base64::decode_block(&to_decode)?;
+        Ok(result)
+    }
+
+    fn verify_hs256(token: &str, secret: &str) -> Result<bool> {
+        verify_hmac(token, secret, MessageDigest::sha256())
+    }
+
+    fn verify_hs384(token: &str, secret: &str) -> Result<bool> {
+        verify_hmac(token, secret, MessageDigest::sha384())
+    }
+
+    fn verify_hs512(token: &str, secret: &str) -> Result<bool> {
+        verify_hmac(token, secret, MessageDigest::sha512())
+    }
+
+    fn verify_rs256(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha256(),
+            Padding::PKCS1,
+            false,
+        )
+    }
+
+    fn verify_rs384(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha384(),
+            Padding::PKCS1,
+            false,
+        )
+    }
+
+    fn verify_rs512(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha512(),
+            Padding::PKCS1,
+            false,
+        )
+    }
+
+    fn verify_ps256(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha256(),
+            Padding::PKCS1_PSS,
+            false,
+        )
+    }
+
+    fn verify_ps384(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha384(),
+            Padding::PKCS1_PSS,
+            false,
+        )
+    }
+
+    fn verify_ps512(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha512(),
+            Padding::PKCS1_PSS,
+            false,
+        )
+    }
+
+    fn verify_es256(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha256(),
+            Padding::NONE,
+            true,
+        )
+    }
+
+    fn verify_es384(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha384(),
+            Padding::NONE,
+            true,
+        )
+    }
+
+    fn verify_es512(token: &str, certificate: &str) -> Result<bool> {
+        verify_rsa(
+            token,
+            certificate,
+            MessageDigest::sha512(),
+            Padding::NONE,
+            true,
+        )
+    }
+}

--- a/src/builtins/jwt/mod.rs
+++ b/src/builtins/jwt/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+pub mod backend;
+mod backends;
+pub mod toolkit;
+pub mod utils;

--- a/src/builtins/jwt/toolkit.rs
+++ b/src/builtins/jwt/toolkit.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(feature = "jwt-openssl")]
+use crate::builtins::jwt::backends::openssl::OpensslBackend;
+
+#[cfg(feature = "jwt-openssl")]
+pub type JwtBackend = OpensslBackend;

--- a/src/builtins/jwt/utils.rs
+++ b/src/builtins/jwt/utils.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use anyhow::{anyhow, Result};
+
+pub fn split_token(token: &str) -> Result<(&str, &str, &str)> {
+    let mut parts = token.split('.');
+    let header = parts.next().ok_or_else(|| anyhow!("Missing JWT header"))?;
+    let payload = parts.next().ok_or_else(|| anyhow!("Missing JWT payload"))?;
+    let signature = parts
+        .next()
+        .ok_or_else(|| anyhow!("Missing JWT signature"))?;
+
+    if parts.next().is_some() {
+        return Err(anyhow!("JWT has more than 3 parts"));
+    }
+
+    Ok((header, payload, signature))
+}

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -49,6 +49,11 @@ mod utils;
 #[cfg(feature = "uuid")]
 mod uuid;
 
+#[cfg(feature = "jwt-openssl")]
+mod jwt;
+#[cfg(feature = "jwt-openssl")]
+mod token_verification;
+
 #[cfg(feature = "opa-testutil")]
 mod test;
 
@@ -108,6 +113,9 @@ lazy_static! {
 	opa::register(&mut m);
 	tracing::register(&mut m);
 	units::register(&mut m);
+
+	#[cfg(feature = "jwt-openssl")]
+	token_verification::register(&mut m);
 
 	#[cfg(feature = "opa-testutil")]
 	test::register(&mut m);

--- a/src/builtins/objects.rs
+++ b/src/builtins/objects.rs
@@ -337,24 +337,26 @@ fn remove(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> R
     Ok(Value::Object(obj))
 }
 
-fn is_subset(sup: &Value, sub: &Value) -> bool {
-    match (sup, sub) {
-        (Value::Object(sup), Value::Object(sub)) => {
-            sub.iter().all(|(k, vsub)| {
-                match sup.get(k) {
+fn is_subset(val1: &Value, val2: &Value) -> bool {
+    match (val1, val2) {
+        (Value::Object(obj1), Value::Object(obj2)) => {
+            obj2.iter().all(|(k, vsub)| {
+                match obj1.get(k) {
                     //		    Some(vsup @ Value::Object(_)) => is_subset(vsup, vsub),
                     Some(vsup) => is_subset(vsup, vsub),
                     _ => false,
                 }
             })
         }
-        (Value::Set(sup), Value::Set(sub)) => sub.is_subset(sup),
-        (Value::Array(sup), Value::Array(sub)) => sup.windows(sub.len()).any(|w| w == &sub[..]),
-        (Value::Array(sup), Value::Set(_)) => {
-            let sup = Value::from_set(sup.iter().cloned().collect());
-            is_subset(&sup, sub)
+        (Value::Set(set1), Value::Set(set2)) => set2.is_subset(set1),
+        (Value::Array(arr1), Value::Array(arr2)) => {
+            arr1.windows(arr2.len()).any(|w| w == &arr2[..])
         }
-        (sup, sub) => sup == sub,
+        (Value::Array(arr), Value::Set(_)) => {
+            let val = Value::from_set(arr.iter().cloned().collect());
+            is_subset(&val, val2)
+        }
+        (val1, val2) => val1 == val2,
     }
 }
 

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -234,7 +234,7 @@ fn parse_epoch(
             return Ok((Utc.timestamp_nanos(ns).fixed_offset(), None));
         }
 
-        Value::Array(arr) => match arr.as_slice() {
+        Value::Array(array) => match array.as_slice() {
             [Value::Number(num)] => {
                 let ns = num.as_i64().ok_or_else(|| {
                     arg.span()

--- a/src/builtins/token_verification.rs
+++ b/src/builtins/token_verification.rs
@@ -1,0 +1,453 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ast::{Expr, Ref};
+use crate::builtins;
+use crate::builtins::jwt::backend::Backend as _;
+use crate::builtins::jwt::toolkit::JwtBackend;
+use crate::builtins::jwt::utils::split_token;
+use crate::builtins::utils::{ensure_args_count, ensure_object, ensure_string};
+use crate::lexer::Span;
+use crate::value::Value;
+use alloc::collections::{BTreeMap, BTreeSet};
+
+use chrono::Utc;
+
+use crate::*;
+
+use anyhow::{anyhow, Result};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref ALLOWED_HEADER_KEYS: BTreeSet<Value> = {
+        let mut set = BTreeSet::new();
+        set.insert(Value::from("alg"));
+        set.insert(Value::from("typ"));
+        set.insert(Value::from("kid"));
+        set.insert(Value::from("cty"));
+        set
+    };
+    static ref KEY_TYP: Value = Value::from("typ");
+    static ref KEY_ALG: Value = Value::from("alg");
+    static ref KEY_ENC: Value = Value::from("enc");
+    static ref KEY_CTY: Value = Value::from("cty");
+    static ref KEY_AUD: Value = Value::from("aud");
+    static ref KEY_ISS: Value = Value::from("iss");
+    static ref KEY_EXP: Value = Value::from("exp");
+    static ref KEY_NBF: Value = Value::from("nbf");
+    static ref KEY_TIME: Value = Value::from("time");
+    static ref KEY_CERT: Value = Value::from("cert");
+    static ref KEY_SECRET: Value = Value::from("secret");
+}
+
+pub fn register(m: &mut builtins::BuiltinsMap<&'static str, builtins::BuiltinFcn>) {
+    m.insert("io.jwt.verify_hs256", (verify_hs256, 2));
+    m.insert("io.jwt.verify_hs384", (verify_hs384, 2));
+    m.insert("io.jwt.verify_hs512", (verify_hs512, 2));
+    m.insert("io.jwt.verify_rs256", (verify_rs256, 2));
+    m.insert("io.jwt.verify_rs384", (verify_rs384, 2));
+    m.insert("io.jwt.verify_rs512", (verify_rs512, 2));
+    m.insert("io.jwt.verify_ps256", (verify_ps256, 2));
+    m.insert("io.jwt.verify_ps384", (verify_ps384, 2));
+    m.insert("io.jwt.verify_ps512", (verify_ps512, 2));
+    m.insert("io.jwt.verify_es256", (verify_es256, 2));
+    m.insert("io.jwt.verify_es384", (verify_es384, 2));
+    m.insert("io.jwt.verify_es512", (verify_es512, 2));
+    m.insert("io.jwt.decode", (decode, 1));
+    m.insert("io.jwt.decode_verify", (decode_verify, 2));
+}
+
+type VerifyImpl = fn(&str, &str) -> Result<bool>;
+
+/// General wrapper for every Backend::verify_xxxxx function
+fn verify_wrapper(
+    buildin_name: &'static str,
+    span: &Span,
+    params: &[Ref<Expr>],
+    args: &[Value],
+    verify_impl: VerifyImpl,
+) -> Result<Value> {
+    ensure_args_count(span, buildin_name, params, args, 2)?;
+    let token = ensure_string(buildin_name, &params[0], &args[0])?;
+    let secret = ensure_string(buildin_name, &params[1], &args[1])?;
+    let verification_result = verify_impl(&token, &secret)?;
+
+    Ok(Value::Bool(verification_result))
+}
+
+fn verify_hs256(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_hs256",
+        span,
+        params,
+        args,
+        JwtBackend::verify_hs256,
+    )
+}
+
+fn verify_hs384(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_hs384",
+        span,
+        params,
+        args,
+        JwtBackend::verify_hs384,
+    )
+}
+
+fn verify_hs512(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_hs512",
+        span,
+        params,
+        args,
+        JwtBackend::verify_hs512,
+    )
+}
+
+fn verify_rs256(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_rs256",
+        span,
+        params,
+        args,
+        JwtBackend::verify_rs256,
+    )
+}
+
+fn verify_rs384(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_rs384",
+        span,
+        params,
+        args,
+        JwtBackend::verify_rs384,
+    )
+}
+
+fn verify_rs512(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_rs512",
+        span,
+        params,
+        args,
+        JwtBackend::verify_rs512,
+    )
+}
+
+fn verify_ps256(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_ps256",
+        span,
+        params,
+        args,
+        JwtBackend::verify_ps256,
+    )
+}
+
+fn verify_ps384(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_ps384",
+        span,
+        params,
+        args,
+        JwtBackend::verify_ps384,
+    )
+}
+
+fn verify_ps512(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_ps512",
+        span,
+        params,
+        args,
+        JwtBackend::verify_ps512,
+    )
+}
+
+fn verify_es256(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_es256",
+        span,
+        params,
+        args,
+        JwtBackend::verify_es256,
+    )
+}
+
+fn verify_es384(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_es384",
+        span,
+        params,
+        args,
+        JwtBackend::verify_es384,
+    )
+}
+
+fn verify_es512(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    verify_wrapper(
+        "io.jwt.verify_es512",
+        span,
+        params,
+        args,
+        JwtBackend::verify_es512,
+    )
+}
+
+fn decode(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {
+    let buildin_name = "io.jwt.decode";
+    ensure_args_count(span, buildin_name, params, args, 1)?;
+
+    let token = ensure_string(buildin_name, &params[0], &args[0])?;
+
+    let (header, payload, signature) = decode_impl(&token)?;
+    let result = vec![
+        Value::Object(header),
+        Value::Object(payload),
+        Value::from(signature),
+    ];
+
+    Ok(Value::from_array(result))
+}
+
+fn decode_verify(
+    span: &Span,
+    params: &[Ref<Expr>],
+    args: &[Value],
+    _strict: bool,
+) -> Result<Value> {
+    let buildin_name = "io.jwt.decode_verify";
+    ensure_args_count(span, buildin_name, params, args, 2)?;
+
+    let token = ensure_string(buildin_name, &params[0], &args[0])?;
+    let constraints = ensure_object(buildin_name, &params[1], args[1].clone())?;
+
+    match decode_verify_impl(&token, &constraints) {
+        Ok((header, payload)) => Ok(Value::from_array(vec![
+            Value::Bool(true),
+            Value::Object(header),
+            Value::Object(payload),
+        ])),
+        Err(_) => Ok(Value::from_array(vec![
+            Value::Bool(false),
+            Value::new_object(),
+            Value::new_object(),
+        ])),
+    }
+}
+
+type Object = Rc<BTreeMap<Value, Value>>;
+
+fn get_value<'a>(obj: &'a Object, key: &'a Value) -> Result<&'a Value> {
+    obj.get(key).ok_or_else(|| anyhow!("Value not found"))
+}
+
+fn verify_header(header: &Object) -> Result<()> {
+    if !header.iter().all(|(k, _)| ALLOWED_HEADER_KEYS.contains(k)) {
+        return Err(anyhow!("Failed to verify JWT header"));
+    }
+    Ok(())
+}
+
+fn verify_type(header: &Object) -> Result<()> {
+    let typ = get_value(header, &KEY_TYP)?.as_string()?;
+    if typ.as_ref() == "JWT" {
+        return Ok(());
+    }
+    Err(anyhow!("Non JWT tokens not supported"))
+}
+
+fn verify_algorithm(header: &Object, constraints: &Object) -> Result<()> {
+    if let Some(expected_val) = constraints.get(&KEY_ALG) {
+        let expected_alg = expected_val.as_string()?;
+        let alg = get_value(header, &KEY_ALG)?.as_string()?;
+        if alg != expected_alg {
+            return Err(anyhow!("Failed to verify algorithm"));
+        }
+    }
+    Ok(())
+}
+
+fn verify_audience(payload: &Object, constraints: &Object) -> Result<()> {
+    if let Some(expected_val) = constraints.get(&KEY_AUD) {
+        let expected_aud = expected_val.as_string()?;
+        let val = get_value(payload, &KEY_AUD)?;
+        match *val {
+            Value::String(ref aud) => {
+                if aud != expected_aud {
+                    return Err(anyhow!("Failed to verify audience"));
+                }
+            }
+            Value::Array(ref aud) => {
+                if !aud.contains(&Value::String(expected_aud.clone())) {
+                    return Err(anyhow!("Failed to verify audience"));
+                }
+            }
+            _ => {
+                return Err(anyhow!("Failed to verify audience"));
+            }
+        }
+    } else if payload.contains_key(&KEY_AUD) {
+        return Err(anyhow!("Failed to verify audience"));
+    }
+    Ok(())
+}
+
+fn verify_issuer(payload: &Object, constraints: &Object) -> Result<()> {
+    if let Some(val) = constraints.get(&KEY_ISS) {
+        let expected_iss = val.as_string()?;
+        let iss = get_value(payload, &KEY_ISS)?.as_string()?;
+        if iss != expected_iss {
+            return Err(anyhow!("Failed to verify issuer"));
+        }
+    }
+    Ok(())
+}
+
+fn verify_time(payload: &Object, constraints: &Object) -> Result<()> {
+    if let Some(time_val) = constraints.get(&KEY_TIME) {
+        let time = time_val.as_number()?;
+        if let Some(exp_val) = payload.get(&KEY_EXP) {
+            // Convert sec to nanosec
+            let exp_ns = exp_val
+                .as_number()?
+                .mul(&number::Number::from(1_000_000_000.))?;
+            if time >= &exp_ns {
+                return Err(anyhow!("Failed to verify time"));
+            }
+        }
+
+        if let Some(nbf_val) = payload.get(&KEY_NBF) {
+            // Convert sec to nanosec
+            let nbf_ns = nbf_val
+                .as_number()?
+                .mul(&number::Number::from(1_000_000_000.))?;
+            if time < &nbf_ns {
+                return Err(anyhow!("Failed to verify time"));
+            }
+        }
+    } else {
+        let now = number::Number::from(Utc::now().timestamp());
+        if let Some(exp_val) = payload.get(&KEY_EXP) {
+            if &now > exp_val.as_number()? {
+                return Err(anyhow!("Failed to verify time"));
+            }
+        }
+        if let Some(nbf_val) = payload.get(&KEY_NBF) {
+            if &now < nbf_val.as_number()? {
+                return Err(anyhow!("Failed to verify time"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_hmac(token: &str, constraints: &Object, verify_impl: VerifyImpl) -> Result<bool> {
+    let secret = get_value(constraints, &KEY_SECRET)?.as_string()?;
+    verify_impl(token, secret)
+}
+
+fn verify_rsa(token: &str, constraints: &Object, verify_impl: VerifyImpl) -> Result<bool> {
+    let cert = get_value(constraints, &KEY_CERT)?.as_string()?;
+    // cert may contain multiple keys
+    if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(cert) {
+        if let Some(keys) = json_val.get("keys").and_then(|k| k.as_array()) {
+            for key in keys {
+                if let Ok(key_json) = serde_json::to_string(key) {
+                    if let Ok(result) = verify_impl(token, &key_json) {
+                        if result {
+                            return Ok(result);
+                        }
+                    }
+                }
+            }
+        }
+        return Err(anyhow!("Failed to verify RSA"));
+    }
+    verify_impl(token, cert)
+}
+
+fn decode_verify_impl(token: &str, constraints: &Object) -> Result<(Object, Object)> {
+    let (header, payload, _) = decode_impl(token)?;
+
+    verify_header(&header)?;
+    verify_type(&header)?;
+    verify_algorithm(&header, constraints)?;
+    verify_audience(&payload, constraints)?;
+    verify_issuer(&payload, constraints)?;
+    verify_time(&payload, constraints)?;
+
+    let alg = get_value(&header, &KEY_ALG)?.as_string()?;
+    let result = match alg.as_ref() {
+        "HS256" => verify_hmac(token, constraints, JwtBackend::verify_hs256)?,
+        "HS384" => verify_hmac(token, constraints, JwtBackend::verify_hs384)?,
+        "HS512" => verify_hmac(token, constraints, JwtBackend::verify_hs512)?,
+        "RS256" => verify_rsa(token, constraints, JwtBackend::verify_rs256)?,
+        "RS384" => verify_rsa(token, constraints, JwtBackend::verify_rs384)?,
+        "RS512" => verify_rsa(token, constraints, JwtBackend::verify_rs512)?,
+        "PS256" => verify_rsa(token, constraints, JwtBackend::verify_ps256)?,
+        "PS384" => verify_rsa(token, constraints, JwtBackend::verify_ps384)?,
+        "PS512" => verify_rsa(token, constraints, JwtBackend::verify_ps512)?,
+        "ES256" => verify_rsa(token, constraints, JwtBackend::verify_es256)?,
+        "ES384" => verify_rsa(token, constraints, JwtBackend::verify_es384)?,
+        "ES512" => verify_rsa(token, constraints, JwtBackend::verify_es512)?,
+        _ => return Err(anyhow!("Unknown algorithm")),
+    };
+
+    if !result {
+        return Err(anyhow!("Failed to verify JWT"));
+    }
+
+    Ok((header, payload))
+}
+
+fn decode_impl(token: &str) -> Result<(Object, Object, String)> {
+    let (header, payload, signature) = split_token(token)?;
+
+    let header = Value::from_json_str(core::str::from_utf8(&JwtBackend::decode_base64url(
+        header,
+    )?)?)?;
+
+    if let Value::Object(ref header_data) = header {
+        // Restrict JWE support
+        if header_data.contains_key(&KEY_ENC) {
+            return Err(anyhow!("JWE not supported"));
+        }
+
+        // Support nested JWT
+        if let Some(value) = header_data.get(&KEY_CTY) {
+            if value.as_string()?.as_ref() == "JWT" {
+                let decoded_payload = JwtBackend::decode_base64url(payload)?;
+                let payload_str = core::str::from_utf8(&decoded_payload)?;
+
+                // Trim the first and the last chars if they are quotes: ""
+                let trimmed_payload = if payload_str.starts_with('"') && payload_str.ends_with('"')
+                {
+                    &payload_str[1..payload_str.len() - 1]
+                } else {
+                    payload_str
+                };
+                return decode_impl(trimmed_payload);
+            }
+        }
+    }
+
+    let payload = Value::from_json_str(core::str::from_utf8(&JwtBackend::decode_base64url(
+        payload,
+    )?)?)?;
+
+    let hex_sign: String = JwtBackend::decode_base64url(signature)?
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<String>>()
+        .join("");
+
+    if let Value::Object(header_data) = header {
+        if let Value::Object(payload_data) = payload {
+            return Ok((header_data, payload_data, hex_sign));
+        }
+    }
+
+    Err(anyhow!("Failed to decode JWT"))
+}

--- a/src/number.rs
+++ b/src/number.rs
@@ -686,11 +686,7 @@ impl Number {
     }
 
     fn ensure_integers(a: &Number, b: &Number) -> Option<(BigInt, BigInt)> {
-        if a.is_integer() && b.is_integer() {
-            Some((a.to_bigint_owned()?, b.to_bigint_owned()?))
-        } else {
-            None
-        }
+        (a.is_integer() && b.is_integer()).then_some((a.to_bigint_owned()?, b.to_bigint_owned()?))
     }
 
     fn ensure_integer(&self) -> Option<BigInt> {

--- a/src/rvm/vm/loops.rs
+++ b/src/rvm/vm/loops.rs
@@ -412,11 +412,8 @@ impl RegoVM {
                         }
                     };
 
-                    let key_value = if key_reg != value_reg {
-                        Some(self.get_register(key_reg)?.clone())
-                    } else {
-                        None
-                    };
+                    let key_value =
+                        (key_reg != value_reg).then_some(self.get_register(key_reg)?.clone());
                     let value_value = self.get_register(value_reg)?.clone();
 
                     let frame = self


### PR DESCRIPTION
**Implemented:**
- Implemented builtins: io.jwt.[decode|decode_verify|verify_xxxxx] (except verify_eddsa)
- Fully passed OPA tests: jwtbuiltins, jwtverifyhs[256|384|512], jwtverifyrsa
- Partially passed OPA tests: jwtdecodeverify (the ones that leverage io.jwt.verify_eddsa and io.jwt.encode_sign still do not pass)
- In order to enable customization of the crypto libraries behind JWT verification algorithms, this implementation introduces JWT Backend trait that describes common interface for JWT verification. The trait can be implemented using variable libraries, depending on user needs. The exact trait implementation is selected based on a feature provided to compiler. Currently only 1 inplementation of the JWT Backend is available (leverages OpenSSL as underlying crypto lib).

**To be implemented in the follow up PRs:**
- verify_eddsa support and token encoding builtins.

**Note** that I've also modified the implementation for opa tests in order to be able to run each test separately, not sure if it really belongs here.

Looking forward for a feedback