### PR TITLE
feat!: Ability to limit policy evaluation time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ bindings/*/target
 # C# build folders
 **bin
 **obj
+bindings/csharp/.nuget/
 
 # Bundler binstubs regenerated during ruby setup
 bindings/ruby/bin/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spin",
  "test-generator",
  "thiserror",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ thiserror = { version = "2.0", default-features = false }
 data-encoding = { version = "2.8.0", optional = true, default-features=false, features = ["alloc"] }
 num-bigint = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex"] }
 
 globset = { version = "0.4.16", features = ["simd-accel"], default-features = false, optional = true }
 regex = {version = "1.11.1", optional = true, default-features = false }

--- a/bindings/csharp/README.md
+++ b/bindings/csharp/README.md
@@ -29,8 +29,11 @@ Once the workflow run completes, the generated Nuget can be downloaded by follow
 
 ## Local
 
-<<<<<<< HEAD
-TODO
+The `cargo xtask` runner provides helpers for local builds:
+
+1. `cargo xtask ffi` builds the `bindings/ffi` crate for the host platform in debug mode. Add `--target <triple>` (repeatable) to cross-compile, or `--release` to produce optimised artefacts. Results land under `bindings/ffi/target/<triple>/<profile>`.
+2. `cargo xtask nuget` reuses those artefacts to pack the C# library. It defaults to debug builds for the host but accepts `--target`, `--release`, `--artifacts-dir <path>` to reuse existing binaries, and `--enforce-artifacts` to require every officially supported platform.
+3. `cargo xtask test-csharp` ensures a NuGet is available (rebuilding when required or when `--force-nuget` is passed) and then runs `Regorus.Tests`, `TestApp`, and `TargetExampleApp` against it. The command accepts the same build flags as `cargo xtask nuget`.
 
 ## Memory Usage Safeguards
 
@@ -48,11 +51,11 @@ using var engine = new Regorus.Engine();
 var veryLargeJson = new string('x', 128 * 1024);
 try
 {
-  engine.SetInputJson(veryLargeJson);
+    engine.SetInputJson(veryLargeJson);
 }
 catch (InvalidOperationException ex)
 {
-  Console.WriteLine($"Allocator reported: {ex.Message}");
+    Console.WriteLine($"Allocator reported: {ex.Message}");
 }
 
 // Restore defaults once done
@@ -60,11 +63,4 @@ Regorus.MemoryLimits.SetGlobalMemoryLimit(null);
 Regorus.MemoryLimits.SetThreadFlushThresholdOverride(null);
 ```
 
-See `bindings/csharp/Regorus.Tests/RegorusTests.cs` for scenario coverage and `bindings/csharp/TargetExampleApp/Program.cs` for end-to-end usage.
-=======
-The `cargo xtask` runner provides helpers for local builds:
-
-1. `cargo xtask ffi` builds the `bindings/ffi` crate for the host platform in debug mode. Add `--target <triple>` (repeatable) to cross-compile, or `--release` to produce optimised artefacts. Results land under `bindings/ffi/target/<triple>/<profile>`.
-2. `cargo xtask nuget` reuses those artefacts to pack the C# library. It defaults to debug builds for the host but accepts `--target`, `--release`, `--artifacts-dir <path>` to reuse existing binaries, and `--enforce-artifacts` to require every officially supported platform.
-3. `cargo xtask test-csharp` ensures a NuGet is available (rebuilding when required or when `--force-nuget` is passed) and then runs `Regorus.Tests`, `TestApp`, and `TargetExampleApp` against it. The command accepts the same build flags as `cargo xtask nuget`.
->>>>>>> 380a27c (feat(xtask): consolidate CI workflows onto xtask helpers)
+See bindings/csharp/Regorus.Tests/RegorusTests.cs for scenario coverage and bindings/csharp/TargetExampleApp/Program.cs for end-to-end usage.

--- a/bindings/csharp/Regorus.Tests/ExecutionTimerTests.cs
+++ b/bindings/csharp/Regorus.Tests/ExecutionTimerTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Regorus;
+
+namespace Regorus.Tests;
+
+[DoNotParallelize] // Uses global fallback config; must run sequentially.
+[TestClass]
+public class ExecutionTimerTests
+{
+    private const string Policy = @"
+package limits.timer
+import rego.v1
+
+triplet_count := count([1 |
+  x := data.values[_]
+  y := data.values[_]
+  z := data.values[_]
+])
+";
+
+    private const string Query = "data.limits.timer.triplet_count";
+    private const int ValueCount = 160;
+
+    [TestMethod]
+    public void Engine_limit_enforced()
+    {
+        Engine.ClearFallbackExecutionTimerConfig();
+        using var engine = CreateEngine(ValueCount);
+        var config = new ExecutionTimerConfig(TimeSpan.FromMilliseconds(2), checkInterval: 1);
+        engine.SetExecutionTimerConfig(config);
+
+        var ex = Assert.ThrowsException<InvalidOperationException>(() => engine.EvalRule(Query));
+        StringAssert.Contains(ex.Message, "execution exceeded time limit");
+    }
+
+    [TestMethod]
+    public void Fallback_applies_to_new_engines()
+    {
+        var fallback = new ExecutionTimerConfig(TimeSpan.FromMilliseconds(2), checkInterval: 1);
+        Engine.SetFallbackExecutionTimerConfig(fallback);
+        try
+        {
+            using var engine = CreateEngine(ValueCount);
+            var ex = Assert.ThrowsException<InvalidOperationException>(() => engine.EvalRule(Query));
+            StringAssert.Contains(ex.Message, "execution exceeded time limit");
+        }
+        finally
+        {
+            Engine.ClearFallbackExecutionTimerConfig();
+        }
+    }
+
+    [TestMethod]
+    public void Engine_override_relaxes_fallback()
+    {
+        var fallback = new ExecutionTimerConfig(TimeSpan.FromMilliseconds(2), checkInterval: 1);
+        Engine.SetFallbackExecutionTimerConfig(fallback);
+        try
+        {
+            using var engine = CreateEngine(ValueCount);
+            var relaxed = new ExecutionTimerConfig(TimeSpan.FromSeconds(12), checkInterval: 1);
+            engine.SetExecutionTimerConfig(relaxed);
+
+            var resultJson = engine.EvalRule(Query);
+            var result = JsonSerializer.Deserialize<int>(resultJson!);
+            Assert.IsTrue(result > 0, "Expected a positive triplet count when limit is relaxed.");
+
+            engine.ClearExecutionTimerConfig();
+            var ex = Assert.ThrowsException<InvalidOperationException>(() => engine.EvalRule(Query));
+            StringAssert.Contains(ex.Message, "execution exceeded time limit");
+        }
+        finally
+        {
+            Engine.ClearFallbackExecutionTimerConfig();
+        }
+    }
+
+    [TestMethod]
+    public void CompiledPolicy_limit_enforced()
+    {
+        var fallback = new ExecutionTimerConfig(TimeSpan.FromMilliseconds(2), checkInterval: 1);
+        Engine.SetFallbackExecutionTimerConfig(fallback);
+        try
+        {
+            using var policy = CreateCompiledPolicy(ValueCount);
+            var ex = Assert.ThrowsException<InvalidOperationException>(() => policy.EvalWithInput("null"));
+            StringAssert.Contains(ex.Message, "execution exceeded time limit");
+        }
+        finally
+        {
+            Engine.ClearFallbackExecutionTimerConfig();
+        }
+    }
+
+    [TestMethod]
+    public void CompiledPolicy_uses_engine_limits_only()
+    {
+        // Compiled policies no longer store per-policy execution timers; limits are managed by Engine.
+        Engine.ClearFallbackExecutionTimerConfig();
+        using var policy = CreateCompiledPolicy(ValueCount);
+        var resultJson = policy.EvalWithInput("null");
+        var result = JsonSerializer.Deserialize<int>(resultJson!);
+        Assert.IsTrue(result > 0, "CompiledPolicy should evaluate using engine defaults without its own timer");
+    }
+
+    private static Engine CreateEngine(int valueCount)
+    {
+        var engine = new Engine();
+        engine.AddPolicy("limits_timer.rego", Policy);
+        engine.AddDataJson(CreateData(valueCount));
+        return engine;
+    }
+
+    private static CompiledPolicy CreateCompiledPolicy(int valueCount)
+    {
+        var modules = new[] { new PolicyModule("limits_timer.rego", Policy) };
+        return Compiler.CompilePolicyWithEntrypoint(CreateData(valueCount), modules, Query);
+    }
+
+    private static string CreateData(int valueCount)
+    {
+        var payload = new { values = Enumerable.Range(0, valueCount).ToArray() };
+        return JsonSerializer.Serialize(payload);
+    }
+}

--- a/bindings/csharp/Regorus.Tests/RegorusTests.cs
+++ b/bindings/csharp/Regorus.Tests/RegorusTests.cs
@@ -12,7 +12,7 @@ namespace Regorus.Tests;
 [TestClass]
 public class RegorusTests
 {
-  private static readonly object LimitLock = new();
+    private static readonly object LimitLock = new();
 
     [TestMethod]
     public void Basic_evaluation_succeeds()
@@ -374,17 +374,17 @@ stretched := concat("", [input.block | numbers.range(0, input.repeat - 1)[_]])
 
     private sealed class MemoryLimitScope : IDisposable
     {
-      private readonly ulong? _originalLimit;
+        private readonly ulong? _originalLimit;
 
-      public MemoryLimitScope()
-      {
-        _originalLimit = MemoryLimits.GetGlobalMemoryLimit();
-      }
+        public MemoryLimitScope()
+        {
+            _originalLimit = MemoryLimits.GetGlobalMemoryLimit();
+        }
 
-      public void Dispose()
-      {
-        MemoryLimits.SetGlobalMemoryLimit(_originalLimit);
-        MemoryLimits.FlushThreadMemoryCounters();
-      }
+        public void Dispose()
+        {
+            MemoryLimits.SetGlobalMemoryLimit(_originalLimit);
+            MemoryLimits.FlushThreadMemoryCounters();
+        }
     }
 }

--- a/bindings/csharp/Regorus/CompiledPolicy.cs
+++ b/bindings/csharp/Regorus/CompiledPolicy.cs
@@ -203,5 +203,14 @@ namespace Regorus
                 }
             }
         }
+
+        private void UseHandle(Action<IntPtr> action)
+        {
+            UseHandle<object?>(handlePtr =>
+            {
+                action(handlePtr);
+                return null;
+            });
+        }
     }
 }

--- a/bindings/csharp/Regorus/ExecutionTimerConfig.cs
+++ b/bindings/csharp/Regorus/ExecutionTimerConfig.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Regorus
+{
+    /// <summary>
+    /// Managed representation of the execution timer configuration used by the engine.
+    /// </summary>
+    public readonly struct ExecutionTimerConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionTimerConfig"/> struct.
+        /// </summary>
+        /// <param name="limit">Maximum wall-clock duration allowed for evaluation. Must be non-negative.</param>
+        /// <param name="checkInterval">Number of work units between timer checks. Must be non-zero.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="limit"/> is negative or <paramref name="checkInterval"/> is zero.</exception>
+        public ExecutionTimerConfig(TimeSpan limit, uint checkInterval)
+        {
+            if (limit < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(limit), "Execution timer limit must be non-negative.");
+            }
+
+            if (checkInterval == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(checkInterval), "Execution timer check interval must be non-zero.");
+            }
+
+            Limit = limit;
+            CheckInterval = checkInterval;
+        }
+
+        /// <summary>
+        /// Maximum wall-clock duration allowed for an evaluation.
+        /// </summary>
+        public TimeSpan Limit { get; }
+
+        /// <summary>
+        /// Number of work units between timer checks.
+        /// </summary>
+        public uint CheckInterval { get; }
+
+        internal Regorus.Internal.RegorusExecutionTimerConfig ToNative()
+        {
+            if (Limit < TimeSpan.Zero)
+            {
+                throw new InvalidOperationException("Execution timer limit must be non-negative.");
+            }
+
+            ulong ticks = checked((ulong)Limit.Ticks);
+            ulong limitNanoseconds = checked(ticks * 100UL);
+
+            return new Regorus.Internal.RegorusExecutionTimerConfig
+            {
+                limit_ns = limitNanoseconds,
+                check_interval = CheckInterval,
+            };
+        }
+    }
+}

--- a/bindings/csharp/Regorus/NativeMethods.cs
+++ b/bindings/csharp/Regorus/NativeMethods.cs
@@ -257,7 +257,7 @@ namespace Regorus.Internal
         [DllImport(LibraryName, EntryPoint = "regorus_engine_compile_with_entrypoint", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern RegorusResult regorus_engine_compile_with_entrypoint(RegorusEngine* engine, byte* rule);
 
-    #if REGORUS_FFI_TEST_HOOKS
+#if REGORUS_FFI_TEST_HOOKS
         /// <summary>
         /// Trigger a panic inside the engine for testing purposes.
         /// </summary>
@@ -269,7 +269,35 @@ namespace Regorus.Internal
         /// </summary>
         [DllImport(LibraryName, EntryPoint = "regorus_engine_test_reset_poison", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern void regorus_engine_test_reset_poison();
-    #endif
+#endif
+
+        /// <summary>
+        /// Configure the execution timer for a specific engine instance.
+        /// </summary>
+        [DllImport(LibraryName, EntryPoint = "regorus_engine_set_execution_timer_config", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusResult regorus_engine_set_execution_timer_config(RegorusEngine* engine, RegorusExecutionTimerConfig* config);
+
+        /// <summary>
+        /// Clear the execution timer configuration for a specific engine instance.
+        /// </summary>
+        [DllImport(LibraryName, EntryPoint = "regorus_engine_clear_execution_timer_config", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusResult regorus_engine_clear_execution_timer_config(RegorusEngine* engine);
+
+        #endregion
+
+        #region Execution Timer Global Methods
+
+        /// <summary>
+        /// Set the process-wide fallback execution timer configuration.
+        /// </summary>
+        [DllImport(LibraryName, EntryPoint = "regorus_set_fallback_execution_timer_config", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusResult regorus_set_fallback_execution_timer_config(RegorusExecutionTimerConfig config);
+
+        /// <summary>
+        /// Clear the process-wide fallback execution timer configuration.
+        /// </summary>
+        [DllImport(LibraryName, EntryPoint = "regorus_clear_fallback_execution_timer_config", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern RegorusResult regorus_clear_fallback_execution_timer_config();
 
         #endregion
 
@@ -577,6 +605,16 @@ namespace Regorus.Internal
         /// Owned by Rust.
         /// </summary>
         public byte* error_message;
+    }
+
+    /// <summary>
+    /// FFI representation of the execution timer configuration.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct RegorusExecutionTimerConfig
+    {
+        public ulong limit_ns;
+        public uint check_interval;
     }
 
     /// <summary>

--- a/bindings/ffi/Cargo.lock
+++ b/bindings/ffi/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "cbindgen"
-version = "0.28.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
@@ -401,9 +401,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -973,6 +973,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spin",
  "thiserror",
  "url",
  "uuid",
@@ -1071,11 +1072,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1108,6 +1109,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1188,44 +1195,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "unicode-ident"
@@ -1425,9 +1430,6 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -43,4 +43,4 @@ contention_checks = ["parking_lot"]
 custom_allocator = []
 
 [build-dependencies]
-cbindgen = "0.28.0"
+cbindgen = "0.29.2"

--- a/bindings/ffi/src/compiled_policy.rs
+++ b/bindings/ffi/src/compiled_policy.rs
@@ -52,6 +52,7 @@ pub extern "C" fn regorus_compiled_policy_eval_with_input(
     })
 }
 
+/// Configure the execution timer for evaluations of this compiled policy.
 /// Get information about the compiled policy including metadata about modules,
 /// target configuration, and resource types.
 ///

--- a/bindings/java/Cargo.lock
+++ b/bindings/java/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spin",
  "thiserror 2.0.18",
  "url",
  "uuid",
@@ -969,6 +970,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spin",
  "thiserror",
  "url",
  "uuid",
@@ -1020,6 +1021,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/bindings/wasm/Cargo.lock
+++ b/bindings/wasm/Cargo.lock
@@ -510,9 +510,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -890,6 +890,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "spin",
  "thiserror",
  "url",
  "uuid",
@@ -1020,6 +1021,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/docs/limits/execution_time.md
+++ b/docs/limits/execution_time.md
@@ -1,0 +1,203 @@
+# Execution Time Limiting Design
+
+## Goal
+
+Introduce configurable execution-time limits so every evaluation stays bounded.
+Policy service can configure these limits to ensure that a single runaway policy never degrades overall availability.
+
+## Design Goals
+
+- Support execution limits per engine. Also support configuring a global fallback execution limit.
+- Use best time sources automatically in std builds but provide ability to set the time source in no-std builds and for deterministic testing.
+- Since computing elapsed time is relatively expensive, provide ability to control how often it is computed during evaluation.
+
+## Prevalent Approaches
+
+The following approaches are used by various execution engines.
+
+### Cooperative Tick Budgets
+Evaluations burn through a configurable “fuel” counter one work unit at a time.
+When fuel hits zero the engine raises an error, forcing callers to top up or abandon the run.
+- **Examples**: Wasmtime fuel, Wasmer metering, Lua debug hooks
+- **Pros**: Precise control over work units; compatible with no_std targets
+- **Cons**: Requires instrumentation at every checkpoint; budget choice affects responsiveness
+
+### Wall-Clock Watchdogs
+Hosts schedule a real-time deadline alongside the policy evaluation.
+When a timer fires, the engine aborts or interrupts, guaranteeing a hard wall-clock cap.
+- **Examples**: V8 termination handler, SpiderMonkey interrupt callback, PostgreSQL statement_timeout
+- **Pros**: Tracks real elapsed time; easy to reason about deadlines
+- **Cons**: Needs host timers or threads; harder to support in no_std environments, and Rust threads cannot be force-cancelled so watchdogs must coordinate cooperative shutdown
+
+### Scheduler Time-Slicing
+Policies run inside a cooperative scheduler that yields after fixed work slices.
+The host can deprioritize or cancel long tasks while allowing others to continue.
+- **Examples**: Erlang BEAM reductions, .NET ThreadPool throttling
+- **Pros**: Isolates runaway workloads by design; integrates with host schedulers
+- **Cons**: Significant state bookkeeping; higher overhead for frequent yields, and feasible for VM control loops but practically impossible for the interpreter without a deep rewrite
+
+
+## Regorus Approach
+
+Regorus adopts the cooperative tick-budget model. In std builds, the best time source is used without any special configuration. In no_std builds (there is no standard time source) and test builds (which need to control the time source to avoid flakiness), the time source can be configured via a trait instance.
+
+Instead of checking elapsed time at each
+Evaluations accrue work units via `tick`, only reading the clock once the configured `check_interval` elapses, which balances responsiveness with low overhead when limits stay off.
+- **Closest Prevalent Approach**: Cooperative tick budgets
+- **Rationale**: Runs on std and no_std targets by swapping time sources, keeps tests deterministic, avoids watchdog threads or complex schedulers, and applies uniformly across evaluation modes without deep architectural changes.
+
+
+
+## Configuration Model
+
+### ExecutionTimerConfig
+
+`ExecutionTimerConfig` lives in `utils::limits::time` and contains:
+
+- `limit: Duration` — enforced wall-clock budget.
+- `check_interval: NonZeroU32` — number of work units between timer checks.
+
+### Work Units
+
+The timer does not prescribe what constitutes a single “work unit.” Instead, each caller chooses a
+granularity that matches its execution model:
+
+- The interpreter treats each scheduling step (e.g., evaluating a single statement or expression in
+   a rule) as a unit.
+- The VM typically reports one instruction per unit.
+
+This abstraction keeps the timer flexible while still guaranteeing that, regardless of the unit
+definition, the timer observes elapsed wall-clock time at predictable checkpoints controlled by
+`check_interval`.
+
+Interpreters treat the absence of an `ExecutionTimerConfig` as "no limit". When a configuration is present, callers can increase `check_interval` to amortize the cost of frequent checks.
+
+### Global Fallback vs Engine Overrides
+
+- `set_fallback_execution_timer_config` installs a process-wide fallback stored behind a spin mutex. Engines without an explicit override consult this value before every evaluation.
+- Each engine holds an optional `execution_timer_config`. When `Engine::set_execution_timer_config` is invoked, the engine stores the provided configuration and applies it to the interpreter immediately. Clearing the override via `Engine::clear_execution_timer_config` restores reliance on the global fallback.
+- Engines default to no time limit. Newly created engines apply the effective configuration (engine override or global fallback or default) during construction so that any first evaluation honors the expected budget.
+
+### Effective Configuration Lifecycle
+
+Before any evaluation entry point (query, rule, compilation), the engine:
+
+1. Computes the effective configuration via `execution_timer_config.or_else(fallback_execution_timer_config)`.
+2. Applies it to the interpreter using `apply_effective_execution_timer_config`, which resets the timer to ensure a fresh window.
+3. Proceeds with evaluation, relying on interpreter checkpoints to enforce the deadline.
+
+This approach guarantees that changing the global fallback impacts both new and existing engines on their next evaluation, while engine overrides remain isolated.
+
+## ExecutionTimer Behavior
+
+`ExecutionTimer` maintains four fields:
+
+- `config`: the active `ExecutionTimerConfig`, if any.
+- `start`: optional start instant.
+- `accumulated_units`: tracks work units until the next check.
+- `last_elapsed`: caches the most recent elapsed duration.
+
+### Key Operations
+
+- `start(now)` records the baseline instant and clears accumulated counters.
+- `tick(work_units, now)` increments the accumulator and triggers `check_now` when the accumulator reaches `check_interval`. If no configuration is installed, the function returns early with `Ok(())`.
+- `check_now(now)` computes elapsed time, updates `last_elapsed`, and returns `LimitError::TimeLimitExceeded` when elapsed > limit.
+- `elapsed(now)` reports elapsed time without mutating state, enabling diagnostics and tests.
+
+Because ticks only perform the expensive comparison after the configured interval, callers can tune `check_interval` to their workloads.
+
+## Time Sources
+
+To avoid direct dependencies on `Instant`, the timer expects callers to supply a monotonic `Duration` via `monotonic_now()` or custom sources.
+
+- On `std` builds, `StdTimeSource` captures a single `Instant` per process (via `OnceLock`) and reports elapsed durations. This keeps time monotonic and stable across threads.
+- Tests and `no_std` builds can install overrides through `set_time_source`, which stores an `&'static dyn TimeSource` in a spin mutex. YAML tests use this hook to provide deterministic timestamps, ensuring repeatable limit violations.
+
+If no source is available (e.g., `no_std` without an override), `monotonic_now` returns `None`; the interpreter treats this as “time limiting unavailable,” effectively disabling checks.
+
+## Interpreter Integration
+
+The interpreter carries an `ExecutionTimer`. Evaluation steps integrate with the timer as follows:
+
+1. `prepare_for_eval` applies the effective configuration and calls `reset` on internal state.
+2. At key checkpoints (rule scheduling, loop iterations, query evaluation steps) the interpreter:
+   - Calls `monotonic_now` to fetch the current time (when available).
+   - Invokes `tick(1, now)` to check for limit violations.
+3. When `LimitError::TimeLimitExceeded` is returned, the interpreter converts it into an error surface consistent with existing APIs (e.g., `anyhow::Error` on Rust, host-specific exceptions on bindings).
+
+Because the interpreter amortizes clock reads via `check_interval`, the overhead remains low even with many evaluation steps.
+
+## Compiled Policy Integration
+
+Compiled policies (VM paths) share the interpreter’s timer via `apply_effective_execution_timer_config`. Before VM execution begins, the engine ensures the VM’s interpreter state reflects the current timer configuration and resets any per-evaluation state.
+
+- VM loops call `tick` with the number of instructions executed since the last check (commonly `1`).
+- Helper functions responsible for longer-running host interactions (e.g., print gathering) may call `check_now` to enforce the deadline before crossing the FFI boundary.
+
+This shared timer model avoids duplicate configuration state and maintains consistent semantics across evaluation modes.
+
+## Public API Surface
+
+The design exposes these primary methods:
+
+- `Engine::set_execution_timer_config(config: ExecutionTimerConfig)` stores a per-engine override and reapplies it immediately, ensuring the next evaluation enforces the new limits.
+- `Engine::clear_execution_timer_config()` removes the override and reverts to the global fallback.
+- `set_fallback_execution_timer_config(config: Option<ExecutionTimerConfig>)` installs an optional global fallback. Passing `None` clears it.
+- `fallback_execution_timer_config() -> Option<ExecutionTimerConfig>` returns the currently active fallback for diagnostics.
+
+Documentation highlights that engines default to no time limit, global settings provide a quick way to protect all engines, and overrides preempt the global value until cleared.
+
+## Testing Strategy
+
+- **Unit Tests** in `utils::limits::time` verify timer configuration handling, `tick` behavior, limit enforcement, and custom time sources.
+- **Integration Tests (YAML)** configure deterministic time sources and assert that engine-level and global configurations interact correctly (override precedence, clearing behavior, fresh windows per evaluation).
+- **Binding Tests** (planned) will demonstrate that FFI surfaces propagate timer errors.
+
+Each test resets global configuration and time sources via RAII guards to avoid cross-test interference.
+
+## Operational Guidance
+
+- Choose conservative `check_interval` values (e.g., 1–10) for latency-sensitive workloads to catch runaway loops quickly. Larger intervals reduce overhead but increase the window between checks.
+- When applying global limits in multi-tenant services, consider setting per-engine overrides for trusted workloads that need higher budgets.
+- Combine with monitoring of `last_elapsed` to understand how close evaluations come to their deadlines.
+
+## Pros and Cons of the Current Design
+
+### Pros
+- **Low overhead via amortized checks**: `check_interval` keeps clock reads cheap while bounding elapsed time.
+- **Works on std + no_std**: `TimeSource` abstraction enables std `Instant` or user-provided clocks.
+- **Simple API surface**: One config struct, plus global fallback and per-engine override.
+- **Suspend-aware VM**: suspendable execution snapshots elapsed time and resumes from that value, so suspended time is not counted.
+
+### Cons
+- **Best-effort when no time source**: If `monotonic_now()` returns `None`, time limits effectively disable for that run.
+- **Granularity depends on `check_interval`**: Large intervals can overshoot the limit before the next check fires.
+- **Cooperative gaps**: Any long-running host work outside evaluation loops is not accounted for.
+- **Global fallback is process-wide**: Requires coordination in tests or multi-tenant hosts.
+
+## Binding Surface (C# / FFI)
+
+Regorus exposes execution timers in bindings through a thin FFI layer:
+
+- **FFI struct**: `RegorusExecutionTimerConfig` uses `limit_ns` + `check_interval` and validates non-zero intervals.
+- **Engine methods**: per-engine `SetExecutionTimerConfig` / `ClearExecutionTimerConfig` map to `regorus_engine_set_execution_timer_config` / `regorus_engine_clear_execution_timer_config`.
+- **Fallback**: static `Engine.SetFallbackExecutionTimerConfig` / `ClearFallbackExecutionTimerConfig` map to `regorus_set_fallback_execution_timer_config` and `regorus_clear_fallback_execution_timer_config`.
+
+These bindings preserve Rust semantics and propagate the `LimitError` message (“execution exceeded time limit”) up to host exceptions.
+
+## Comparison: Cancellation Token Approach
+
+A cancellation token design would add an explicit “stop now” signal that evaluators check at the same checkpoints used for time limiting. This has value for host‑initiated cancellation, but it is **not a replacement** for the current time‑based approach.
+
+- **Semantics**: Tokens require the host to decide when to cancel; the current design enforces wall‑clock budgets inside Regorus.
+- **Portability**: Tokens are portable, but time‑based cancellation would require a watchdog or scheduler to flip the token at a deadline.
+- **Threads**: A watchdog typically implies background threads or an async runtime. We explicitly want to **avoid introducing threads** inside Regorus for simplicity, no_std compatibility, and predictability.
+- **Performance**: Frequent timer‑thread ticks or per‑evaluation scheduling can add overhead for microsecond‑scale evaluations. The current cooperative checks amortize clock reads and avoid extra threads, keeping steady‑state costs low.
+
+For these reasons, Regorus keeps the cooperative time‑limit checks as the primary mechanism and treats cancellation tokens (if added) as an optional, host‑driven complement rather than a replacement.
+
+## Future Work
+
+- Expose per-evaluation overrides (e.g., request-scoped budgets) to complement global and engine-level configuration.
+- Surface telemetry events whenever limits are hit, providing elapsed time at breach for observability pipelines.
+- Investigate dynamic adjustment of `check_interval` based on observed evaluation patterns to balance overhead and responsiveness.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ mod schema;
 pub mod target;
 #[cfg(any(test, all(feature = "yaml", feature = "std")))]
 pub mod test_utils;
-mod utils;
+pub mod utils;
 mod value;
 
 #[cfg(feature = "azure_policy")]

--- a/src/rvm/vm/errors.rs
+++ b/src/rvm/vm/errors.rs
@@ -5,6 +5,7 @@ use super::execution_model::SuspendReason;
 use crate::value::Value;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::time::Duration;
 use thiserror::Error;
 
 /// VM execution errors
@@ -17,7 +18,14 @@ pub enum VmError {
         pc: usize,
     },
 
-    #[error("Execution stopped: exceeded maximum memory limit of {limit} bytes with usage {usage} bytes (pc={pc})")]
+    #[error("Execution exceeded time limit (elapsed={elapsed:?}, limit={limit:?}, pc={pc})")]
+    TimeLimitExceeded {
+        elapsed: Duration,
+        limit: Duration,
+        pc: usize,
+    },
+
+    #[error("Execution exceeded memory limit (usage={usage} bytes, limit={limit} bytes, pc={pc})")]
     MemoryLimitExceeded { usage: u64, limit: u64, pc: usize },
 
     #[error("Literal index {index} out of bounds (pc={pc})")]

--- a/src/utils/limits/mod.rs
+++ b/src/utils/limits/mod.rs
@@ -8,8 +8,11 @@
 mod error;
 #[cfg(feature = "allocator-memory-limits")]
 mod memory;
+mod time;
+
 #[allow(unused_imports)]
 pub use error::LimitError;
+
 #[allow(unused_imports)]
 #[cfg(feature = "allocator-memory-limits")]
 pub use memory::{
@@ -17,6 +20,19 @@ pub use memory::{
     global_memory_limit, set_global_memory_limit, set_thread_flush_threshold_override,
     thread_memory_flush_threshold,
 };
+
+#[allow(unused_imports)]
+pub use time::{
+    fallback_execution_timer_config, monotonic_now, set_fallback_execution_timer_config,
+    ExecutionTimer, ExecutionTimerConfig, TimeSource,
+};
+
+#[cfg(test)]
+pub use time::acquire_limits_test_lock;
+
+#[cfg(any(test, not(feature = "std")))]
+#[allow(unused_imports)]
+pub use time::{set_time_source, TimeSourceRegistrationError};
 
 #[cfg(feature = "allocator-memory-limits")]
 #[inline]
@@ -26,12 +42,12 @@ pub fn check_memory_limit_if_needed() -> core::result::Result<(), LimitError> {
 
 #[cfg(not(feature = "allocator-memory-limits"))]
 #[inline]
-pub fn enforce_memory_limit() -> core::result::Result<(), LimitError> {
+pub const fn enforce_memory_limit() -> core::result::Result<(), LimitError> {
     Ok(())
 }
 
 #[cfg(not(feature = "allocator-memory-limits"))]
 #[inline]
-pub fn check_memory_limit_if_needed() -> core::result::Result<(), LimitError> {
+pub const fn check_memory_limit_if_needed() -> core::result::Result<(), LimitError> {
     Ok(())
 }

--- a/src/utils/limits/time.rs
+++ b/src/utils/limits/time.rs
@@ -1,0 +1,474 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/*
+ExecutionTimer provides cooperative wall-clock enforcement for long-running
+policy evaluations. The timer tracks three pieces of state:
+- ExecutionTimerConfig, which holds the optional wall-clock budget and the
+    interval (in work units) between time checks.
+- The monotonic start instant recorded via start(now), expressed as a
+    Duration from whatever time source the engine uses.
+- An accumulator that counts work units so callers can amortize expensive
+    time queries; once the counter reaches the configured interval, tick()
+    performs a check and preserves any remainder.
+
+The timer never calls into a clock directly. Instead, callers pass the
+current monotonic Duration to start(), tick(), check_now(), or elapsed().
+Helper monotonic_now() returns that Duration by selecting a TimeSource
+implementation:
+- On std builds we use StdTimeSource, which anchors a std::time::Instant via
+    OnceLock and reports elapsed() for stable, monotonic measurements.
+- In tests and truly no_std builds we allow integrators to inject a global
+    &'static dyn TimeSource using set_time_source(). This override lives behind
+    a spin::Mutex<Option<...>> so the critical section stays small (just a
+    pointer read) while remaining usable in bare-metal environments.
+
+With this design the interpreter can cheaply interleave work with periodic
+limit checks. Std builds automatically use the Instant-backed source, while
+embedded users configure both their ExecutionTimerConfig and a single global
+time source without paying for per-interpreter callbacks or unsafe code.
+*/
+
+use core::num::NonZeroU32;
+use core::time::Duration;
+
+use spin::Mutex;
+
+use super::LimitError;
+
+#[cfg(test)]
+use std::sync::{Mutex as StdMutex, MutexGuard as StdMutexGuard};
+
+/// Public configuration for the cooperative execution time limiter.
+///
+/// The limiter reads this struct to determine how often it should check for wall-clock overruns and
+/// what deadline to enforce. Engines without a configuration skip time checks; when a configuration
+/// is present, it normally pairs a concrete deadline with a small [`NonZeroU32`] interval so
+/// interpreter loops amortize their clock reads without skipping checks for long stretches of
+/// repetitive work. The process-wide fallback installed via [`set_fallback_execution_timer_config`]
+/// supplies this configuration when an engine lacks its own override.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExecutionTimerConfig {
+    /// Maximum allowed wall-clock duration.
+    pub limit: Duration,
+    /// Number of work units between time checks (minimum 1).
+    pub check_interval: NonZeroU32,
+}
+
+/// Cooperative time-limit tracker shared across interpreter and VM loops.
+#[derive(Debug)]
+pub struct ExecutionTimer {
+    config: Option<ExecutionTimerConfig>,
+    start: Option<Duration>,
+    accumulated_units: u32,
+    last_elapsed: Duration,
+}
+
+/// Monotonic time provider.
+pub trait TimeSource: Send + Sync {
+    /// Returns a non-decreasing duration since an arbitrary anchor.
+    fn now(&self) -> Option<Duration>;
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+struct StdTimeSource;
+
+#[cfg(feature = "std")]
+impl StdTimeSource {
+    const fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(feature = "std")]
+impl TimeSource for StdTimeSource {
+    fn now(&self) -> Option<Duration> {
+        use std::sync::OnceLock;
+
+        static ANCHOR: OnceLock<std::time::Instant> = OnceLock::new();
+        let anchor = ANCHOR.get_or_init(std::time::Instant::now);
+        Some(anchor.elapsed())
+    }
+}
+
+#[cfg(feature = "std")]
+static STD_TIME_SOURCE: StdTimeSource = StdTimeSource::new();
+
+#[cfg(any(test, not(feature = "std")))]
+static TIME_SOURCE_OVERRIDE: Mutex<Option<&'static dyn TimeSource>> = Mutex::new(None);
+
+#[cfg(any(test, not(feature = "std")))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeSourceRegistrationError {
+    AlreadySet,
+}
+
+#[cfg(any(test, not(feature = "std")))]
+impl core::fmt::Display for TimeSourceRegistrationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::AlreadySet => f.write_str("time source already configured"),
+        }
+    }
+}
+
+#[cfg(any(test, not(feature = "std")))]
+impl core::error::Error for TimeSourceRegistrationError {}
+
+static FALLBACK_EXECUTION_TIMER_CONFIG: Mutex<Option<ExecutionTimerConfig>> = Mutex::new(None);
+
+#[cfg(test)]
+static LIMITS_TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+#[cfg(test)]
+pub fn acquire_limits_test_lock() -> StdMutexGuard<'static, ()> {
+    LIMITS_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Returns the duration supplied by the chosen source for this build.
+pub fn monotonic_now() -> Option<Duration> {
+    #[cfg(any(test, not(feature = "std")))]
+    // Spin mutex acquisition incurs only a few atomic ops; the critical section
+    // is a single pointer read, so uncontended overhead stays tiny.
+    if let Some(source) = {
+        let guard = TIME_SOURCE_OVERRIDE.lock();
+        *guard
+    } {
+        if let Some(duration) = source.now() {
+            return Some(duration);
+        }
+    }
+
+    #[cfg(feature = "std")]
+    {
+        STD_TIME_SOURCE.now()
+    }
+
+    #[cfg(not(feature = "std"))]
+    {
+        None
+    }
+}
+
+#[cfg(any(test, not(feature = "std")))]
+pub fn set_time_source(source: &'static dyn TimeSource) -> Result<(), TimeSourceRegistrationError> {
+    let mut slot = TIME_SOURCE_OVERRIDE.lock();
+    if slot.is_some() {
+        Err(TimeSourceRegistrationError::AlreadySet)
+    } else {
+        *slot = Some(source);
+        Ok(())
+    }
+}
+
+/// Sets the process-wide fallback configuration for the execution time limiter. Engine instances can
+/// override this fallback via [`Engine::set_execution_timer_config`](crate::Engine::set_execution_timer_config).
+///
+/// # Examples
+///
+/// ```
+/// use std::num::NonZeroU32;
+/// use std::time::Duration;
+/// use regorus::utils::limits::{
+///     fallback_execution_timer_config,
+///     set_fallback_execution_timer_config,
+///     ExecutionTimerConfig,
+/// };
+///
+/// let config = ExecutionTimerConfig {
+///     limit: Duration::from_secs(1),
+///     check_interval: NonZeroU32::new(10).unwrap(),
+/// };
+/// set_fallback_execution_timer_config(Some(config));
+/// assert_eq!(fallback_execution_timer_config(), Some(config));
+/// ```
+pub fn set_fallback_execution_timer_config(config: Option<ExecutionTimerConfig>) {
+    *FALLBACK_EXECUTION_TIMER_CONFIG.lock() = config;
+}
+
+/// Returns the process-wide fallback configuration for the execution time limiter, if any.
+///
+/// # Examples
+///
+/// ```
+/// use regorus::utils::limits::fallback_execution_timer_config;
+///
+/// // By default no fallback execution timer is configured.
+/// assert!(fallback_execution_timer_config().is_none());
+/// ```
+pub fn fallback_execution_timer_config() -> Option<ExecutionTimerConfig> {
+    let guard = FALLBACK_EXECUTION_TIMER_CONFIG.lock();
+    guard.as_ref().copied()
+}
+
+impl ExecutionTimer {
+    /// Construct a new timer with the provided configuration.
+    pub const fn new(config: Option<ExecutionTimerConfig>) -> Self {
+        Self {
+            config,
+            start: None,
+            accumulated_units: 0,
+            last_elapsed: Duration::ZERO,
+        }
+    }
+
+    /// Reset the timer state to its initial configuration without recording a start instant.
+    pub const fn reset(&mut self) {
+        self.start = None;
+        self.accumulated_units = 0;
+        self.last_elapsed = Duration::ZERO;
+    }
+
+    /// Reset any prior state and record the start instant.
+    pub const fn start(&mut self, now: Duration) {
+        self.start = Some(now);
+        self.accumulated_units = 0;
+        self.last_elapsed = Duration::ZERO;
+    }
+
+    /// Returns the timer configuration.
+    pub const fn config(&self) -> Option<ExecutionTimerConfig> {
+        self.config
+    }
+
+    /// Returns the configured limit.
+    pub const fn limit(&self) -> Option<Duration> {
+        match self.config {
+            Some(config) => Some(config.limit),
+            None => None,
+        }
+    }
+
+    /// Returns the last elapsed duration recorded by a check.
+    pub const fn last_elapsed(&self) -> Duration {
+        self.last_elapsed
+    }
+
+    /// Increment work units and run the periodic limit check when necessary.
+    pub fn tick(&mut self, work_units: u32, now: Duration) -> Result<(), LimitError> {
+        let Some(config) = self.config else {
+            return Ok(());
+        };
+        self.accumulated_units = self.accumulated_units.saturating_add(work_units);
+        if self.accumulated_units < config.check_interval.get() {
+            return Ok(());
+        }
+
+        // Preserve the remainder so that callers do not lose fractional work.
+        let interval = config.check_interval.get();
+        self.accumulated_units %= interval;
+        self.check_now(now)
+    }
+
+    /// Force an immediate check against the configured deadline.
+    pub fn check_now(&mut self, now: Duration) -> Result<(), LimitError> {
+        let Some(config) = self.config else {
+            return Ok(());
+        };
+        let Some(start) = self.start else {
+            return Ok(());
+        };
+
+        let elapsed = now.checked_sub(start).unwrap_or(Duration::ZERO);
+        self.last_elapsed = elapsed;
+        if elapsed > config.limit {
+            return Err(LimitError::TimeLimitExceeded {
+                elapsed,
+                limit: config.limit,
+            });
+        }
+        Ok(())
+    }
+
+    /// Compute elapsed time relative to the recorded start, if available.
+    pub fn elapsed(&self, now: Duration) -> Option<Duration> {
+        let start = self.start?;
+        Some(now.checked_sub(start).unwrap_or(Duration::ZERO))
+    }
+
+    /// Realign the timer start so that a previously consumed `elapsed` duration is preserved while
+    /// ignoring any wall-clock time that passed during a suspension window.
+    pub const fn resume_from_elapsed(&mut self, now: Duration, elapsed: Duration) {
+        if self.config.is_none() {
+            return;
+        }
+
+        self.start = Some(now.saturating_sub(elapsed));
+        self.last_elapsed = elapsed;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::num::NonZeroU32;
+    use core::sync::atomic::{AtomicU64, Ordering};
+    use core::time::Duration;
+
+    fn nz(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).unwrap_or(NonZeroU32::MIN)
+    }
+
+    #[test]
+    fn tick_defers_checks_until_interval_is_reached() {
+        let mut timer = ExecutionTimer::new(Some(ExecutionTimerConfig {
+            limit: Duration::from_millis(100),
+            check_interval: nz(4),
+        }));
+
+        timer.start(Duration::from_millis(0));
+
+        for step in 1..4 {
+            let now = Duration::from_millis((step * 10) as u64);
+            let result = timer.tick(1, now);
+            assert_eq!(result, Ok(()), "tick before reaching interval must succeed");
+            assert_eq!(timer.last_elapsed(), Duration::ZERO);
+        }
+
+        let result = timer.tick(1, Duration::from_millis(40));
+        assert_eq!(result, Ok(()), "tick at interval boundary must succeed");
+        assert_eq!(timer.last_elapsed(), Duration::from_millis(40));
+    }
+
+    #[test]
+    fn check_now_reports_limit_exceeded() {
+        let mut timer = ExecutionTimer::new(Some(ExecutionTimerConfig {
+            limit: Duration::from_millis(25),
+            check_interval: nz(1),
+        }));
+
+        timer.start(Duration::from_millis(0));
+        assert_eq!(
+            timer.tick(1, Duration::from_millis(10)),
+            Ok(()),
+            "tick before limit breach must succeed"
+        );
+
+        let result = timer.check_now(Duration::from_millis(30));
+        assert!(matches!(&result, Err(LimitError::TimeLimitExceeded { .. })));
+
+        if let Err(LimitError::TimeLimitExceeded { elapsed, limit }) = result {
+            assert!(elapsed > limit);
+            assert_eq!(limit, Duration::from_millis(25));
+        }
+    }
+
+    #[test]
+    fn tick_reports_limit_exceeded() {
+        let mut timer = ExecutionTimer::new(Some(ExecutionTimerConfig {
+            limit: Duration::from_millis(30),
+            check_interval: nz(2),
+        }));
+
+        timer.start(Duration::from_millis(0));
+        assert_eq!(
+            timer.tick(1, Duration::from_millis(10)),
+            Ok(()),
+            "initial tick must succeed"
+        );
+
+        let result = timer.tick(1, Duration::from_millis(35));
+        assert!(matches!(&result, Err(LimitError::TimeLimitExceeded { .. })));
+
+        if let Err(LimitError::TimeLimitExceeded { elapsed, limit }) = result {
+            assert!(elapsed > limit);
+            assert_eq!(limit, Duration::from_millis(30));
+            assert_eq!(timer.last_elapsed(), elapsed);
+        }
+    }
+
+    #[test]
+    fn tick_before_start_is_noop() {
+        let mut timer = ExecutionTimer::new(Some(ExecutionTimerConfig {
+            limit: Duration::from_secs(1),
+            check_interval: nz(1),
+        }));
+
+        let result = timer.tick(1, Duration::from_millis(100));
+        assert_eq!(result, Ok(()), "tick before start should be ignored");
+        assert_eq!(timer.last_elapsed(), Duration::ZERO);
+        assert!(timer.elapsed(Duration::from_millis(200)).is_none());
+    }
+
+    #[test]
+    fn check_now_allows_elapsed_equal_to_limit() {
+        let mut timer = ExecutionTimer::new(Some(ExecutionTimerConfig {
+            limit: Duration::from_millis(50),
+            check_interval: nz(1),
+        }));
+
+        timer.start(Duration::from_millis(0));
+        assert_eq!(
+            timer.tick(1, Duration::from_millis(30)),
+            Ok(()),
+            "tick prior to equality check must succeed"
+        );
+        let result = timer.check_now(Duration::from_millis(50));
+        assert_eq!(result, Ok(()), "elapsed equal to limit must not fail");
+        assert_eq!(timer.last_elapsed(), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn tick_is_noop_when_limit_disabled() {
+        let mut timer = ExecutionTimer::new(None);
+
+        timer.start(Duration::from_millis(0));
+
+        for step in 0..8 {
+            let now = Duration::from_millis((step + 1) as u64);
+            assert_eq!(
+                timer.tick(1, now),
+                Ok(()),
+                "ticks with disabled limit must succeed"
+            );
+        }
+
+        assert_eq!(timer.last_elapsed(), Duration::ZERO);
+    }
+
+    #[test]
+    fn check_now_is_noop_before_start() {
+        let mut timer = ExecutionTimer::new(None);
+        let result = timer.check_now(Duration::from_secs(1));
+        assert_eq!(result, Ok(()), "check before start must be ignored");
+        assert!(timer.elapsed(Duration::from_secs(2)).is_none());
+    }
+
+    #[test]
+    fn elapsed_reports_offset_from_start() {
+        let mut timer = ExecutionTimer::new(None);
+        timer.start(Duration::from_millis(5));
+        let elapsed = timer.elapsed(Duration::from_millis(20));
+        assert_eq!(elapsed, Some(Duration::from_millis(15)));
+    }
+
+    #[test]
+    fn monotonic_now_uses_override_when_present() {
+        static TEST_TIME: AtomicU64 = AtomicU64::new(0);
+
+        struct TestSource;
+
+        impl TimeSource for TestSource {
+            fn now(&self) -> Option<Duration> {
+                Some(Duration::from_nanos(TEST_TIME.load(Ordering::Relaxed)))
+            }
+        }
+
+        static SOURCE: TestSource = TestSource;
+
+        let _suite_guard = super::acquire_limits_test_lock();
+
+        let mut slot = super::TIME_SOURCE_OVERRIDE.lock();
+        let previous = (*slot).replace(&SOURCE);
+        drop(slot);
+
+        TEST_TIME.store(123_000_000, Ordering::Relaxed);
+        assert_eq!(monotonic_now(), Some(Duration::from_nanos(123_000_000)));
+
+        let mut slot = super::TIME_SOURCE_OVERRIDE.lock();
+        *slot = previous;
+    }
+}

--- a/tests/interpreter/cases/limits/execution_timer.yaml
+++ b/tests/interpreter/cases/limits/execution_timer.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: engine-configured timer triggers limit error
+    data:
+      values: [1, 2, 3, 4, 5]
+    modules:
+      - |
+        package limits.timer
+        import rego.v1
+
+        count_values := count({value | value := data.values[_]})
+    query: data.limits.timer.count_values
+    execution_timer:
+      limit_ms: 1
+      check_interval: 1
+    time_source:
+      default_increment_ms: 5
+    error: execution exceeded time limit
+
+  - note: global timer limit applies without engine override
+    data:
+      values: [1, 2, 3, 4, 5]
+    modules:
+      - |
+        package limits.timer
+        import rego.v1
+
+        count_values := count({value | value := data.values[_]})
+    query: data.limits.timer.count_values
+    global_execution_timer:
+      limit_ms: 1
+      check_interval: 1
+    time_source:
+      default_increment_ms: 5
+    error: execution exceeded time limit
+
+  - note: engine override increases limit above global default
+    data:
+      values: [1, 2, 3, 4, 5]
+    modules:
+      - |
+        package limits.timer
+        import rego.v1
+
+        count_values := count({value | value := data.values[_]})
+    query: data.limits.timer.count_values
+    global_execution_timer:
+      limit_ms: 1
+      check_interval: 1
+    execution_timer:
+      limit_ms: 500
+      check_interval: 1
+    time_source:
+      default_increment_ms: 5
+    want_result: 5
+
+  - note: repeated ticks eventually exceed limit
+    data:
+      values: [1, 2, 3, 4, 5]
+    modules:
+      - |
+        package limits.timer
+        import rego.v1
+
+        count_values := count({value | value := data.values[_]})
+    query: data.limits.timer.count_values
+    execution_timer:
+      limit_ms: 6
+      check_interval: 1
+    time_source:
+      default_increment_ms: 2
+    error: execution exceeded time limit
+
+  - note: global timer disabled removes limit
+    data:
+      values: [1, 2, 3, 4, 5]
+    modules:
+      - |
+        package limits.timer
+        import rego.v1
+
+        count_values := count({value | value := data.values[_]})
+    query: data.limits.timer.count_values
+    global_execution_timer:
+      disable: true
+    time_source:
+      default_increment_ms: 5
+    want_result: 5


### PR DESCRIPTION
  - Introduce ExecutionTimer/ExecutionTimerConfig to allow limiting evaluating time.
  - To amortize time checking costs, checking interval can be configured via the notion of work units
  - A global fallback time limit can be set to universally limit all evaluation in addition to engine level limit setting.
  - Implement limnits in interpreter and RVM. In RVM, also handle suspend/resume so that time during pause is not counted.
  - Add engine-level APIs to set/clear per-engine timer configuration and apply global fallback defaults.
  - Surface execution-time limits through FFI and C# bindings
  - Add C# tests and example usage to validate engine overrides, global fallback behavior, and compiled policy enforcement.
  - Expand docs for execution-time limit
  - Add interpreter YAML cases and VM unit tests for time-limit behavior and deterministic time sources.
