### PR TITLE
test: OPA RVM validation

### DIFF
--- a/src/compiler/hoist.rs
+++ b/src/compiler/hoist.rs
@@ -510,6 +510,7 @@ impl LoopHoister {
         query: &Query,
         parent_context: &ScopeContext,
     ) -> Result<ScopeContext> {
+        self.lookup.ensure_query_capacity(module_idx, query.qidx);
         let mut context = parent_context.clone();
         context.current_scope_bound_vars = parent_context.current_scope_bound_vars.clone();
 


### PR DESCRIPTION
- fixes:
  - ensure loop hoist lookups reserve query capacity and keep loop-var tables sized when compiling default rules
  - rebuild hoisting tables with the analyzer’s schedule when available so statement order matches evaluation

- OPA test
  - Also test using RVM workflow in OPA suite
  - Maintain a list of test folders that don't yet pass and skip them