### PR TITLE
chore(nuget): Add support for macosx

### DIFF
--- a/.github/workflows/test-csharp.yml
+++ b/.github/workflows/test-csharp.yml
@@ -31,17 +31,18 @@ jobs:
             target: x86_64-unknown-linux-gnu
             libpath: |
               **/release/libregorus_ffi.so
-          # Disabled for now
-          #- os: macos-latest
-          #  target: aarch64-apple-darwin
-          #  libpath: |
-          #    **/release/libregorus_ffi.dylib
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            libpath: |
+              **/release/libregorus_ffi.dylib
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
       - uses: ./.github/actions/toolchains/rust
+        with:
+          targets: ${{ matrix.runtime.target }}
       - name: Cache cargo
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
@@ -99,13 +100,15 @@ jobs:
         run: ls -R ./bindings/csharp/Regorus/tmp
 
       - name: Build Regorus nuget via xtask
-        run: cargo xtask build-csharp --release --clean --artifacts-dir ./bindings/csharp/Regorus/tmp/bindings/ffi/target --enforce-artifacts
+        run: cargo xtask build-csharp --release --clean --artifacts-dir ./bindings/csharp/Regorus/tmp/bindings/ffi/target --enforce-artifacts --repository-commit ${{ github.sha }} --include-symbols
 
       - name: Upload Regorus nuget
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: regorus-nuget
-          path: bindings/csharp/Regorus/bin/Release/Regorus*.nupkg
+          path: |
+            bindings/csharp/Regorus/bin/Release/Regorus*.nupkg
+            bindings/csharp/Regorus/bin/Release/Regorus*.snupkg
           if-no-files-found: error
           retention-days: 1
 
@@ -122,8 +125,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          #- os: macos-latest
-          #  target: aarch64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/bindings/csharp/Regorus/Regorus.csproj
+++ b/bindings/csharp/Regorus/Regorus.csproj
@@ -11,6 +11,15 @@
         <VersionPrefix>0.9.0</VersionPrefix>
         <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseExpression>MIT AND Apache-2.0 AND BSD-3-Clause</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/microsoft/regorus</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/microsoft/regorus</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <Authors>Microsoft</Authors>
+        <Company>Microsoft</Company>
+        <PackageTags>rego;policy;engine;authorization;opa;rust</PackageTags>
+        <Description>Fast, lightweight Rego interpreter and policy engine for .NET, powered by Rust.</Description>
+        <Copyright>Copyright (c) Microsoft Corporation.</Copyright>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -46,10 +55,14 @@
 
          <Error Text="$(RegorusFFIArtifactsDir)/x86_64-unknown-linux-gnu/$(RegorusFFIArtifactsProfile)/libregorus_ffi.so missing."
              Condition="!Exists('$(RegorusFFIArtifactsDir)/x86_64-unknown-linux-gnu/$(RegorusFFIArtifactsProfile)/libregorus_ffi.so')" />
+
+         <Error Text="$(RegorusFFIArtifactsDir)/aarch64-apple-darwin/$(RegorusFFIArtifactsProfile)/libregorus_ffi.dylib missing."
+             Condition="!Exists('$(RegorusFFIArtifactsDir)/aarch64-apple-darwin/$(RegorusFFIArtifactsProfile)/libregorus_ffi.dylib')" />
     </Target>
 
     <ItemGroup>
         <None Include="docs/README.md" Pack="true"  PackagePath="/" />
+        <None Include="../../../LICENSE" Pack="true" PackagePath="/" />
 
         <!-- Copy each binary to expected location within the package -->
         <None Include="$(RegorusFFIArtifactsDir)/x86_64-pc-windows-msvc/$(RegorusFFIArtifactsProfile)/*.dll" Pack="true" PackagePath="runtimes/win-x64/native/" />

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -4,6 +4,7 @@
 name = "regorus-ffi"
 version = "0.9.0"
 edition = "2021"
+license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.9.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/java"
 description = "Java bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
+license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 keywords = ["interpreter", "opa", "policy-as-code", "rego"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -18,7 +18,15 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>https://opensource.org/blog/license/mit</url>
+      <url>https://opensource.org/licenses/MIT</url>
+    </license>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+    <license>
+      <name>BSD 3-Clause License</name>
+      <url>https://opensource.org/licenses/BSD-3-Clause</url>
     </license>
   </licenses>
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.9.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/python"
 description = "Python bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
+license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 keywords = ["interpreter", "opa", "policy-as-code", "rego"]
 
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -5,7 +5,11 @@ build-backend = "maturin"
 [project]
 name = "regorus"
 requires-python = ">=3.8"
+license = { text = "MIT AND Apache-2.0 AND BSD-3-Clause" }
 classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: BSD License",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",

--- a/bindings/ruby/ext/regorusrb/Cargo.toml
+++ b/bindings/ruby/ext/regorusrb/Cargo.toml
@@ -3,6 +3,7 @@ name = "regorusrb"
 version = "0.9.0"
 edition = "2024"
 description = "Ruby bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
+license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 publish = false
 
 [lib]

--- a/bindings/ruby/regorusrb.gemspec
+++ b/bindings/ruby/regorusrb.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Ruby bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
   spec.homepage = "https://github.com/microsoft/regorus/blob/main/bindings/ruby"
-  spec.license = "MIT"
+  spec.licenses = ["MIT", "Apache-2.0", "BSD-3-Clause"]
   spec.required_ruby_version = ">= 3.4.2"
   spec.required_rubygems_version = ">= 3.6.5"
 

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.9.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/wasm"
 description = "WASM bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
+license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 keywords = ["interpreter", "opa", "policy-as-code", "rego"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/xtask/src/tasks/bindings/all.rs
+++ b/xtask/src/tasks/bindings/all.rs
@@ -36,6 +36,8 @@ impl BuildAllBindingsCommand {
             clean: false,
             artifacts_dir: Some(ffi_dir.clone()),
             enforce_artifacts: false,
+            repository_commit: None,
+            include_symbols: false,
         })?;
 
         if nuget_result.packages.is_empty() {


### PR DESCRIPTION
Additionally
- Include more metadata in nuget package
- Also generate snupkg for native symbols.
  We intentionally don't add the symbols for native rust shared library
  to the nuget package since that could increase the size of the nuget.
  We will revisit that later.
- update licenses of all the bindings.

closes #551 
