### PR TITLE
chore: Make clippy clean and harden helpers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::missing_const_for_fn, clippy::pattern_type_mismatch)]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -265,61 +264,59 @@ pub enum Expr {
 }
 
 impl Expr {
-    pub fn span(&self) -> &Span {
-        use Expr::*;
-        match self {
-            String { span, .. }
-            | RawString { span, .. }
-            | Number { span, .. }
-            | Bool { span, .. }
-            | Null { span, .. }
-            | Var { span, .. }
-            | Array { span, .. }
-            | Set { span, .. }
-            | Object { span, .. }
-            | ArrayCompr { span, .. }
-            | SetCompr { span, .. }
-            | ObjectCompr { span, .. }
-            | Call { span, .. }
-            | UnaryExpr { span, .. }
-            | RefDot { span, .. }
-            | RefBrack { span, .. }
-            | BinExpr { span, .. }
-            | BoolExpr { span, .. }
-            | ArithExpr { span, .. }
-            | AssignExpr { span, .. }
-            | Membership { span, .. } => span,
+    pub const fn span(&self) -> &Span {
+        match *self {
+            Self::String { ref span, .. }
+            | Self::RawString { ref span, .. }
+            | Self::Number { ref span, .. }
+            | Self::Bool { ref span, .. }
+            | Self::Null { ref span, .. }
+            | Self::Var { ref span, .. }
+            | Self::Array { ref span, .. }
+            | Self::Set { ref span, .. }
+            | Self::Object { ref span, .. }
+            | Self::ArrayCompr { ref span, .. }
+            | Self::SetCompr { ref span, .. }
+            | Self::ObjectCompr { ref span, .. }
+            | Self::Call { ref span, .. }
+            | Self::UnaryExpr { ref span, .. }
+            | Self::RefDot { ref span, .. }
+            | Self::RefBrack { ref span, .. }
+            | Self::BinExpr { ref span, .. }
+            | Self::BoolExpr { ref span, .. }
+            | Self::ArithExpr { ref span, .. }
+            | Self::AssignExpr { ref span, .. }
+            | Self::Membership { ref span, .. } => span,
             #[cfg(feature = "rego-extensions")]
-            OrExpr { span, .. } => span,
+            Self::OrExpr { ref span, .. } => span,
         }
     }
 
-    pub fn eidx(&self) -> u32 {
-        use Expr::*;
-        match self {
-            String { eidx, .. }
-            | RawString { eidx, .. }
-            | Number { eidx, .. }
-            | Bool { eidx, .. }
-            | Null { eidx, .. }
-            | Var { eidx, .. }
-            | Array { eidx, .. }
-            | Set { eidx, .. }
-            | Object { eidx, .. }
-            | ArrayCompr { eidx, .. }
-            | SetCompr { eidx, .. }
-            | ObjectCompr { eidx, .. }
-            | Call { eidx, .. }
-            | UnaryExpr { eidx, .. }
-            | RefDot { eidx, .. }
-            | RefBrack { eidx, .. }
-            | BinExpr { eidx, .. }
-            | BoolExpr { eidx, .. }
-            | ArithExpr { eidx, .. }
-            | AssignExpr { eidx, .. }
-            | Membership { eidx, .. } => *eidx,
+    pub const fn eidx(&self) -> u32 {
+        match *self {
+            Self::String { eidx, .. }
+            | Self::RawString { eidx, .. }
+            | Self::Number { eidx, .. }
+            | Self::Bool { eidx, .. }
+            | Self::Null { eidx, .. }
+            | Self::Var { eidx, .. }
+            | Self::Array { eidx, .. }
+            | Self::Set { eidx, .. }
+            | Self::Object { eidx, .. }
+            | Self::ArrayCompr { eidx, .. }
+            | Self::SetCompr { eidx, .. }
+            | Self::ObjectCompr { eidx, .. }
+            | Self::Call { eidx, .. }
+            | Self::UnaryExpr { eidx, .. }
+            | Self::RefDot { eidx, .. }
+            | Self::RefBrack { eidx, .. }
+            | Self::BinExpr { eidx, .. }
+            | Self::BoolExpr { eidx, .. }
+            | Self::ArithExpr { eidx, .. }
+            | Self::AssignExpr { eidx, .. }
+            | Self::Membership { eidx, .. } => eidx,
             #[cfg(feature = "rego-extensions")]
-            OrExpr { eidx, .. } => *eidx,
+            Self::OrExpr { eidx, .. } => eidx,
         }
     }
 }
@@ -435,9 +432,9 @@ pub enum Rule {
 }
 
 impl Rule {
-    pub fn span(&self) -> &Span {
-        match self {
-            Self::Spec { span, .. } | Self::Default { span, .. } => span,
+    pub const fn span(&self) -> &Span {
+        match *self {
+            Self::Spec { ref span, .. } | Self::Default { ref span, .. } => span,
         }
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![allow(
-    clippy::missing_const_for_fn,
-    clippy::option_if_let_else,
-    clippy::if_then_some_else_none,
-    clippy::unused_self,
-    clippy::semicolon_if_nothing_returned,
-    clippy::useless_let_if_seq
-)]
 //! Compiler-related functionality for Regorus.
 //!
 //! This module contains utilities and data structures used during

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -65,7 +65,7 @@ pub struct ScopeContext {
 
 impl ScopeContext {
     /// Create a new context with Query type (default, no output expressions)
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             context_type: ContextType::Query,
             bound_vars: BTreeSet::new(),
@@ -81,7 +81,7 @@ impl ScopeContext {
 
     /// Create a new context with a specific context type
     #[allow(dead_code)]
-    pub fn with_context_type(context_type: ContextType) -> Self {
+    pub const fn with_context_type(context_type: ContextType) -> Self {
         Self {
             context_type,
             bound_vars: BTreeSet::new(),
@@ -97,7 +97,7 @@ impl ScopeContext {
 
     /// Create a new context with output expressions (for rules and comprehensions)
     #[allow(dead_code)]
-    pub fn with_output_exprs(
+    pub const fn with_output_exprs(
         context_type: ContextType,
         key_expr: Option<ExprRef>,
         value_expr: Option<ExprRef>,

--- a/src/compiler/destructuring_planner/utils.rs
+++ b/src/compiler/destructuring_planner/utils.rs
@@ -149,10 +149,9 @@ pub(crate) fn check_literal_structure(
 }
 
 pub(crate) fn ensure_literal_match(plan: &DestructuringPlan, expr: &ExprRef) -> Result<()> {
-    match check_literal_structure(plan, expr).into_error() {
-        Some(err) => Err(err),
-        None => Ok(()),
-    }
+    check_literal_structure(plan, expr)
+        .into_error()
+        .map_or(Ok(()), Err)
 }
 
 pub(crate) fn collect_pattern_var_spans(expr: &ExprRef, spans: &mut Vec<Span>) {
@@ -248,13 +247,7 @@ pub(crate) fn ensure_structural_compatibility(
 
 /// Helper that discards destructuring plans which do not bind any variables.
 pub(crate) fn plan_only_if_binds(plan: Option<DestructuringPlan>) -> Option<DestructuringPlan> {
-    plan.and_then(|plan| {
-        if plan.introduces_binding() || plan.contains_wildcards() {
-            Some(plan)
-        } else {
-            None
-        }
-    })
+    plan.and_then(|plan| (plan.introduces_binding() || plan.contains_wildcards()).then_some(plan))
 }
 
 pub(crate) fn extract_literal_key(expr: &ExprRef) -> Option<Value> {

--- a/src/compiler/hoist.rs
+++ b/src/compiler/hoist.rs
@@ -576,20 +576,20 @@ impl LoopHoister {
 
         // Get the scheduled order if available
         let stmt_order: Vec<usize> = if let Some(ref schedule) = self.schedule {
-            if let Some(query_schedule) = schedule
+            schedule
                 .queries
                 .get_checked(module_idx, query.qidx)
                 .map_err(|err| anyhow!("schedule out of bounds: {err}"))?
-            {
-                query_schedule
-                    .order
-                    .iter()
-                    .map(|&idx| idx as usize)
-                    .collect()
-            } else {
-                // No schedule for this query, use source order
-                (0..query.stmts.len()).collect()
-            }
+                .map_or_else(
+                    || (0..query.stmts.len()).collect(),
+                    |query_schedule| {
+                        query_schedule
+                            .order
+                            .iter()
+                            .map(|&idx| idx as usize)
+                            .collect()
+                    },
+                )
         } else {
             // No schedule available, use source order
             (0..query.stmts.len()).collect()


### PR DESCRIPTION
- Promote common accessors (Expr/Rule span/eidx, ScopeContext constructors, Engine::set_rego_v0) to const
- Prefer Option combinators (map_or, then_some) and map_or_else
- Tighten engine logic: add missing semicolons, use checked u32::try_from, make boolean query evaluation avoid unchecked indexing,