### PR TITLE
feat: implement `net.cidr_expand` builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ The following test suites don't pass fully due to missing builtins:
 - `jwtverifyhs512`
 - `jwtverifyrsa`
 - `netcidrcontainsmatches`
-- `netcidrexpand`
 - `netcidrintersects`
 - `netcidrmerge`
 - `netcidroverlap`

--- a/tests/opa.passing
+++ b/tests/opa.passing
@@ -47,6 +47,7 @@ v0/negation
 v0/nestedreferences
 v0/netcidrisvalid
 v0/netcidrcontains
+v0/netcidrexpand
 v0/numbersrange
 v0/numbersrangestep
 v0/objectfilter
@@ -153,6 +154,7 @@ v1/negation
 v1/nestedreferences
 v1/netcidrcontains
 v1/netcidrisvalid
+v1/netcidrexpand
 v1/numbersrange
 v1/numbersrangestep
 v1/objectfilter


### PR DESCRIPTION
Implements `net.cidr_expand` from https://github.com/microsoft/regorus/issues/96.

@anakrish the rvm implementation seems to have caused some issues with clippy checking lifetimes during precommit hooks:
```
123 - impl<'a> Serialize for BinarySetRef<'a> {
123 + impl Serialize for BinarySetRef<'_> {
    |

error: the following explicit lifetimes could be elided: 'a
   --> src/rvm/program/serialization/value.rs:138:6
    |
138 | impl<'a> Serialize for BinaryObjectRef<'a> {
    |      ^^                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
138 - impl<'a> Serialize for BinaryObjectRef<'a> {
138 + impl Serialize for BinaryObjectRef<'_> {
    |

error: the following explicit lifetimes could be elided: 'a
   --> src/rvm/program/serialization/value.rs:153:6
    |
153 | impl<'a> Serialize for BinaryEntryRef<'a> {
    |      ^^                               ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
153 - impl<'a> Serialize for BinaryEntryRef<'a> {
153 + impl Serialize for BinaryEntryRef<'_> {
    |

error: could not compile `regorus` (lib) due to 19 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `regorus` (lib test) due to 19 previous errors
error: failed to push some refs to 'github.com:tjons/regorus.git'
```

is this expected?