### PR TITLE
fix: Integer underflow in lexer error message formatting

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -203,7 +203,7 @@ impl Source {
 
         let line_str = format!("{line}");
         let line_num_width = line_str.len() + 1;
-        let col_spaces = col as usize - 1;
+        let col_spaces = (col as usize).saturating_sub(1);
 
         format!(
             "\n--> {}:{}:{}\n{:<line_num_width$}|\n\

--- a/tests/interpreter/cases/call/basic.yaml
+++ b/tests/interpreter/cases/call/basic.yaml
@@ -75,4 +75,13 @@ cases:
         }
     query: data.test
     error: expects numeric argument.
-    
+
+  - note: multiline-member-access-should-error
+    data: {}
+    modules:
+      - |
+        package test
+        output := regex.
+        match("^a", "b")
+    query: data.test
+    error: invalid whitespace between . and identifier


### PR DESCRIPTION
See #518 

The example now produces:

```
Error adding policy:
--> example.rego:8:0
  |
8 | match("^hello", text)
  | ^
error: invalid whitespace between . and identifier
Input set successfully
Result: QueryResults {
    result: [],
}
```

fixes #518 