### PR TITLE
chore: Add clippy lints

### DIFF
--- a/.github/actions/toolchains/rust/action.yml
+++ b/.github/actions/toolchains/rust/action.yml
@@ -4,7 +4,7 @@ inputs:
   toolchain:
     description: 'Rust toolchain version'
     required: false
-    default: '1.89.0'
+    default: '1.92.0'
   components:
     description: 'Additional components to install'
     required: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Regorus** is
 
   - *Rego*-*Rus(t)*  - A fast, light-weight [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/)
-   interpreter written in Rust.
+    interpreter written in Rust.
   - *Rigorous* - A rigorous enforcer of well-defined Rego semantics.
 
 Regorus is also

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_const_for_fn, clippy::pattern_type_mismatch)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/builtins/aggregates.rs
+++ b/src/builtins/aggregates.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_numeric};

--- a/src/builtins/arrays.rs
+++ b/src/builtins/arrays.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::as_conversions)]
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;

--- a/src/builtins/comparison.rs
+++ b/src/builtins/comparison.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 use crate::ast::BoolOp;
 use crate::value::Value;
 

--- a/src/builtins/conversions.rs
+++ b/src/builtins/conversions.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::unseparated_literal_suffix, clippy::pattern_type_mismatch)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::ensure_args_count;

--- a/src/builtins/encoding.rs
+++ b/src/builtins/encoding.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names, clippy::pattern_type_mismatch)]
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;

--- a/src/builtins/glob.rs
+++ b/src/builtins/glob.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_string, ensure_string_collection};

--- a/src/builtins/graph.rs
+++ b/src/builtins/graph.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_object};

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,6 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::shadow_unrelated,
+    clippy::unwrap_used,
+    clippy::missing_const_for_fn,
+    clippy::option_if_let_else,
+    clippy::semicolon_if_nothing_returned,
+    clippy::useless_let_if_seq
+)] // builtins perform validated indexing and intentional arithmetic/string ops
+
 mod aggregates;
 mod arrays;
 mod bitwise;

--- a/src/builtins/net.rs
+++ b/src/builtins/net.rs
@@ -1,3 +1,10 @@
+#![allow(
+    clippy::panic,
+    clippy::expect_used,
+    clippy::needless_continue,
+    clippy::unused_trait_names
+)] // net builtins panic/expect in invariant checks
+
 use core::net::IpAddr;
 use ipnet::IpNet;
 use std::format;

--- a/src/builtins/numbers.rs
+++ b/src/builtins/numbers.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::unseparated_literal_suffix,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
+
 use crate::ast::{ArithOp, Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_numeric};

--- a/src/builtins/objects.rs
+++ b/src/builtins/objects.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_array, ensure_object};

--- a/src/builtins/regex.rs
+++ b/src/builtins/regex.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::as_conversions)]
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;

--- a/src/builtins/semver.rs
+++ b/src/builtins/semver.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::as_conversions, clippy::pattern_type_mismatch)]
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;

--- a/src/builtins/sets.rs
+++ b/src/builtins/sets.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_set};

--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::unseparated_literal_suffix,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
+
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::indexing_slicing)]
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
+#![allow(
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_numeric, ensure_string};

--- a/src/builtins/time/compat.rs
+++ b/src/builtins/time/compat.rs
@@ -31,6 +31,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::unseparated_literal_suffix,
+    clippy::pattern_type_mismatch
+)] // ported Go time parsing uses intentional arithmetic and explicit suffixes
+
 use crate::*;
 use core::fmt;
 use core::iter;
@@ -584,6 +590,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::unused_trait_names,
+        clippy::as_conversions
+    )] // test fixtures build durations with unwrap for brevity
     use chrono::{Datelike, Month, TimeZone, Timelike, Weekday};
     use chrono_tz::PST8PDT;
 

--- a/src/builtins/time/diff.rs
+++ b/src/builtins/time/diff.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT and Apache 2.0 License.
-
+#![allow(clippy::as_conversions, clippy::unused_trait_names)]
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, Timelike};
 

--- a/src/builtins/tracing.rs
+++ b/src/builtins/tracing.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_string};

--- a/src/builtins/types.rs
+++ b/src/builtins/types.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::indexing_slicing, clippy::pattern_type_mismatch)]
 
 use crate::ast::{Expr, Ref};
 use crate::builtins;

--- a/src/builtins/units.rs
+++ b/src/builtins/units.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
+#![allow(clippy::unused_trait_names)]
 use alloc::borrow::Cow;
 use core::str::FromStr;
 

--- a/src/builtins/utils.rs
+++ b/src/builtins/utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
 use crate::ast::{Expr, Ref};
 use crate::lexer::Span;
 use crate::number::Number;

--- a/src/builtins/uuid.rs
+++ b/src/builtins/uuid.rs
@@ -1,6 +1,6 @@
+#![allow(clippy::missing_const_for_fn, clippy::as_conversions)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 use crate::ast::{Expr, Ref};
 use crate::builtins;
 use crate::builtins::utils::{ensure_args_count, ensure_string};

--- a/src/compiled_policy.rs
+++ b/src/compiled_policy.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::redundant_pub_crate,
+    clippy::missing_const_for_fn,
+    clippy::option_if_let_else,
+    clippy::pattern_type_mismatch
+)]
 
 use crate::ast::*;
 use crate::compiler::hoist::HoistedLoopsLookup;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::missing_const_for_fn,
+    clippy::option_if_let_else,
+    clippy::if_then_some_else_none,
+    clippy::unused_self,
+    clippy::semicolon_if_nothing_returned,
+    clippy::useless_let_if_seq
+)]
 //! Compiler-related functionality for Regorus.
 //!
 //! This module contains utilities and data structures used during

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names)]
 
 //! Compilation context types shared across compiler components.
 //!

--- a/src/compiler/destructuring_planner/assignment.rs
+++ b/src/compiler/destructuring_planner/assignment.rs
@@ -1,5 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::unreachable,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 //! Assignment-specific planning utilities.
 

--- a/src/compiler/destructuring_planner/context.rs
+++ b/src/compiler/destructuring_planner/context.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::redundant_pub_crate)]
 
 //! Context traits shared across planner submodules.
 

--- a/src/compiler/destructuring_planner/destructuring.rs
+++ b/src/compiler/destructuring_planner/destructuring.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::redundant_pub_crate,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 //! Functions responsible for building destructuring plans.
 

--- a/src/compiler/destructuring_planner/error.rs
+++ b/src/compiler/destructuring_planner/error.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 //! Error definitions for the destructuring planner.
 
 use alloc::format;

--- a/src/compiler/destructuring_planner/parameters.rs
+++ b/src/compiler/destructuring_planner/parameters.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names)]
 
 //! Planner helpers for function parameters and loop indices.
 

--- a/src/compiler/destructuring_planner/plans.rs
+++ b/src/compiler/destructuring_planner/plans.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names, clippy::pattern_type_mismatch)]
 
 //! Core data structures used by the destructuring planner.
 

--- a/src/compiler/destructuring_planner/some_in.rs
+++ b/src/compiler/destructuring_planner/some_in.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 //! Planner support for `some .. in` expressions.
 
 use alloc::collections::BTreeSet;

--- a/src/compiler/destructuring_planner/utils.rs
+++ b/src/compiler/destructuring_planner/utils.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::redundant_pub_crate,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 //! Shared helper routines for the destructuring planner modules.
 

--- a/src/compiler/hoist.rs
+++ b/src/compiler/hoist.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 //! Loop hoisting functionality for compilation.
 //!
@@ -277,6 +283,7 @@ impl HoistedLoopsLookup {
         self.query_contexts.truncate_modules(module_count);
     }
 
+    #[cfg(debug_assertions)]
     pub fn module_len(&self) -> usize {
         self.statement_loops.module_len()
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::missing_const_for_fn,
+    clippy::semicolon_if_nothing_returned,
+    clippy::print_stderr,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use crate::ast::*;
 use crate::compiled_policy::CompiledPolicy;

--- a/src/indexchecker.rs
+++ b/src/indexchecker.rs
@@ -1,7 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
+#![allow(
+    clippy::panic_in_result_fn,
+    clippy::arithmetic_side_effects,
+    clippy::shadow_unrelated,
+    clippy::unused_self,
+    clippy::pattern_type_mismatch
+)]
 #![cfg(debug_assertions)]
+#![allow(clippy::panic)] // debug-only index checks panic on invariants
 
 use crate::ast::*;
 use alloc::collections::BTreeSet;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,5 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::unimplemented,
+    clippy::panic_in_result_fn,
+    clippy::shadow_unrelated,
+    clippy::missing_const_for_fn,
+    clippy::semicolon_if_nothing_returned,
+    clippy::useless_let_if_seq,
+    clippy::option_if_let_else,
+    clippy::unused_self,
+    clippy::print_stderr,
+    clippy::needless_continue,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use crate::ast::*;
 use crate::builtins::{self, BuiltinFcn};
@@ -3432,6 +3449,7 @@ impl Interpreter {
     }
 
     /// Evaluate a default rule and return the resulting value for compiler consumers.
+    #[cfg(feature = "rvm")]
     pub fn eval_default_rule_for_compiler(&mut self, rule_path: &str) -> Result<Value> {
         self.input = Value::Undefined;
         self.data = Value::Undefined;

--- a/src/interpreter/target/resolve.rs
+++ b/src/interpreter/target/resolve.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::indexing_slicing)]
 
 use super::super::error::TargetCompileError;
 #[cfg(feature = "azure_policy")]

--- a/src/languages/azure_rbac/ast/expr.rs
+++ b/src/languages/azure_rbac/ast/expr.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_const_for_fn)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/languages/azure_rbac/ast/operators.rs
+++ b/src/languages/azure_rbac/ast/operators.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_const_for_fn, clippy::pattern_type_mismatch)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/languages/azure_rbac/parser/condition_parser.rs
+++ b/src/languages/azure_rbac/parser/condition_parser.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names)]
+#![allow(missing_debug_implementations)] // parser structs are internal; Debug not required
 
 use alloc::boxed::Box;
 use alloc::format;

--- a/src/languages/azure_rbac/parser/error.rs
+++ b/src/languages/azure_rbac/parser/error.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::pattern_type_mismatch)]
 
 use alloc::string::String;
 

--- a/src/languages/azure_rbac/parser/primary.rs
+++ b/src/languages/azure_rbac/parser/primary.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::arithmetic_side_effects, clippy::unused_trait_names)]
 
 use alloc::format;
 use alloc::string::{String, ToString};

--- a/src/languages/azure_rbac/tests.rs
+++ b/src/languages/azure_rbac/tests.rs
@@ -5,6 +5,7 @@
 
 #[cfg(test)]
 mod condition_tests {
+    #![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)] // tests unwrap/expect to assert parse results
     use crate::languages::azure_rbac::parser::*;
     use alloc::string::String;
     use alloc::vec;

--- a/src/languages/rego/compiler/comprehensions.rs
+++ b/src/languages/rego/compiler/comprehensions.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::as_conversions)]
 
 use super::{CompilationContext, Compiler, ComprehensionType, ContextType, Register, Result};
 use crate::ast::{ExprRef, Query};

--- a/src/languages/rego/compiler/core.rs
+++ b/src/languages/rego/compiler/core.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::as_conversions,
+    clippy::unused_trait_names
+)]
 
 use super::{CompilationContext, Compiler, CompilerError, Register, Result, Scope};
 use crate::ast::ExprRef;

--- a/src/languages/rego/compiler/destructuring.rs
+++ b/src/languages/rego/compiler/destructuring.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::pattern_type_mismatch)]
 use super::Compiler;
 use super::Register;
 use crate::compiler::destructuring_planner::plans::{

--- a/src/languages/rego/compiler/error.rs
+++ b/src/languages/rego/compiler/error.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::pattern_type_mismatch)]
 
 use alloc::format;
 use alloc::string::String;

--- a/src/languages/rego/compiler/expressions.rs
+++ b/src/languages/rego/compiler/expressions.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names, clippy::pattern_type_mismatch)]
 
 mod collection_literals;
 mod operations;

--- a/src/languages/rego/compiler/expressions/collection_literals.rs
+++ b/src/languages/rego/compiler/expressions/collection_literals.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{Compiler, Register, Result};
 use crate::ast::ExprRef;

--- a/src/languages/rego/compiler/expressions/operations.rs
+++ b/src/languages/rego/compiler/expressions/operations.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::pattern_type_mismatch)]
 
 use super::{Compiler, CompilerError, Register, Result};
 use crate::ast::{ArithOp, BinOp, BoolOp, ExprRef};

--- a/src/languages/rego/compiler/function_calls.rs
+++ b/src/languages/rego/compiler/function_calls.rs
@@ -1,5 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::unseparated_literal_suffix,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{Compiler, CompilerError, Register, Result};
 use crate::ast::ExprRef;

--- a/src/languages/rego/compiler/loops.rs
+++ b/src/languages/rego/compiler/loops.rs
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{CompilationContext, Compiler, CompilerError, ContextType, Register, Result};
 use crate::ast::{self, ExprRef, LiteralStmt, Query};

--- a/src/languages/rego/compiler/mod.rs
+++ b/src/languages/rego/compiler/mod.rs
@@ -1,3 +1,11 @@
+#![allow(
+    missing_debug_implementations,
+    clippy::missing_const_for_fn,
+    clippy::option_if_let_else,
+    clippy::if_then_some_else_none,
+    clippy::unused_self
+)] // compiler internals do not require Debug
+
 mod comprehensions;
 mod core;
 mod destructuring;

--- a/src/languages/rego/compiler/program.rs
+++ b/src/languages/rego/compiler/program.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{Compiler, CompilerError, Result};
 use crate::interpreter::Interpreter;

--- a/src/languages/rego/compiler/queries.rs
+++ b/src/languages/rego/compiler/queries.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{Compiler, CompilerError, ComprehensionType, ContextType, Result};
 use crate::ast::{self, LiteralStmt, Query};

--- a/src/languages/rego/compiler/references.rs
+++ b/src/languages/rego/compiler/references.rs
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{Compiler, CompilerError, Register, Result, WorklistEntry};
 use crate::lexer::Span;

--- a/src/languages/rego/compiler/rules.rs
+++ b/src/languages/rego/compiler/rules.rs
@@ -1,5 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::shadow_unrelated,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use super::{CompilationContext, Compiler, CompilerError, ContextType, Result, WorklistEntry};
 use crate::ast::{Expr, Rule, RuleHead};
@@ -105,12 +114,11 @@ impl<'a> Compiler<'a> {
     }
 
     fn find_module_index_for_rule(&self, rule_ref: &crate::ast::NodeRef<Rule>) -> Result<u32> {
-        let rule_ptr = rule_ref.as_ref() as *const Rule;
+        let rule = rule_ref.as_ref();
 
         for (module_idx, module) in self.policy.get_modules().iter().enumerate() {
             for policy_rule in &module.policy {
-                let policy_rule_ptr = policy_rule.as_ref() as *const Rule;
-                if policy_rule_ptr == rule_ptr {
+                if core::ptr::eq(policy_rule.as_ref(), rule) {
                     return Ok(module_idx as u32);
                 }
             }
@@ -126,12 +134,11 @@ impl<'a> Compiler<'a> {
     ) -> Result<(String, u32)> {
         if let Some(rule_definitions) = rules.get(rule_path) {
             if let Some(first_rule_ref) = rule_definitions.first() {
-                let rule_ptr = first_rule_ref.as_ref() as *const Rule;
+                let rule = first_rule_ref.as_ref();
 
                 for (module_index, module) in self.policy.get_modules().iter().enumerate() {
                     for policy_rule in &module.policy {
-                        let policy_rule_ptr = policy_rule.as_ref() as *const Rule;
-                        if policy_rule_ptr == rule_ptr {
+                        if core::ptr::eq(policy_rule.as_ref(), rule) {
                             let package_path =
                                 match get_path_string(&module.package.refr, Some("data")) {
                                     Ok(path) => path,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,5 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::std_instead_of_core,
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::missing_const_for_fn,
+    clippy::semicolon_if_nothing_returned,
+    clippy::unseparated_literal_suffix,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
+#![allow(missing_debug_implementations)] // lexer types are internal
 
 use crate::*;
 use core::cmp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,104 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// Unsafe code should not be used.
+// Hard to reason about correctness, and maintainability.
+#![forbid(unsafe_code)]
+// Ensure that all lint names are valid.
+#![deny(unknown_lints)]
+// Fail-fast lints: correctness, safety, and API surface
+#![deny(
+    // Panic sources - catch all ways code can panic
+    clippy::panic, // forbid explicit panic! macro
+    clippy::unreachable, // catches unreachable! macro usage
+    clippy::todo, // blocks remaining todo! placeholders
+    clippy::unimplemented, // blocks unimplemented! placeholders
+    clippy::unwrap_used, // reject Result/Option unwraps
+    clippy::expect_used, // reject expect with panic messages
+    clippy::manual_assert, // prefer assert! over manual if/panic
+    clippy::indexing_slicing, // reject unchecked [] indexing
+    clippy::arithmetic_side_effects, // reject overflowing/unchecked math
+    clippy::panic_in_result_fn, // disallow panic inside functions returning Result
+
+    // Rust warnings/upstream
+    dead_code, // ban unused items
+    deprecated, // prevent use of deprecated APIs
+    deprecated_in_future, // catch items scheduled for deprecation
+    exported_private_dependencies, // avoid leaking private deps in public API
+    future_incompatible, // catch patterns slated to break
+    invalid_doc_attributes, // ensure doc attributes are valid
+    keyword_idents, // disallow identifiers that are keywords
+    macro_use_extern_crate, // block legacy macro_use extern crate
+    missing_debug_implementations, // require Debug on public types
+    // TODO: Address in future pass
+    // missing_docs, // require docs on public items
+    non_ascii_idents, // disallow non-ASCII identifiers
+    nonstandard_style, // enforce idiomatic naming/style
+    noop_method_call, // catch no-op method calls
+    trivial_bounds, // forbid useless trait bounds
+    trivial_casts, // block needless casts
+    unreachable_code, // catch dead/unreachable code
+    unreachable_patterns, // catch unreachable match arms
+    // TODO: Address in future pass
+    // unreachable_pub,
+    unused_extern_crates, // remove unused extern crate declarations
+    unused_import_braces, // avoid unused braces in imports
+    absolute_paths_not_starting_with_crate, // enforce crate:: prefix for absolute paths
+
+    // Unsafe code / low-level hazards
+    clippy::unseparated_literal_suffix, // enforce underscore before literal suffixes
+    clippy::print_stderr, // discourage printing to stderr
+    clippy::use_debug, // discourage Debug formatting in display contexts
+
+    // Documentation & diagnostics
+    // TODO: Address in future pass
+    // clippy::doc_link_with_quotes, // avoid quoted intra-doc links
+    // clippy::doc_markdown, // flag bad Markdown in docs
+    // clippy::missing_docs_in_private_items, // require docs on private items
+    // clippy::missing_errors_doc, // require docs for error cases
+
+    // API correctness / style
+    clippy::missing_const_for_fn, // suggest const fn where possible
+    clippy::option_if_let_else, // prefer map_or/unwrap_or_else over if/let
+    clippy::if_then_some_else_none, // prefer Option combinators over if/else
+    clippy::semicolon_if_nothing_returned, // enforce trailing semicolon for unit
+    clippy::unused_self, // remove unused self parameters
+    clippy::used_underscore_binding, // avoid using bindings prefixed with _
+    clippy::useless_let_if_seq, // simplify let-if sequences
+    clippy::similar_names, // flag confusingly similar identifiers
+    clippy::shadow_unrelated, // discourage shadowing unrelated variables
+    clippy::redundant_pub_crate, // avoid pub(crate) on already pub items
+    clippy::wildcard_dependencies, // disallow wildcard Cargo dependency versions
+    // TODO: Address in future pass
+    // clippy::wildcard_imports, // discourage glob imports
+
+    // Numeric correctness
+    // TODO: Address in future pass
+    clippy::float_cmp, // avoid exact float equality checks
+    clippy::float_cmp_const, // avoid comparing floats to consts directly
+    clippy::float_equality_without_abs, // require tolerance in float equality
+    clippy::suspicious_operation_groupings, // catch ambiguous operator precedence
+
+    // no_std hygiene
+    clippy::std_instead_of_core, // prefer core/alloc over std in no_std
+
+    // Misc polish
+    clippy::dbg_macro, // forbid dbg! in production code
+    clippy::debug_assert_with_mut_call, // avoid mutating inside debug_assert
+    clippy::empty_line_after_outer_attr, // enforce spacing after outer attrs
+    clippy::empty_structs_with_brackets, // use unit structs without braces
+)]
+// Advisory lints: useful, but not fatal
+#![warn(
+    clippy::assertions_on_result_states, // avoid asserts on Result state
+    clippy::match_like_matches_macro, // prefer matches! macro over verbose match
+    clippy::needless_continue, // remove redundant continue statements
+    clippy::unused_trait_names, // drop unused trait imports
+    clippy::verbose_file_reads, // prefer concise file read helpers
+    clippy::as_conversions, // discourage lossy as casts
+    clippy::pattern_type_mismatch, // catch mismatched types in patterns
+)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(unknown_lints)]
-#![allow(clippy::doc_lazy_continuation)]
 // Use README.md as crate documentation.
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 // We'll default to building for no_std - use core, alloc instead of std.
@@ -86,10 +181,10 @@ use std::collections::{hash_map::Entry as MapEntry, HashMap as Map, HashSet as S
 use alloc::collections::{btree_map::Entry as MapEntry, BTreeMap as Map, BTreeSet as Set};
 
 use alloc::{
-    borrow::ToOwned,
+    borrow::ToOwned as _,
     boxed::Box,
     format,
-    string::{String, ToString},
+    string::{String, ToString as _},
     vec,
     vec::Vec,
 };
@@ -414,6 +509,7 @@ impl fmt::Debug for dyn Extension {
 pub mod coverage {
     use crate::*;
 
+    #[allow(missing_debug_implementations)]
     #[derive(Default, serde::Serialize, serde::Deserialize)]
     /// Coverage information about a rego policy file.
     pub struct File {
@@ -430,6 +526,7 @@ pub mod coverage {
         pub not_covered: alloc::collections::BTreeSet<u32>,
     }
 
+    #[allow(missing_debug_implementations)]
     #[derive(Default, serde::Serialize, serde::Deserialize)]
     /// Policy coverage report.
     pub struct Report {
@@ -444,6 +541,7 @@ pub mod coverage {
         /// Lines that are not covered are red.
         ///
         /// <img src="https://github.com/microsoft/regorus/blob/main/docs/coverage.png?raw=true">
+        #[allow(clippy::arithmetic_side_effects)]
         pub fn to_string_pretty(&self) -> anyhow::Result<String> {
             let mut s = String::default();
             s.push_str("COVERAGE REPORT:\n");
@@ -454,8 +552,8 @@ pub mod coverage {
                 }
 
                 s.push_str(&format!("{}:\n", file.path));
-                for (line, code) in file.code.split('\n').enumerate() {
-                    let line = line as u32 + 1;
+                for (line_idx, code) in file.code.split('\n').enumerate() {
+                    let line = u32::try_from(line_idx + 1).unwrap_or(u32::MAX);
                     if file.not_covered.contains(&line) {
                         s.push_str(&format!("\x1b[31m {line:4}  {code}\x1b[0m\n"));
                     } else if file.covered.contains(&line) {

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -1,5 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::std_instead_of_core,
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::missing_const_for_fn,
+    clippy::if_then_some_else_none,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 //! Lookup table for associating data structures with AST nodes.
 //!

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,5 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::float_cmp,
+    clippy::unwrap_used,
+    clippy::unreachable,
+    clippy::option_if_let_else,
+    clippy::unseparated_literal_suffix,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use alloc::format;
 use alloc::string::{String, ToString};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::missing_const_for_fn,
+    clippy::semicolon_if_nothing_returned,
+    clippy::unused_self,
+    clippy::print_stderr,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
+#![allow(missing_debug_implementations)] // parser types are internal
 
 use crate::ast::*;
 use crate::lexer::*;

--- a/src/policy_info.rs
+++ b/src/policy_info.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(missing_debug_implementations)] // policy info structs used for serialization only
+
 #[cfg(feature = "azure_policy")]
 use crate::engine::PolicyParameters;
 use crate::*;

--- a/src/query/traversal.rs
+++ b/src/query/traversal.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::if_then_some_else_none,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(missing_debug_implementations, clippy::pattern_type_mismatch)] // registry internals are not debug logged
 #![allow(dead_code)]
 use crate::*;
 use core::fmt;

--- a/src/registry/tests/core.rs
+++ b/src/registry/tests/core.rs
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::shadow_unrelated,
+    clippy::assertions_on_result_states
+)] // registry tests unwrap/panic to assert outcomes
+
 use super::super::registry::*;
 use crate::{schema::Schema, *};
 use serde_json::json;

--- a/src/registry/tests/effect.rs
+++ b/src/registry/tests/effect.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable,
+    clippy::indexing_slicing,
+    clippy::assertions_on_result_states,
+    clippy::pattern_type_mismatch
+)] // registry effect tests unwrap/panic for invariant checks
+
 use super::super::registry::*;
 use crate::{
     registry::{instances::EFFECT_SCHEMA_REGISTRY, schemas::effect},

--- a/src/registry/tests/resource.rs
+++ b/src/registry/tests/resource.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable,
+    clippy::indexing_slicing,
+    clippy::assertions_on_result_states,
+    clippy::pattern_type_mismatch
+)] // registry resource tests unwrap/panic for fixture setup
+
 use super::super::registry::*;
 use crate::{
     registry::{instances::RESOURCE_SCHEMA_REGISTRY, schemas::resource},

--- a/src/registry/tests/target.rs
+++ b/src/registry/tests/target.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::unreachable,
+    clippy::assertions_on_result_states,
+    clippy::pattern_type_mismatch
+)] // registry target tests unwrap/panic for expectations
+
 use super::super::registry::*;
 use crate::{
     registry::{instances::TARGET_REGISTRY, targets},

--- a/src/rvm/instructions/display.rs
+++ b/src/rvm/instructions/display.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::option_if_let_else,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/rvm/instructions/mod.rs
+++ b/src/rvm/instructions/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_const_for_fn)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/rvm/instructions/params.rs
+++ b/src/rvm/instructions/params.rs
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::missing_const_for_fn,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};

--- a/src/rvm/program/core.rs
+++ b/src/rvm/program/core.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::missing_const_for_fn,
+    clippy::as_conversions,
+    clippy::unused_trait_names
+)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/rvm/program/listing.rs
+++ b/src/rvm/program/listing.rs
@@ -1,5 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::unwrap_used,
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::option_if_let_else,
+    clippy::missing_const_for_fn,
+    clippy::as_conversions,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use alloc::format;
 use alloc::string::{String, ToString};

--- a/src/rvm/program/recompile.rs
+++ b/src/rvm/program/recompile.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::unused_trait_names)]
 
 use super::Program;
 use alloc::string::{String, ToString};

--- a/src/rvm/program/rule_tree.rs
+++ b/src/rvm/program/rule_tree.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use alloc::format;
 use alloc::string::{String, ToString};

--- a/src/rvm/program/serialization/binary.rs
+++ b/src/rvm/program/serialization/binary.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::unused_trait_names
+)]
 
 use alloc::format;
 use alloc::string::{String, ToString};

--- a/src/rvm/program/serialization/json.rs
+++ b/src/rvm/program/serialization/json.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::as_conversions, clippy::unused_trait_names)]
+
 use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/rvm/program/serialization/mod.rs
+++ b/src/rvm/program/serialization/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::redundant_pub_crate)]
 
 pub(crate) mod binary;
 mod json;

--- a/src/rvm/program/serialization/value.rs
+++ b/src/rvm/program/serialization/value.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::redundant_pub_crate,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)]
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;

--- a/src/rvm/program/types.rs
+++ b/src/rvm/program/types.rs
@@ -1,6 +1,11 @@
+#![allow(clippy::missing_const_for_fn)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions
+)]
 use alloc::string::String;
 use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};

--- a/src/rvm/tests/instruction_parser.rs
+++ b/src/rvm/tests/instruction_parser.rs
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::arithmetic_side_effects,
+    clippy::option_if_let_else,
+    clippy::unused_trait_names,
+    clippy::pattern_type_mismatch
+)] // tests unwrap conversions and slice math for brevity
+
 use crate::rvm::instructions::{Instruction, LoopMode};
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;

--- a/src/rvm/tests/test_utils.rs
+++ b/src/rvm/tests/test_utils.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::shadow_unrelated,
+    clippy::as_conversions
+)]
 
 //! Test utility functions for RVM serialization
 

--- a/src/rvm/tests/vm.rs
+++ b/src/rvm/tests/vm.rs
@@ -1,6 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used,
+    clippy::manual_assert,
+    clippy::indexing_slicing,
+    clippy::option_if_let_else,
+    clippy::semicolon_if_nothing_returned,
+    clippy::unseparated_literal_suffix,
+    clippy::use_debug,
+    clippy::unused_trait_names,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)] // VM tests assert/unwrap and use manual panics to validate scenarios
+
 #[cfg(test)]
 mod tests {
     use crate::rvm::tests::instruction_parser::{parse_instruction, parse_loop_mode};

--- a/src/rvm/vm/arithmetic.rs
+++ b/src/rvm/vm/arithmetic.rs
@@ -1,3 +1,9 @@
+#![allow(
+    clippy::unused_self,
+    clippy::missing_const_for_fn,
+    clippy::unseparated_literal_suffix,
+    clippy::pattern_type_mismatch
+)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/rvm/vm/comprehension.rs
+++ b/src/rvm/vm/comprehension.rs
@@ -1,5 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::option_if_let_else,
+    clippy::useless_let_if_seq,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use crate::rvm::instructions::{ComprehensionBeginParams, ComprehensionMode};
 use crate::value::Value;

--- a/src/rvm/vm/context.rs
+++ b/src/rvm/vm/context.rs
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::missing_const_for_fn,
+    clippy::pattern_type_mismatch
+)]
 
 use crate::rvm::instructions::{ComprehensionMode, LoopMode};
 use crate::value::Value;

--- a/src/rvm/vm/dispatch.rs
+++ b/src/rvm/vm/dispatch.rs
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::used_underscore_binding,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)]
 
 use crate::rvm::instructions::{Instruction, LiteralOrRegister};
 use crate::rvm::program::Program;

--- a/src/rvm/vm/execution.rs
+++ b/src/rvm/vm/execution.rs
@@ -1,5 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::option_if_let_else,
+    clippy::as_conversions,
+    clippy::needless_continue,
+    clippy::pattern_type_mismatch
+)]
 use crate::rvm::instructions::Instruction;
 use crate::rvm::program::Program;
 use crate::value::Value;

--- a/src/rvm/vm/execution_model.rs
+++ b/src/rvm/vm/execution_model.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_const_for_fn)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 

--- a/src/rvm/vm/functions.rs
+++ b/src/rvm/vm/functions.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#![allow(clippy::indexing_slicing, clippy::as_conversions)]
 use crate::builtins;
 use crate::value::Value;
 use alloc::string::String;

--- a/src/rvm/vm/loops.rs
+++ b/src/rvm/vm/loops.rs
@@ -1,6 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::shadow_unrelated,
+    clippy::missing_const_for_fn,
+    clippy::unused_self,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)] // VM loop handling indexes directly for performance and clarity
+
 use crate::rvm::instructions::LoopMode;
 use crate::value::Value;
 

--- a/src/rvm/vm/machine.rs
+++ b/src/rvm/vm/machine.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    missing_debug_implementations,
+    clippy::missing_const_for_fn,
+    clippy::pattern_type_mismatch
+)] // VM structs are not debug printed
+
 use crate::rvm::program::Program;
 use crate::value::Value;
 use crate::CompiledPolicy;

--- a/src/rvm/vm/mod.rs
+++ b/src/rvm/vm/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-extern crate alloc;
-
 mod arithmetic;
 mod comprehension;
 mod context;

--- a/src/rvm/vm/rules.rs
+++ b/src/rvm/vm/rules.rs
@@ -1,6 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::shadow_unrelated,
+    clippy::unused_self,
+    clippy::semicolon_if_nothing_returned,
+    clippy::missing_const_for_fn,
+    clippy::as_conversions,
+    clippy::needless_continue,
+    clippy::pattern_type_mismatch
+)] // VM rule execution indexes directly and uses expect for invariant checks
+
 use crate::rvm::instructions::FunctionCallParams;
 use crate::rvm::program::{RuleInfo, RuleType};
 use crate::value::Value;

--- a/src/rvm/vm/virtual_data.rs
+++ b/src/rvm/vm/virtual_data.rs
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::unused_self,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)] // virtual data paths index directly for speed; unwraps assert invariants
+
 use crate::rvm::instructions::LiteralOrRegister;
 use crate::value::Value;
 use alloc::vec::Vec;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::indexing_slicing,
+    clippy::arithmetic_side_effects,
+    clippy::unwrap_used,
+    clippy::shadow_unrelated,
+    clippy::unused_self,
+    clippy::option_if_let_else,
+    clippy::semicolon_if_nothing_returned,
+    clippy::print_stderr,
+    clippy::use_debug,
+    clippy::as_conversions,
+    clippy::pattern_type_mismatch
+)] // scheduler logic indexes arrays and unwraps queues intentionally
+
 use crate::ast::Expr::*;
 use crate::ast::*;
 use crate::lexer::*;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch)]
+
 /// There are two type systems of interest:
 ///     1. JSON Schema used by Azure Policy for some of its metadata.
 ///     2. Bicep's type system generated from Azure API swagger files.

--- a/src/schema/error.rs
+++ b/src/schema/error.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::use_debug, clippy::pattern_type_mismatch)]
+
 use crate::*;
 
 type String = Rc<str>;

--- a/src/schema/meta.rs
+++ b/src/schema/meta.rs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::expect_used,
+    clippy::missing_const_for_fn,
+    clippy::option_if_let_else
+)] // meta schema loader expects static resources
 #![allow(dead_code)]
 use crate::*;
 use lazy_static::lazy_static;

--- a/src/schema/meta/tests.rs
+++ b/src/schema/meta/tests.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::unwrap_used, clippy::assertions_on_result_states)] // meta-schema tests unwrap errors to assert failures
+
 use super::*;
 use serde_json::json;
 

--- a/src/schema/tests/azure.rs
+++ b/src/schema/tests/azure.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::pattern_type_mismatch
+)] // azure schema tests panic/unwrap to assert structures
+
 use super::super::*;
 
 #[test]

--- a/src/schema/tests/suite.rs
+++ b/src/schema/tests/suite.rs
@@ -1,6 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::semicolon_if_nothing_returned,
+    clippy::pattern_type_mismatch,
+    clippy::assertions_on_result_states,
+    clippy::as_conversions
+)] // schema suite tests panic/unwrap to assert specific error shapes
+
 use super::super::*;
 use crate::{format, vec};
 use serde_json::json;

--- a/src/schema/tests/validate/effect.rs
+++ b/src/schema/tests/validate/effect.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::pattern_type_mismatch,
+    clippy::assertions_on_result_states
+)] // test cases assert failures via unwrap/expect panic paths and pattern matching
+
 use crate::{
     schema::{error::ValidationError, validate::SchemaValidator, Schema},
     *,

--- a/src/schema/tests/validate/resource.rs
+++ b/src/schema/tests/validate/resource.rs
@@ -1,6 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_unrelated,
+    clippy::pattern_type_mismatch,
+    clippy::assertions_on_result_states,
+    clippy::as_conversions
+)] // test cases use unwrap/expect and panic to assert error flows
+
 use crate::{
     schema::{error::ValidationError, validate::SchemaValidator, Schema},
     *,

--- a/src/schema/validate.rs
+++ b/src/schema/validate.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(missing_debug_implementations)] // validator is zero-sized marker
 #![allow(dead_code)]
+#![allow(clippy::pattern_type_mismatch, clippy::needless_continue)]
 
 use crate::{
     schema::{error::ValidationError, Schema, Type},

--- a/src/target/deserialize.rs
+++ b/src/target/deserialize.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::unused_trait_names)]
+
 use crate::registry::instances::{EFFECT_SCHEMA_REGISTRY, RESOURCE_SCHEMA_REGISTRY};
 use crate::{format, Rc, Schema, Vec};
 use alloc::collections::BTreeMap;

--- a/src/target/resource_schema_selector.rs
+++ b/src/target/resource_schema_selector.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::option_if_let_else, clippy::pattern_type_mismatch)]
+
 use crate::schema::Type;
 use crate::{format, Rc, Schema, Value};
 use alloc::collections::BTreeMap;

--- a/src/target/tests/deserialize.rs
+++ b/src/target/tests/deserialize.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::unwrap_used, clippy::unused_trait_names)] // tests unwrap intentional failures and import ToString anonymously
+
 use super::super::*;
 use crate::Value;
 use alloc::string::ToString;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(clippy::pattern_type_mismatch, clippy::unused_trait_names)]
+
 //! Shared helpers for YAML-driven integration tests.
 
 use crate::Value;

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -1,6 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::semicolon_if_nothing_returned,
+    clippy::pattern_type_mismatch,
+    clippy::print_stderr
+)] // test harness asserts and unwraps to validate interpreter behavior
+
 use std::env;
 
 use crate::test_utils::{check_output, ValueOrVec};

--- a/src/tests/scheduler/analyzer/mod.rs
+++ b/src/tests/scheduler/analyzer/mod.rs
@@ -1,6 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::std_instead_of_core,
+    clippy::semicolon_if_nothing_returned,
+    clippy::pattern_type_mismatch,
+    clippy::as_conversions
+)] // scheduler analyzer tests rely on asserts/unwraps and std conveniences
+
 use crate::*;
 use crate::{ast::*, lexer::*, parser::*, scheduler::*};
 use anyhow::{anyhow, bail, Result};

--- a/src/tests/scheduler/mod.rs
+++ b/src/tests/scheduler/mod.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::panic_in_result_fn,
+    clippy::indexing_slicing,
+    clippy::as_conversions
+)] // scheduler tests assert and index directly for clarity
+
 use crate::scheduler::*;
 use crate::*;
 use anyhow::{bail, Result};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::shadow_unrelated,
+    clippy::pattern_type_mismatch,
+    clippy::as_conversions
+)] // small arithmetic checks are intentional
+
 use crate::ast::*;
 use crate::builtins::*;
 use crate::lexer::*;

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#![allow(
+    clippy::indexing_slicing,
+    clippy::shadow_unrelated,
+    clippy::option_if_let_else,
+    clippy::semicolon_if_nothing_returned,
+    clippy::pattern_type_mismatch,
+    clippy::unused_trait_names,
+    clippy::as_conversions
+)] // value helpers index paths directly for performance
+
 use crate::number::Number;
 
 use alloc::collections::{BTreeMap, BTreeSet};


### PR DESCRIPTION
Lints are added (deny) at crate level.

In each offending file, the failing lints are explicitly allowed. Each file will be fixed in subsequent PRs.