### PR TITLE
chore: Gate exports using allocator-limits feature

### DIFF
--- a/mimalloc/src/lib.rs
+++ b/mimalloc/src/lib.rs
@@ -4,6 +4,7 @@
 #[cfg(not(any(target_family = "wasm")))]
 pub mod mimalloc;
 
+#[cfg(feature = "allocator-memory-limits")]
 #[cfg(not(any(target_family = "wasm")))]
 pub use mimalloc::{
     allocation_stats_snapshot, current_thread_allocation_stats, global_allocation_stats_snapshot,

--- a/mimalloc/src/mimalloc.rs
+++ b/mimalloc/src/mimalloc.rs
@@ -29,9 +29,9 @@ unsafe impl GlobalAlloc for Mimalloc {
     }
 
     #[inline]
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
         #[cfg(feature = "allocator-memory-limits")]
-        record_free(layout.size());
+        record_free(_layout.size());
         mi_free(ptr.cast::<c_void>());
     }
 


### PR DESCRIPTION
This is needed to publish regorus-mimalloc