### PR TITLE
fix(bindings): harden C# bindings and tests, add pooling, bump 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/microsoft/regorus/compare/regorus-v0.9.0...regorus-v0.9.1) - 2026-02-06
+
+### Fixed
+- Release native C# handles reliably to avoid memory growth ([#571](https://github.com/microsoft/regorus/pull/571)).
+- Centralize C# handle gating with a short dispose wait and deferred release to avoid leaks while blocking new calls ([#571](https://github.com/microsoft/regorus/pull/571)).
+
+### Added
+- Manual C# memory growth tests for both `using` and finalizer paths ([#571](https://github.com/microsoft/regorus/pull/571)).
+- C# test runner options for filtered tests, console logging, and skipping sample apps ([#571](https://github.com/microsoft/regorus/pull/571)).
+
 ## [0.5.0](https://github.com/microsoft/regorus/compare/regorus-v0.4.0...regorus-v0.5.0) - 2025-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regorus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "regorus"
 description = "A fast, lightweight Rego (OPA policy language) interpreter"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 repository = "https://github.com/microsoft/regorus"

--- a/bindings/csharp/Benchmarks/Program.cs
+++ b/bindings/csharp/Benchmarks/Program.cs
@@ -7,7 +7,7 @@ namespace Benchmarks
         static void Main(string[] args)
         {
             Console.WriteLine("=== Regorus C# Benchmarks ===\n");
-            
+
             try
             {
                 Console.WriteLine("Running Engine Evaluation Benchmark...");
@@ -17,9 +17,9 @@ namespace Benchmarks
             {
                 Console.WriteLine($"Engine benchmark failed: {ex.Message}");
             }
-            
+
             Console.WriteLine("\n" + new string('=', 80) + "\n");
-            
+
             try
             {
                 Console.WriteLine("Running Compiled Policy Evaluation Benchmark...");
@@ -29,7 +29,7 @@ namespace Benchmarks
             {
                 Console.WriteLine($"Compiled policy benchmark failed: {ex.Message}");
             }
-            
+
             Console.WriteLine("\n=== Benchmarks Complete ===");
         }
     }

--- a/bindings/csharp/Directory.Packages.props
+++ b/bindings/csharp/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <RegorusPackageVersion>0.9.0</RegorusPackageVersion>
+    <RegorusPackageVersion>0.9.1</RegorusPackageVersion>
     <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
   </PropertyGroup>
 

--- a/bindings/csharp/Regorus.Tests/MemoryGrowthTests.cs
+++ b/bindings/csharp/Regorus.Tests/MemoryGrowthTests.cs
@@ -1,0 +1,320 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Regorus;
+
+namespace Regorus.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public class MemoryGrowthTests
+{
+    private static int Iterations =>
+        int.TryParse(Environment.GetEnvironmentVariable("REGORUS_MEMORY_TEST_ITERS"), out var value) ? value : 50_000;
+
+    private static int LogEvery =>
+        int.TryParse(Environment.GetEnvironmentVariable("REGORUS_MEMORY_TEST_LOG_EVERY"), out var value) ? value : 500;
+
+    private static int GcEvery
+    {
+        get
+        {
+            if (!int.TryParse(Environment.GetEnvironmentVariable("REGORUS_MEMORY_TEST_GC_EVERY"), out var value))
+            {
+                value = LogEvery;
+            }
+
+            return value <= 0 ? LogEvery : value;
+        }
+    }
+
+    private static long? MaxWorkingSetDeltaBytes
+    {
+        get
+        {
+            if (!long.TryParse(Environment.GetEnvironmentVariable("REGORUS_MEMORY_TEST_MAX_DELTA_MB"), out var mb))
+            {
+                mb = 32;
+            }
+
+            if (mb <= 0)
+            {
+                return null;
+            }
+
+            return mb * 1024L * 1024L;
+        }
+    }
+
+    private static ulong? GlobalRegorusMemoryLimitBytes
+    {
+        get
+        {
+            if (!ulong.TryParse(Environment.GetEnvironmentVariable("REGORUS_MEMORY_TEST_GLOBAL_REGORUS_LIMIT_MB"), out var mb))
+            {
+                return null;
+            }
+
+            if (mb == 0)
+            {
+                return null;
+            }
+
+            return mb * 1024UL * 1024UL;
+        }
+    }
+
+    private static void WithOptionalGlobalRegorusMemoryLimit(Action action)
+    {
+        var priorLimit = MemoryLimits.GetGlobalMemoryLimit();
+        try
+        {
+            if (GlobalRegorusMemoryLimitBytes is { } limit)
+            {
+                MemoryLimits.SetGlobalMemoryLimit(limit);
+            }
+
+            action();
+        }
+        finally
+        {
+            MemoryLimits.SetGlobalMemoryLimit(priorLimit);
+        }
+    }
+
+    private static void ForceFullGc()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+
+    [TestMethod]
+    public void Engine_create_eval_dispose_does_not_grow_working_set()
+    {
+        WithOptionalGlobalRegorusMemoryLimit(() =>
+        {
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var baseline = process.WorkingSet64;
+            var maxDelta = 0L;
+            var baselineManaged = GC.GetTotalMemory(false);
+            var maxManagedDelta = 0L;
+
+            for (var i = 1; i <= Iterations; i++)
+            {
+                using (var engine = new Engine())
+                {
+                    engine.AddPolicy("test.rego", "package test\nx = 1\nmessage = `Hello`");
+                    _ = engine.EvalRule("data.test.message");
+                }
+
+                if (i % LogEvery == 0)
+                {
+                    process.Refresh();
+                    var workingSet = process.WorkingSet64;
+                    var managed = GC.GetTotalMemory(false);
+                    var delta = workingSet - baseline;
+                    var managedDelta = managed - baselineManaged;
+                    if (delta > maxDelta)
+                    {
+                        maxDelta = delta;
+                    }
+                    if (managedDelta > maxManagedDelta)
+                    {
+                        maxManagedDelta = managedDelta;
+                    }
+                    Console.WriteLine($"\n\n\u001b[1m{i} ws_mb={workingSet / 1048576.0:F1} managed_mb={managed / 1048576.0:F1} delta_mb={delta / 1048576.0:F1}\u001b[0m\n\n");
+                }
+            }
+
+            if (MaxWorkingSetDeltaBytes is { } limit)
+            {
+                Console.WriteLine($"\n\n\u001b[1mSUMMARY: max ws delta {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB); max managed delta {maxManagedDelta / 1048576.0:F1} MB.\u001b[0m\n\n");
+                Assert.IsTrue(
+                    maxDelta <= limit,
+                    $"Working set grew by {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB). Managed heap max delta {maxManagedDelta / 1048576.0:F1} MB.");
+            }
+        });
+    }
+
+    [TestMethod]
+    public void Engine_create_eval_finalize_does_not_grow_working_set()
+    {
+        WithOptionalGlobalRegorusMemoryLimit(() =>
+        {
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var baseline = process.WorkingSet64;
+            var maxDelta = 0L;
+            var baselineManaged = GC.GetTotalMemory(false);
+            var maxManagedDelta = 0L;
+
+            for (var i = 1; i <= Iterations; i++)
+            {
+                var engine = new Engine();
+                engine.AddPolicy("test.rego", "package test\nx = 1\nmessage = `Hello`");
+                _ = engine.EvalRule("data.test.message");
+
+                if (i % GcEvery == 0)
+                {
+                    ForceFullGc();
+                }
+
+                if (i % LogEvery == 0)
+                {
+                    process.Refresh();
+                    var workingSet = process.WorkingSet64;
+                    var managed = GC.GetTotalMemory(false);
+                    var delta = workingSet - baseline;
+                    var managedDelta = managed - baselineManaged;
+                    if (delta > maxDelta)
+                    {
+                        maxDelta = delta;
+                    }
+                    if (managedDelta > maxManagedDelta)
+                    {
+                        maxManagedDelta = managedDelta;
+                    }
+                    Console.WriteLine($"\n\n\u001b[1m{i} ws_mb={workingSet / 1048576.0:F1} managed_mb={managed / 1048576.0:F1} delta_mb={delta / 1048576.0:F1}\u001b[0m\n\n");
+                }
+            }
+
+            if (MaxWorkingSetDeltaBytes is { } limit)
+            {
+                Console.WriteLine($"\n\n\u001b[1mSUMMARY: max ws delta {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB); max managed delta {maxManagedDelta / 1048576.0:F1} MB.\u001b[0m\n\n");
+                Assert.IsTrue(
+                    maxDelta <= limit,
+                    $"Working set grew by {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB). Managed heap max delta {maxManagedDelta / 1048576.0:F1} MB.");
+            }
+        });
+    }
+
+
+    [TestMethod]
+    public void Rvm_rehydrate_execute_dispose_does_not_grow_working_set()
+    {
+        WithOptionalGlobalRegorusMemoryLimit(() =>
+        {
+            var modules = new[]
+            {
+                new PolicyModule("test.rego", "package test\nallow = true"),
+            };
+
+            using var compiled = Program.CompileFromModules("{}", modules, new[] { "data.test.allow" });
+            var serialized = compiled.SerializeBinary();
+
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var baseline = process.WorkingSet64;
+            var maxDelta = 0L;
+            var baselineManaged = GC.GetTotalMemory(false);
+            var maxManagedDelta = 0L;
+
+            for (var i = 1; i <= Iterations; i++)
+            {
+                using (var vm = new Rvm())
+                using (var program = Program.DeserializeBinary(serialized, out _))
+                {
+                    vm.LoadProgram(program);
+                    vm.SetDataJson("{}");
+                    vm.SetInputJson("{}");
+                    _ = vm.ExecuteEntryPoint(0);
+                }
+
+                if (i % LogEvery == 0)
+                {
+                    process.Refresh();
+                    var workingSet = process.WorkingSet64;
+                    var managed = GC.GetTotalMemory(false);
+                    var delta = workingSet - baseline;
+                    var managedDelta = managed - baselineManaged;
+                    if (delta > maxDelta)
+                    {
+                        maxDelta = delta;
+                    }
+                    if (managedDelta > maxManagedDelta)
+                    {
+                        maxManagedDelta = managedDelta;
+                    }
+                    Console.WriteLine($"\n\n\u001b[1m{i} ws_mb={workingSet / 1048576.0:F1} managed_mb={managed / 1048576.0:F1} delta_mb={delta / 1048576.0:F1}\u001b[0m\n\n");
+                }
+            }
+
+            if (MaxWorkingSetDeltaBytes is { } limit)
+            {
+                Console.WriteLine($"\n\n\u001b[1mSUMMARY: max ws delta {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB); max managed delta {maxManagedDelta / 1048576.0:F1} MB.\u001b[0m\n\n");
+                Assert.IsTrue(
+                    maxDelta <= limit,
+                    $"Working set grew by {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB). Managed heap max delta {maxManagedDelta / 1048576.0:F1} MB.");
+            }
+        });
+    }
+
+    [TestMethod]
+    public void Rvm_rehydrate_execute_finalize_does_not_grow_working_set()
+    {
+        WithOptionalGlobalRegorusMemoryLimit(() =>
+        {
+            var modules = new[]
+            {
+                new PolicyModule("test.rego", "package test\nallow = true"),
+            };
+
+            using var compiled = Program.CompileFromModules("{}", modules, new[] { "data.test.allow" });
+            var serialized = compiled.SerializeBinary();
+
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var baseline = process.WorkingSet64;
+            var maxDelta = 0L;
+            var baselineManaged = GC.GetTotalMemory(false);
+            var maxManagedDelta = 0L;
+
+            for (var i = 1; i <= Iterations; i++)
+            {
+                var vm = new Rvm();
+                var program = Program.DeserializeBinary(serialized, out _);
+                vm.LoadProgram(program);
+                vm.SetDataJson("{}");
+                vm.SetInputJson("{}");
+                _ = vm.ExecuteEntryPoint(0);
+
+                if (i % GcEvery == 0)
+                {
+                    ForceFullGc();
+                }
+
+                if (i % LogEvery == 0)
+                {
+                    process.Refresh();
+                    var workingSet = process.WorkingSet64;
+                    var managed = GC.GetTotalMemory(false);
+                    var delta = workingSet - baseline;
+                    var managedDelta = managed - baselineManaged;
+                    if (delta > maxDelta)
+                    {
+                        maxDelta = delta;
+                    }
+                    if (managedDelta > maxManagedDelta)
+                    {
+                        maxManagedDelta = managedDelta;
+                    }
+                    Console.WriteLine($"\n\n\u001b[1m{i} ws_mb={workingSet / 1048576.0:F1} managed_mb={managed / 1048576.0:F1} delta_mb={delta / 1048576.0:F1}\u001b[0m\n\n");
+                }
+            }
+
+            if (MaxWorkingSetDeltaBytes is { } limit)
+            {
+                Console.WriteLine($"\n\n\u001b[1mSUMMARY: max ws delta {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB); max managed delta {maxManagedDelta / 1048576.0:F1} MB.\u001b[0m\n\n");
+                Assert.IsTrue(
+                    maxDelta <= limit,
+                    $"Working set grew by {maxDelta / 1048576.0:F1} MB (limit {limit / 1048576.0:F1} MB). Managed heap max delta {maxManagedDelta / 1048576.0:F1} MB.");
+            }
+        });
+    }
+}

--- a/bindings/csharp/Regorus.Tests/RvmProgramTests.cs
+++ b/bindings/csharp/Regorus.Tests/RvmProgramTests.cs
@@ -96,9 +96,9 @@ allow if {
         Assert.AreEqual("true", result, "expected allow=true");
     }
 
-      [TestMethod]
-      public void Program_host_await_suspend_and_resume_succeeds()
-      {
+    [TestMethod]
+    public void Program_host_await_suspend_and_resume_succeeds()
+    {
         var modules = new[] { new PolicyModule("host_await.rego", HostAwaitPolicy) };
         var entryPoints = new[] { "data.demo.allow" };
 
@@ -115,5 +115,5 @@ allow if {
 
         var resumed = vm.Resume("{\"tier\":\"gold\"}");
         Assert.AreEqual("true", resumed, "expected allow=true after resume");
-      }
+    }
 }

--- a/bindings/csharp/Regorus/Engine.cs
+++ b/bindings/csharp/Regorus/Engine.cs
@@ -16,14 +16,11 @@ namespace Regorus
     /// Cloning is cheap and involves only incrementing reference counts for shared immutable objects like parsed policies,
     /// data etc. Mutable state is deep copied as needed.
     /// </summary>
-    public unsafe sealed class Engine : IDisposable
+    public unsafe sealed class Engine : SafeHandleWrapper
     {
-        private RegorusEngineHandle? _handle;
-        private int _isDisposed;
-
         public Engine()
+            : base(RegorusEngineHandle.Create(), nameof(Engine))
         {
-            _handle = RegorusEngineHandle.Create();
         }
 
         public static void SetFallbackExecutionTimerConfig(ExecutionTimerConfig config)
@@ -37,42 +34,13 @@ namespace Regorus
             CheckAndDropResult(Regorus.Internal.API.regorus_clear_fallback_execution_timer_config());
         }
 
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-
-            // This object will be cleaned up by the Dispose method.
-            // Therefore, call GC.SuppressFinalize to
-            // take this object off the finalization queue
-            // and prevent finalization code for this object
-            // from executing a second time.
-            GC.SuppressFinalize(this);
-        }
-
-        // Dispose(bool disposing) executes in two distinct scenarios.
-        // If disposing equals true, the method has been called directly
-        // or indirectly by a user's code. Managed and unmanaged resources
-        // can be disposed.
-        // If disposing equals false, the method has been called by the
-        // runtime from inside the finalizer and you should not reference
-        // other objects. Only unmanaged resources can be disposed.
-        void Dispose(bool disposing)
-        {
-            if (System.Threading.Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
-            {
-                _handle?.Dispose();
-                _handle = null;
-            }
-        }
-
         private Engine(RegorusEngineHandle handle)
+            : base(handle, nameof(Engine))
         {
-            _handle = handle ?? throw new ArgumentNullException(nameof(handle));
         }
 
         public Engine Clone()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
                 unsafe
@@ -91,402 +59,198 @@ namespace Regorus
 
         public void SetStrictBuiltinErrors(bool strict)
         {
-            ThrowIfDisposed();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_strict_builtin_errors((Regorus.Internal.RegorusEngine*)enginePtr, strict));
-                }
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_strict_builtin_errors((Regorus.Internal.RegorusEngine*)enginePtr, strict));
             });
         }
 
         public void SetExecutionTimerConfig(ExecutionTimerConfig config)
         {
-            ThrowIfDisposed();
             var nativeConfig = config.ToNative();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    var localConfig = nativeConfig;
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_execution_timer_config((Regorus.Internal.RegorusEngine*)enginePtr, &localConfig));
-                }
+                var localConfig = nativeConfig;
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_execution_timer_config((Regorus.Internal.RegorusEngine*)enginePtr, &localConfig));
             });
         }
 
         public void ClearExecutionTimerConfig()
         {
-            ThrowIfDisposed();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_clear_execution_timer_config((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_clear_execution_timer_config((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
         public string? AddPolicy(string path, string rego)
         {
-            ThrowIfDisposed();
             return Utf8Marshaller.WithUtf8(path, pathPtr =>
                 Utf8Marshaller.WithUtf8(rego, regoPtr =>
-                {
-                    unsafe
-                    {
-                        return UseHandle(enginePtr =>
-                        {
-                            unsafe
-                            {
-                                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_policy((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr, (byte*)regoPtr));
-                            }
-                        });
-                    }
-                }));
+                    UseHandle(enginePtr =>
+                        CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_policy((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr, (byte*)regoPtr))
+                    )));
         }
 
         public void SetRegoV0(bool enable)
         {
-            ThrowIfDisposed();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_rego_v0((Regorus.Internal.RegorusEngine*)enginePtr, enable));
-                }
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_rego_v0((Regorus.Internal.RegorusEngine*)enginePtr, enable));
             });
         }
 
         public string? AddPolicyFromFile(string path)
         {
-            ThrowIfDisposed();
             return Utf8Marshaller.WithUtf8(path, pathPtr =>
             {
-                unsafe
-                {
-                    return UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            return CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_policy_from_file((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr));
-                        }
-                    });
-                }
+                return UseHandle(enginePtr =>
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_policy_from_file((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr))
+                );
             });
 
         }
 
         public void AddDataJson(string data)
         {
-            ThrowIfDisposed();
             Utf8Marshaller.WithUtf8(data, dataPtr =>
             {
-                unsafe
+                UseHandle(enginePtr =>
                 {
-                    UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_data_json((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)dataPtr));
-                        }
-                    });
-                }
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_data_json((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)dataPtr));
+                });
             });
 
         }
 
         public void AddDataFromJsonFile(string path)
         {
-            ThrowIfDisposed();
             Utf8Marshaller.WithUtf8(path, pathPtr =>
             {
-                unsafe
+                UseHandle(enginePtr =>
                 {
-                    UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_data_from_json_file((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr));
-                        }
-                    });
-                }
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_add_data_from_json_file((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr));
+                });
             });
 
         }
 
         public void SetInputJson(string input)
         {
-            ThrowIfDisposed();
             Utf8Marshaller.WithUtf8(input, inputPtr =>
             {
-                unsafe
+                UseHandle(enginePtr =>
                 {
-                    UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_input_json((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)inputPtr));
-                        }
-                    });
-                }
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_input_json((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)inputPtr));
+                });
             });
         }
 
         public void SetInputFromJsonFile(string path)
         {
-            ThrowIfDisposed();
             Utf8Marshaller.WithUtf8(path, pathPtr =>
             {
-                unsafe
+                UseHandle(enginePtr =>
                 {
-                    UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_input_from_json_file((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr));
-                        }
-                    });
-                }
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_input_from_json_file((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)pathPtr));
+                });
             });
         }
 
         public string? EvalQuery(string query)
         {
-            ThrowIfDisposed();
             return Utf8Marshaller.WithUtf8(query, queryPtr =>
             {
-                unsafe
-                {
-                    return UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            return CheckAndDropResult(Regorus.Internal.API.regorus_engine_eval_query((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)queryPtr));
-                        }
-                    });
-                }
+                return UseHandle(enginePtr =>
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_eval_query((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)queryPtr))
+                );
             });
         }
 
         public string? EvalRule(string rule)
         {
-            ThrowIfDisposed();
             return Utf8Marshaller.WithUtf8(rule, rulePtr =>
             {
-                unsafe
-                {
-                    return UseHandle(enginePtr =>
-                    {
-                        unsafe
-                        {
-                            return CheckAndDropResult(Regorus.Internal.API.regorus_engine_eval_rule((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)rulePtr));
-                        }
-                    });
-                }
+                return UseHandle(enginePtr =>
+                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_eval_rule((Regorus.Internal.RegorusEngine*)enginePtr, (byte*)rulePtr))
+                );
             });
         }
 
         public void SetEnableCoverage(bool enable)
         {
-            ThrowIfDisposed();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_enable_coverage((Regorus.Internal.RegorusEngine*)enginePtr, enable));
-                }
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_enable_coverage((Regorus.Internal.RegorusEngine*)enginePtr, enable));
             });
         }
 
         public void ClearCoverageData()
         {
-            ThrowIfDisposed();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_clear_coverage_data((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_clear_coverage_data((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
         public string? GetCoverageReport()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_coverage_report((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_coverage_report((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
         public string? GetCoverageReportPretty()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_coverage_report_pretty((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_coverage_report_pretty((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
         public void SetGatherPrints(bool enable)
         {
-            ThrowIfDisposed();
             UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_gather_prints((Regorus.Internal.RegorusEngine*)enginePtr, enable));
-                }
+                CheckAndDropResult(Regorus.Internal.API.regorus_engine_set_gather_prints((Regorus.Internal.RegorusEngine*)enginePtr, enable));
             });
         }
 
         public string? TakePrints()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    return CheckAndDropResult(Regorus.Internal.API.regorus_engine_take_prints((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_take_prints((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
         public string? GetAstAsJson()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_ast_as_json((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_ast_as_json((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
         public string? GetPolicyPackageNames()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_policy_package_names((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_policy_package_names((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
         public string? GetPolicyParameters()
         {
-            ThrowIfDisposed();
             return UseHandle(enginePtr =>
             {
-                unsafe
-                {
-                    return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_policy_parameters((Regorus.Internal.RegorusEngine*)enginePtr));
-                }
+                return CheckAndDropResult(Regorus.Internal.API.regorus_engine_get_policy_parameters((Regorus.Internal.RegorusEngine*)enginePtr));
             });
         }
 
-    private static string? StringFromUtf8(IntPtr ptr)
+        private static string? CheckAndDropResult(Regorus.Internal.RegorusResult result)
         {
-
-#if NETSTANDARD2_1
-			return Marshal.PtrToStringUTF8(ptr);
-#else
-            int len = 0;
-            while (Marshal.ReadByte(ptr, len) != 0) { ++len; }
-            byte[] buffer = new byte[len];
-            Marshal.Copy(ptr, buffer, 0, buffer.Length);
-            return Encoding.UTF8.GetString(buffer);
-#endif
-        }
-
-    private static string? CheckAndDropResult(Regorus.Internal.RegorusResult result)
-        {
-            try
-            {
-                if (result.status != Regorus.Internal.RegorusStatus.Ok)
-                {
-                    var message = Utf8Marshaller.FromUtf8(result.error_message);
-                    throw result.status.CreateException(message);
-                }
-
-                return result.data_type switch
-                {
-                    Regorus.Internal.RegorusDataType.String => Utf8Marshaller.FromUtf8(result.output),
-                    Regorus.Internal.RegorusDataType.Boolean => result.bool_value.ToString().ToLowerInvariant(),
-                    Regorus.Internal.RegorusDataType.Integer => result.int_value.ToString(),
-                    Regorus.Internal.RegorusDataType.None => null,
-                    _ => Utf8Marshaller.FromUtf8(result.output)
-                };
-            }
-            finally
-            {
-                Regorus.Internal.API.regorus_result_drop(result);
-            }
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_isDisposed != 0 || _handle is null || _handle.IsClosed)
-            {
-                throw new ObjectDisposedException(nameof(Engine));
-            }
-        }
-
-        internal RegorusEngineHandle GetHandleForUse()
-        {
-            var handle = _handle;
-            if (handle is null || handle.IsClosed || handle.IsInvalid)
-            {
-                throw new ObjectDisposedException(nameof(Engine));
-            }
-            return handle;
-        }
-
-        internal void UseHandle(Action<IntPtr> action)
-        {
-            UseHandle<object?>(handlePtr =>
-            {
-                action(handlePtr);
-                return null;
-            });
-        }
-
-        internal T UseHandle<T>(Func<IntPtr, T> func)
-        {
-            var handle = GetHandleForUse();
-            bool addedRef = false;
-            try
-            {
-                handle.DangerousAddRef(ref addedRef);
-                var pointer = handle.DangerousGetHandle();
-                if (pointer == IntPtr.Zero)
-                {
-                    throw new ObjectDisposedException(nameof(Engine));
-                }
-
-                return func(pointer);
-            }
-            finally
-            {
-                if (addedRef)
-                {
-                    handle.DangerousRelease();
-                }
-            }
-        }
-
-        internal T UseHandleForInterop<T>(Func<IntPtr, T> func)
-        {
-            return UseHandle(func);
+            return ResultHelpers.GetStringResult(result);
         }
 
     }

--- a/bindings/csharp/Regorus/MemoryLimits.cs
+++ b/bindings/csharp/Regorus/MemoryLimits.cs
@@ -89,12 +89,14 @@ namespace Regorus
                     );
                 }
 
-                if (result.int_value < 0)
+                try
                 {
-                    throw new OverflowException($"{errorContext}: native value was negative ({result.int_value})");
+                    return checked((ulong)result.int_value);
                 }
-
-                return (ulong)result.int_value;
+                catch (OverflowException ex)
+                {
+                    throw new OverflowException($"{errorContext}: native value was out of range ({result.int_value})", ex);
+                }
             }
             finally
             {

--- a/bindings/csharp/Regorus/ModuleMarshalling.cs
+++ b/bindings/csharp/Regorus/ModuleMarshalling.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Regorus;
+
+#nullable enable
+
+namespace Regorus.Internal
+{
+    internal static unsafe class ModuleMarshalling
+    {
+        internal sealed class PinnedPolicyModules : IDisposable
+        {
+            private readonly List<Utf8Marshaller.PinnedUtf8> _pins;
+            private bool _disposed;
+
+            internal PinnedPolicyModules(RegorusPolicyModule[] buffer, int length, List<Utf8Marshaller.PinnedUtf8> pins)
+            {
+                Buffer = buffer;
+                Length = length;
+                _pins = pins;
+            }
+
+            internal RegorusPolicyModule[] Buffer { get; }
+
+            internal int Length { get; }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                foreach (var pin in _pins)
+                {
+                    pin.Dispose();
+                }
+
+                ArrayPool<RegorusPolicyModule>.Shared.Return(Buffer, clearArray: true);
+                _disposed = true;
+            }
+        }
+
+        internal sealed class PinnedEntryPoints : IDisposable
+        {
+            private readonly List<Utf8Marshaller.PinnedUtf8> _pins;
+            private bool _disposed;
+
+            internal PinnedEntryPoints(IntPtr[] buffer, int length, List<Utf8Marshaller.PinnedUtf8> pins)
+            {
+                Buffer = buffer;
+                Length = length;
+                _pins = pins;
+            }
+
+            internal IntPtr[] Buffer { get; }
+
+            internal int Length { get; }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                foreach (var pin in _pins)
+                {
+                    pin.Dispose();
+                }
+
+                ArrayPool<IntPtr>.Shared.Return(Buffer, clearArray: true);
+                _disposed = true;
+            }
+        }
+
+        internal static PinnedPolicyModules PinPolicyModules(IReadOnlyList<PolicyModule> modules)
+        {
+            if (modules is null)
+            {
+                throw new ArgumentNullException(nameof(modules));
+            }
+
+            var count = modules.Count;
+            var buffer = ArrayPool<RegorusPolicyModule>.Shared.Rent(count);
+            var pins = new List<Utf8Marshaller.PinnedUtf8>(count * 2);
+
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var idPinned = Utf8Marshaller.Pin(modules[i].Id);
+                    var contentPinned = Utf8Marshaller.Pin(modules[i].Content);
+                    pins.Add(idPinned);
+                    pins.Add(contentPinned);
+
+                    buffer[i] = new RegorusPolicyModule
+                    {
+                        id = idPinned.Pointer,
+                        content = contentPinned.Pointer
+                    };
+                }
+
+                return new PinnedPolicyModules(buffer, count, pins);
+            }
+            catch
+            {
+                foreach (var pin in pins)
+                {
+                    pin.Dispose();
+                }
+
+                ArrayPool<RegorusPolicyModule>.Shared.Return(buffer, clearArray: true);
+                throw;
+            }
+        }
+
+        internal static PinnedEntryPoints PinEntryPoints(IReadOnlyList<string> entryPoints)
+        {
+            if (entryPoints is null)
+            {
+                throw new ArgumentNullException(nameof(entryPoints));
+            }
+
+            var count = entryPoints.Count;
+            var buffer = ArrayPool<IntPtr>.Shared.Rent(count);
+            var pins = new List<Utf8Marshaller.PinnedUtf8>(count);
+
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var entryPinned = Utf8Marshaller.Pin(entryPoints[i]);
+                    pins.Add(entryPinned);
+                    buffer[i] = (IntPtr)entryPinned.Pointer;
+                }
+
+                return new PinnedEntryPoints(buffer, count, pins);
+            }
+            catch
+            {
+                foreach (var pin in pins)
+                {
+                    pin.Dispose();
+                }
+
+                ArrayPool<IntPtr>.Shared.Return(buffer, clearArray: true);
+                throw;
+            }
+        }
+    }
+}

--- a/bindings/csharp/Regorus/Program.cs
+++ b/bindings/csharp/Regorus/Program.cs
@@ -13,14 +13,11 @@ namespace Regorus
     /// <summary>
     /// Represents a compiled RVM program.
     /// </summary>
-    public unsafe sealed class Program : IDisposable
+    public unsafe sealed class Program : SafeHandleWrapper
     {
-        private RegorusProgramHandle? _handle;
-        private int _isDisposed;
-
         private Program(RegorusProgramHandle handle)
+            : base(handle, nameof(Program))
         {
-            _handle = handle ?? throw new ArgumentNullException(nameof(handle));
         }
 
         /// <summary>
@@ -36,63 +33,57 @@ namespace Regorus
         /// </summary>
         public static Program CompileFromModules(string dataJson, IEnumerable<PolicyModule> modules, IEnumerable<string> entryPoints)
         {
-            var modulesArray = modules.ToArray();
-            var entryPointsArray = entryPoints.ToArray();
-            if (entryPointsArray.Length == 0)
+            if (modules is null)
+            {
+                throw new ArgumentNullException(nameof(modules));
+            }
+
+            if (entryPoints is null)
+            {
+                throw new ArgumentNullException(nameof(entryPoints));
+            }
+
+            return CompileFromModules(dataJson, modules.ToArray(), entryPoints.ToArray());
+        }
+
+        /// <summary>
+        /// Compile an RVM program from modules and entry points.
+        /// </summary>
+        public static Program CompileFromModules(string dataJson, IReadOnlyList<PolicyModule> modules, IReadOnlyList<string> entryPoints)
+        {
+            if (modules is null)
+            {
+                throw new ArgumentNullException(nameof(modules));
+            }
+
+            if (entryPoints is null)
+            {
+                throw new ArgumentNullException(nameof(entryPoints));
+            }
+
+            if (entryPoints.Count == 0)
             {
                 throw new ArgumentException("At least one entry point is required.", nameof(entryPoints));
             }
 
-            var nativeModules = new RegorusPolicyModule[modulesArray.Length];
-            var pinnedStrings = new List<Utf8Marshaller.PinnedUtf8>(modulesArray.Length * 2 + entryPointsArray.Length);
-            var entryPointers = new IntPtr[entryPointsArray.Length];
+            using var pinnedModules = ModuleMarshalling.PinPolicyModules(modules);
+            using var pinnedEntryPoints = ModuleMarshalling.PinEntryPoints(entryPoints);
 
-            try
+            return Utf8Marshaller.WithUtf8(dataJson, dataPtr =>
             {
-                for (int i = 0; i < modulesArray.Length; i++)
+                fixed (RegorusPolicyModule* modulesPtr = pinnedModules.Buffer)
+                fixed (IntPtr* entryPtr = pinnedEntryPoints.Buffer)
                 {
-                    var idPinned = Utf8Marshaller.Pin(modulesArray[i].Id);
-                    var contentPinned = Utf8Marshaller.Pin(modulesArray[i].Content);
-                    pinnedStrings.Add(idPinned);
-                    pinnedStrings.Add(contentPinned);
+                    var result = API.regorus_program_compile_from_modules(
+                        (byte*)dataPtr,
+                        modulesPtr,
+                        (UIntPtr)pinnedModules.Length,
+                        (byte**)entryPtr,
+                        (UIntPtr)pinnedEntryPoints.Length);
 
-                    nativeModules[i] = new RegorusPolicyModule
-                    {
-                        id = idPinned.Pointer,
-                        content = contentPinned.Pointer
-                    };
+                    return GetProgramResult(result);
                 }
-
-                for (int i = 0; i < entryPointsArray.Length; i++)
-                {
-                    var entryPinned = Utf8Marshaller.Pin(entryPointsArray[i]);
-                    pinnedStrings.Add(entryPinned);
-                    entryPointers[i] = (IntPtr)entryPinned.Pointer;
-                }
-
-                return Utf8Marshaller.WithUtf8(dataJson, dataPtr =>
-                {
-                    fixed (RegorusPolicyModule* modulesPtr = nativeModules)
-                    fixed (IntPtr* entryPtr = entryPointers)
-                    {
-                        var result = API.regorus_program_compile_from_modules(
-                            (byte*)dataPtr,
-                            modulesPtr,
-                            (UIntPtr)modulesArray.Length,
-                            (byte**)entryPtr,
-                            (UIntPtr)entryPointsArray.Length);
-
-                        return GetProgramResult(result);
-                    }
-                });
-            }
-            finally
-            {
-                foreach (var pinned in pinnedStrings)
-                {
-                    pinned.Dispose();
-                }
-            }
+            });
         }
 
         /// <summary>
@@ -104,44 +95,48 @@ namespace Regorus
             {
                 throw new ArgumentNullException(nameof(engine));
             }
+            if (entryPoints is null)
+            {
+                throw new ArgumentNullException(nameof(entryPoints));
+            }
 
-            var entryPointsArray = entryPoints.ToArray();
-            if (entryPointsArray.Length == 0)
+            return CompileFromEngine(engine, entryPoints.ToArray());
+        }
+
+        /// <summary>
+        /// Compile an RVM program from an engine instance and entry points.
+        /// </summary>
+        public static Program CompileFromEngine(Engine engine, IReadOnlyList<string> entryPoints)
+        {
+            if (engine is null)
+            {
+                throw new ArgumentNullException(nameof(engine));
+            }
+
+            if (entryPoints is null)
+            {
+                throw new ArgumentNullException(nameof(entryPoints));
+            }
+
+            if (entryPoints.Count == 0)
             {
                 throw new ArgumentException("At least one entry point is required.", nameof(entryPoints));
             }
 
-            var pinnedStrings = new List<Utf8Marshaller.PinnedUtf8>(entryPointsArray.Length);
-            var entryPointers = new IntPtr[entryPointsArray.Length];
-            try
-            {
-                for (int i = 0; i < entryPointsArray.Length; i++)
-                {
-                    var entryPinned = Utf8Marshaller.Pin(entryPointsArray[i]);
-                    pinnedStrings.Add(entryPinned);
-                    entryPointers[i] = (IntPtr)entryPinned.Pointer;
-                }
+            using var pinnedEntryPoints = ModuleMarshalling.PinEntryPoints(entryPoints);
 
-                return engine.UseHandleForInterop(enginePtr =>
-                {
-                    fixed (IntPtr* entryPtr = entryPointers)
-                    {
-                        var result = API.regorus_engine_compile_program_with_entrypoints(
-                            (RegorusEngine*)enginePtr,
-                            (byte**)entryPtr,
-                            (UIntPtr)entryPointsArray.Length);
-
-                        return GetProgramResult(result);
-                    }
-                });
-            }
-            finally
+            return engine.UseHandleForInterop(enginePtr =>
             {
-                foreach (var pinned in pinnedStrings)
+                fixed (IntPtr* entryPtr = pinnedEntryPoints.Buffer)
                 {
-                    pinned.Dispose();
+                    var result = API.regorus_engine_compile_program_with_entrypoints(
+                        (RegorusEngine*)enginePtr,
+                        (byte**)entryPtr,
+                        (UIntPtr)pinnedEntryPoints.Length);
+
+                    return GetProgramResult(result);
                 }
-            }
+            });
         }
 
         /// <summary>
@@ -169,7 +164,6 @@ namespace Regorus
         /// </summary>
         public byte[] SerializeBinary()
         {
-            ThrowIfDisposed();
             return UseHandle(programPtr =>
             {
                 var result = API.regorus_program_serialize_binary((RegorusProgram*)programPtr);
@@ -182,68 +176,10 @@ namespace Regorus
         /// </summary>
         public string? GenerateListing()
         {
-            ThrowIfDisposed();
             return UseHandle(programPtr =>
             {
                 return CheckAndDropResult(API.regorus_program_generate_listing((RegorusProgram*)programPtr));
             });
-        }
-
-        public void Dispose()
-        {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (System.Threading.Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
-            {
-                _handle?.Dispose();
-                _handle = null;
-            }
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_isDisposed != 0 || _handle is null || _handle.IsClosed)
-            {
-                throw new ObjectDisposedException(nameof(Program));
-            }
-        }
-
-        internal RegorusProgramHandle GetHandleForUse()
-        {
-            var handle = _handle;
-            if (handle is null || handle.IsClosed || handle.IsInvalid)
-            {
-                throw new ObjectDisposedException(nameof(Program));
-            }
-            return handle;
-        }
-
-        internal T UseHandle<T>(Func<IntPtr, T> func)
-        {
-            var handle = GetHandleForUse();
-            bool addedRef = false;
-            try
-            {
-                handle.DangerousAddRef(ref addedRef);
-                var pointer = handle.DangerousGetHandle();
-                if (pointer == IntPtr.Zero)
-                {
-                    throw new ObjectDisposedException(nameof(Program));
-                }
-
-                return func(pointer);
-            }
-            finally
-            {
-                if (addedRef)
-                {
-                    handle.DangerousRelease();
-                }
-            }
         }
 
         private static Program GetProgramResult(RegorusResult result)
@@ -272,27 +208,7 @@ namespace Regorus
 
         private static string? CheckAndDropResult(RegorusResult result)
         {
-            try
-            {
-                if (result.status != RegorusStatus.Ok)
-                {
-                    var message = Utf8Marshaller.FromUtf8(result.error_message);
-                    throw result.status.CreateException(message);
-                }
-
-                return result.data_type switch
-                {
-                    RegorusDataType.String => Utf8Marshaller.FromUtf8(result.output),
-                    RegorusDataType.Boolean => result.bool_value.ToString().ToLowerInvariant(),
-                    RegorusDataType.Integer => result.int_value.ToString(),
-                    RegorusDataType.None => null,
-                    _ => Utf8Marshaller.FromUtf8(result.output)
-                };
-            }
-            finally
-            {
-                API.regorus_result_drop(result);
-            }
+            return ResultHelpers.GetStringResult(result);
         }
 
         private static byte[] ExtractBuffer(RegorusResult result)

--- a/bindings/csharp/Regorus/Regorus.csproj
+++ b/bindings/csharp/Regorus/Regorus.csproj
@@ -8,7 +8,7 @@
        <LangVersion>10.0</LangVersion>
 
         <!-- See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-pack -->
-        <VersionPrefix>0.9.0</VersionPrefix>
+        <VersionPrefix>0.9.1</VersionPrefix>
         <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT AND Apache-2.0 AND BSD-3-Clause</PackageLicenseExpression>

--- a/bindings/csharp/Regorus/ResultHelpers.cs
+++ b/bindings/csharp/Regorus/ResultHelpers.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+#nullable enable
+
+namespace Regorus.Internal
+{
+    internal static unsafe class ResultHelpers
+    {
+        internal static string? GetStringResult(RegorusResult result)
+        {
+            try
+            {
+                if (result.status != RegorusStatus.Ok)
+                {
+                    var message = Utf8Marshaller.FromUtf8(result.error_message);
+                    throw result.status.CreateException(message);
+                }
+
+                return result.data_type switch
+                {
+                    RegorusDataType.String => Utf8Marshaller.FromUtf8(result.output),
+                    RegorusDataType.Boolean => result.bool_value.ToString().ToLowerInvariant(),
+                    RegorusDataType.Integer => result.int_value.ToString(),
+                    RegorusDataType.None => null,
+                    _ => Utf8Marshaller.FromUtf8(result.output)
+                };
+            }
+            finally
+            {
+                API.regorus_result_drop(result);
+            }
+        }
+
+        internal static bool GetBoolResult(RegorusResult result)
+        {
+            try
+            {
+                if (result.status != RegorusStatus.Ok)
+                {
+                    var message = Utf8Marshaller.FromUtf8(result.error_message);
+                    throw result.status.CreateException(message);
+                }
+
+                return result.data_type == RegorusDataType.Boolean && result.bool_value;
+            }
+            finally
+            {
+                API.regorus_result_drop(result);
+            }
+        }
+
+        internal static long GetIntResult(RegorusResult result)
+        {
+            try
+            {
+                if (result.status != RegorusStatus.Ok)
+                {
+                    var message = Utf8Marshaller.FromUtf8(result.error_message);
+                    throw result.status.CreateException(message);
+                }
+
+                return result.data_type == RegorusDataType.Integer ? result.int_value : 0;
+            }
+            finally
+            {
+                API.regorus_result_drop(result);
+            }
+        }
+    }
+}

--- a/bindings/csharp/Regorus/SafeHandleWrapper.cs
+++ b/bindings/csharp/Regorus/SafeHandleWrapper.cs
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+#nullable enable
+namespace Regorus
+{
+    /// <summary>
+    /// Base class for native handle wrappers that coordinates handle usage and disposal.
+    ///
+    /// Behavior summary:
+    /// - UseHandle: blocks Dispose while running; throws ObjectDisposedException if disposal has started or the handle is invalid.
+    /// - Dispose: marks disposing and blocks new calls; waits briefly for in-flight calls to finish, then defers native release to the last exiting call if needed.
+    /// - Handles are never exposed directly; derived classes can only work through UseHandle helpers.
+    ///
+    /// Concurrency model:
+    /// - _state tracks lifecycle transitions (Active -> DisposeRequested -> Released).
+    /// - HandleGate tracks in-flight operations and enforces the "no new calls after Dispose" rule.
+    /// - SafeHandle is pinned per call via DangerousAddRef to prevent use-after-free while native work runs.
+    /// - If Dispose times out, the last in-flight caller performs the release to avoid leaks.
+    /// </summary>
+    public abstract class SafeHandleWrapper : IDisposable
+    {
+        private static readonly TimeSpan DefaultDisposeTimeout = TimeSpan.FromMilliseconds(50);
+        private const int StateActive = 0;
+        private const int StateDisposeRequested = 1;
+        private const int StateReleased = 2;
+        private readonly HandleGate _gate;
+        private readonly string _ownerName;
+        private int _state;
+        private SafeHandle? _handle;
+
+        protected SafeHandleWrapper(SafeHandle handle, string ownerName)
+        {
+            // Cache ownership info and initialize the gate before any use to avoid racing disposal.
+            _handle = handle ?? throw new ArgumentNullException(nameof(handle));
+            _ownerName = ownerName ?? throw new ArgumentNullException(nameof(ownerName));
+            _gate = new HandleGate(ownerName);
+            // Default to a very short wait when in-flight calls exist; release is deferred to the last caller if needed.
+        }
+
+        protected void UseHandle(Action<IntPtr> action)
+        {
+            // Reuse the generic path to keep add/ref/release in one place.
+            UseHandle<object?>(ptr =>
+            {
+                action(ptr);
+                return null;
+            });
+        }
+
+        protected T UseHandle<T>(Func<IntPtr, T> func)
+        {
+            // Fast reject if dispose was requested.
+            if (System.Threading.Volatile.Read(ref _state) != StateActive)
+            {
+                throw new ObjectDisposedException(_ownerName);
+            }
+
+            // Enter gate so Dispose waits for in-flight native calls.
+            _gate.Enter();
+            bool addedRef = false;
+            SafeHandle? handle = null;
+            try
+            {
+                // Race: Dispose could begin after Enter; GetHandleForUse validates the handle again.
+                handle = GetHandleForUse();
+                // DangerousAddRef pins the SafeHandle so Dispose cannot close it mid-call.
+                handle.DangerousAddRef(ref addedRef);
+                var pointer = handle.DangerousGetHandle();
+                // Validate pointer after AddRef in case handle became invalid between checks.
+                if (pointer == IntPtr.Zero)
+                {
+                    throw new ObjectDisposedException(_ownerName);
+                }
+
+                return func(pointer);
+            }
+            finally
+            {
+                // Always release the DangerousAddRef to avoid leaking the native handle.
+                if (addedRef)
+                {
+                    handle?.DangerousRelease();
+                }
+
+                // Leave gate so Dispose can proceed when the last caller exits.
+                var idle = _gate.Exit();
+                // Race: Dispose may have timed out while we were in-flight.
+                // The last exiting caller performs the native release to avoid leaks.
+                if (idle && System.Threading.Volatile.Read(ref _state) == StateDisposeRequested)
+                {
+                    TryReleaseHandle();
+                }
+            }
+        }
+
+        internal T UseHandleForInterop<T>(Func<IntPtr, T> func)
+        {
+            // Explicit alias for interop-specific call sites.
+            return UseHandle(func);
+        }
+
+        internal void UseHandleForInterop(Action<IntPtr> action)
+        {
+            // Explicit alias for interop-specific call sites.
+            UseHandle(action);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            // Fast check for dispose state so callers fail deterministically.
+            if (System.Threading.Volatile.Read(ref _state) != StateActive)
+            {
+                throw new ObjectDisposedException(_ownerName);
+            }
+
+            // Validate the underlying SafeHandle is still usable; avoids races with release.
+            var handle = _handle;
+            if (handle is null || handle.IsClosed || handle.IsInvalid)
+            {
+                throw new ObjectDisposedException(_ownerName);
+            }
+        }
+
+        private SafeHandle GetHandleForUse()
+        {
+            // Centralized gate for derived classes to grab the handle safely.
+            // This is a second line of defense in case disposal began after the initial state check.
+            var handle = _handle;
+            if (handle is null || handle.IsClosed || handle.IsInvalid)
+            {
+                throw new ObjectDisposedException(_ownerName);
+            }
+            return handle;
+        }
+
+        public void Dispose()
+        {
+            // Only the first caller runs disposal; others become no-ops.
+            if (System.Threading.Interlocked.CompareExchange(ref _state, StateDisposeRequested, StateActive) == StateActive)
+            {
+                // Block new calls and wait briefly if there are in-flight operations.
+                var completed = _gate.TryBeginDispose(DefaultDisposeTimeout, out var hadActive);
+                if (completed)
+                {
+                    // Either no active calls or they drained within the short timeout.
+                    TryReleaseHandle();
+                }
+                else
+                {
+                    // Defer release to the last in-flight caller to avoid leaks without blocking indefinitely.
+                    // Race: if the last in-flight caller already exited, there will be no Exit() to trigger release.
+                    // Re-check active state and release immediately in that case.
+                    if (!hadActive || _gate.IsIdle)
+                    {
+                        TryReleaseHandle();
+                    }
+                }
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        private void TryReleaseHandle()
+        {
+            if (System.Threading.Interlocked.CompareExchange(ref _state, StateReleased, StateDisposeRequested) != StateDisposeRequested)
+            {
+                return;
+            }
+
+            // Once released, no caller should be able to observe a valid handle.
+            // SafeHandle.Dispose closes the native resource; null to prevent reuse after dispose.
+            _handle?.Dispose();
+            _handle = null;
+            // Release the wait handle resources after disposal completes.
+            _gate.Dispose();
+        }
+
+        /// <summary>
+        /// Tracks in-flight operations and coordinates disposal.
+        /// </summary>
+        private sealed class HandleGate : IDisposable
+        {
+            private readonly string _ownerName;
+            private readonly System.Threading.ManualResetEventSlim _idle = new(initialState: true);
+            private int _active;
+            private int _disposing;
+
+            internal HandleGate(string ownerName)
+            {
+                _ownerName = ownerName;
+            }
+
+            internal void Enter()
+            {
+                // If disposal already started, reject new work immediately.
+                if (System.Threading.Volatile.Read(ref _disposing) != 0)
+                {
+                    ThrowDisposed();
+                }
+
+                // Track active callers; first one resets idle event.
+                var active = System.Threading.Interlocked.Increment(ref _active);
+                if (active == 1)
+                {
+                    _idle.Reset();
+                }
+
+                // Re-check disposing to handle races where Dispose began after increment.
+                if (System.Threading.Volatile.Read(ref _disposing) != 0)
+                {
+                    Exit();
+                    ThrowDisposed();
+                }
+            }
+
+            internal bool Exit()
+            {
+                // Last caller signals idle so Dispose can continue.
+                if (System.Threading.Interlocked.Decrement(ref _active) == 0)
+                {
+                    _idle.Set();
+                    return true;
+                }
+
+                return false;
+            }
+
+            internal bool IsIdle => System.Threading.Volatile.Read(ref _active) == 0;
+
+            internal bool TryBeginDispose(TimeSpan timeout, out bool hadActive)
+            {
+                // Set disposing flag once; subsequent calls treat as already disposing.
+                if (System.Threading.Interlocked.Exchange(ref _disposing, 1) != 0)
+                {
+                    hadActive = System.Threading.Volatile.Read(ref _active) != 0;
+                    return true;
+                }
+
+                hadActive = System.Threading.Volatile.Read(ref _active) != 0;
+                if (!hadActive)
+                {
+                    // No in-flight callers; disposal can proceed without waiting.
+                    return true;
+                }
+
+                // Wait for active callers to drain; optional timeout avoids blocking forever.
+                if (timeout == System.Threading.Timeout.InfiniteTimeSpan)
+                {
+                    _idle.Wait();
+                    return true;
+                }
+
+                // Race note: callers may finish between the timeout decision and Wait call; Wait handles that safely.
+                return _idle.Wait(timeout);
+            }
+
+            private void ThrowDisposed()
+            {
+                throw new ObjectDisposedException(_ownerName);
+            }
+
+            public void Dispose()
+            {
+                _idle.Dispose();
+            }
+        }
+    }
+}

--- a/bindings/csharp/Regorus/SafeHandles.cs
+++ b/bindings/csharp/Regorus/SafeHandles.cs
@@ -44,7 +44,7 @@ namespace Regorus
 
         protected override bool ReleaseHandle()
         {
-            if (!IsInvalid && !IsClosed)
+            if (!IsInvalid)
             {
                 unsafe
                 {
@@ -76,7 +76,7 @@ namespace Regorus
 
         protected override bool ReleaseHandle()
         {
-            if (!IsInvalid && !IsClosed)
+            if (!IsInvalid)
             {
                 unsafe
                 {
@@ -124,7 +124,7 @@ namespace Regorus
 
         protected override bool ReleaseHandle()
         {
-            if (!IsInvalid && !IsClosed)
+            if (!IsInvalid)
             {
                 unsafe
                 {
@@ -172,7 +172,7 @@ namespace Regorus
 
         protected override bool ReleaseHandle()
         {
-            if (!IsInvalid && !IsClosed)
+            if (!IsInvalid)
             {
                 unsafe
                 {

--- a/bindings/csharp/Regorus/Utf8Marshaller.cs
+++ b/bindings/csharp/Regorus/Utf8Marshaller.cs
@@ -17,10 +17,10 @@ namespace Regorus.Internal
     /// </summary>
     internal static class Utf8Marshaller
     {
-    // Mirrors BCL patterns (e.g., System.Text.Json encoding helpers) by stackalloc'ing
-    // up to 512 bytes to cover common short strings while keeping the stack usage well
-    // below typical per-frame limits; larger payloads fall back to pooled buffers.
-    private const int StackAllocThreshold = 512;
+        // Mirrors BCL patterns (e.g., System.Text.Json encoding helpers) by stackalloc'ing
+        // up to 512 bytes to cover common short strings while keeping the stack usage well
+        // below typical per-frame limits; larger payloads fall back to pooled buffers.
+        private const int StackAllocThreshold = 512;
 
         /// <summary>
         /// Represents a pooled and pinned UTF-8 buffer suitable for scenarios where

--- a/bindings/csharp/TargetExampleApp/Program.cs
+++ b/bindings/csharp/TargetExampleApp/Program.cs
@@ -65,7 +65,7 @@ triplet_count := count([1 |
     private const string EXECUTION_TIMER_QUERY = "data.limits.timer.triplet_count";
     private const int EXECUTION_TIMER_VALUE_COUNT = 40;
 
-        private const string RVM_POLICY = """
+    private const string RVM_POLICY = """
 package demo
 import rego.v1
 
@@ -78,7 +78,7 @@ allow if {
 }
 """;
 
-        private const string RVM_DATA = """
+    private const string RVM_DATA = """
 {
     "roles": {
         "alice": ["admin", "reader"]
@@ -86,13 +86,13 @@ allow if {
 }
 """;
 
-        private const string RVM_INPUT = """
+    private const string RVM_INPUT = """
 {
     "user": "alice"
 }
 """;
 
-        private const string HOST_AWAIT_POLICY = """
+    private const string HOST_AWAIT_POLICY = """
 package demo
 import rego.v1
 
@@ -105,7 +105,7 @@ allow if {
 }
 """;
 
-        private const string HOST_AWAIT_INPUT = """
+    private const string HOST_AWAIT_INPUT = """
     {
         "account": {
             "id": "acct-1",
@@ -216,7 +216,7 @@ allow if {
 
         var nonCompliantResult = compiledPolicy.EvalWithInput(NON_COMPLIANT_STORAGE_ACCOUNT);
         Console.WriteLine($"Result: {nonCompliantResult}");
-        
+
         // 4. Demonstrate thread-safe concurrent evaluation
         Console.WriteLine("\n4. Testing concurrent evaluation from multiple threads:");
         DemonstrateConcurrentEvaluation(compiledPolicy);
@@ -246,42 +246,44 @@ allow if {
         };
 
         Console.WriteLine($"Starting {testInputs.Length} concurrent evaluations...");
-        
-        var tasks = testInputs.Select(input => 
-            Task.Run(() => {
+
+        var tasks = testInputs.Select(input =>
+            Task.Run(() =>
+            {
                 var (threadName, json) = input;
                 var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-                
+
                 // Multiple evaluations per thread to stress test
                 var results = new List<string>();
                 for (int i = 0; i < 1000; i++)
                 {
-                    var result = compiledPolicy.EvalWithInput(json);
+                    var result = compiledPolicy.EvalWithInput(json)
+                        ?? throw new System.InvalidOperationException("Expected EvalWithInput to return a JSON value.");
                     results.Add(result);
                 }
-                
+
                 stopwatch.Stop();
                 var microseconds = stopwatch.ElapsedTicks * 1000000 / System.Diagnostics.Stopwatch.Frequency;
-                
+
                 // Verify all results are identical (thread safety)
                 var firstResult = results[0];
                 var allIdentical = results.All(r => r == firstResult);
-                
+
                 Console.WriteLine($"✓ {threadName}: {results.Count} evaluations in {microseconds}μs, " +
                                 $"Results consistent: {allIdentical}");
-                
+
                 return (threadName, results.Count, microseconds, allIdentical);
             })
         ).ToArray();
 
         // Wait for all threads to complete
         var results = Task.WhenAll(tasks).Result;
-        
+
         Console.WriteLine("\nConcurrency test results:");
         var totalEvaluations = results.Sum(r => r.Item2);
         var maxTime = results.Max(r => r.Item3);
         var allConsistent = results.All(r => r.allIdentical);
-        
+
         Console.WriteLine($"✓ Total evaluations: {totalEvaluations}");
         Console.WriteLine($"✓ Max thread time: {maxTime}μs");
         Console.WriteLine($"✓ All threads consistent: {allConsistent}");
@@ -292,28 +294,28 @@ allow if {
     static void DemonstratePolicyInfo(Regorus.CompiledPolicy compiledPolicy)
     {
         Console.WriteLine("Getting policy metadata using GetPolicyInfo()...");
-        
+
         try
         {
             var policyInfo = compiledPolicy.GetPolicyInfo();
-            
+
             Console.WriteLine($"✓ Policy Information Retrieved:");
             Console.WriteLine($"  Target Name: {policyInfo.TargetName ?? "None"}");
             Console.WriteLine($"  Effect Rule: {policyInfo.EffectRule ?? "None"}");
             Console.WriteLine($"  Entrypoint Rule: {policyInfo.EntrypointRule}");
-            
+
             Console.WriteLine($"  Module IDs ({policyInfo.ModuleIds.Count}):");
             foreach (var moduleId in policyInfo.ModuleIds)
             {
                 Console.WriteLine($"    - {moduleId}");
             }
-            
+
             Console.WriteLine($"  Applicable Resource Types ({policyInfo.ApplicableResourceTypes.Count}):");
             foreach (var resourceType in policyInfo.ApplicableResourceTypes)
             {
                 Console.WriteLine($"    - {resourceType}");
             }
-            
+
             if (policyInfo.Parameters != null && policyInfo.Parameters.Count > 0)
             {
                 Console.WriteLine($"  Policy Parameters:");
@@ -333,7 +335,7 @@ allow if {
                             Console.WriteLine($"          Description: {param.Description}");
                         }
                     }
-                    
+
                     if (parameterSet.Modifiers.Count > 0)
                     {
                         Console.WriteLine($"      Modifiers ({parameterSet.Modifiers.Count}):");
@@ -348,11 +350,11 @@ allow if {
             {
                 Console.WriteLine("  No parameter information available");
             }
-            
+
             // Demonstrate JSON serialization of policy info
             Console.WriteLine("\n✓ Policy Info as JSON:");
-            var jsonOptions = new JsonSerializerOptions 
-            { 
+            var jsonOptions = new JsonSerializerOptions
+            {
                 WriteIndented = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };

--- a/bindings/csharp/TestApp/Program.cs
+++ b/bindings/csharp/TestApp/Program.cs
@@ -42,7 +42,8 @@ w.Restart();
 
 // Set input and eval rule.
 engine.SetInputFromJsonFile("../../../tests/aci/input.json");
-var value = engine.EvalRule("data.framework.mount_overlay");
+var value = engine.EvalRule("data.framework.mount_overlay")
+    ?? throw new System.InvalidOperationException("Expected EvalRule to return a JSON value.");
 
 #if NET8_0_OR_GREATER
 var valueDoc = System.Text.Json.JsonDocument.Parse(value);

--- a/bindings/ffi/Cargo.lock
+++ b/bindings/ffi/Cargo.lock
@@ -950,7 +950,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regorus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "regorus-ffi"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cbindgen",

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regorus-ffi"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 

--- a/bindings/java/Cargo.lock
+++ b/bindings/java/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regorus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "regorus-java"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "jni",

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regorus-java"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/java"
 description = "Java bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.microsoft.regorus</groupId>
   <artifactId>regorus-java</artifactId>
-  <version>0.9.0</version>
+  <version>0.9.1</version>
 
   <name>Regorus Java</name>
   <description>Java bindings for Regorus - a fast, lightweight Rego interpreter written in Rust</description>

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -885,7 +885,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regorus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "regoruspy"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ordered-float",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regoruspy"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/python"
 description = "Python bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"

--- a/bindings/ruby/ext/regorusrb/Cargo.toml
+++ b/bindings/ruby/ext/regorusrb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regorusrb"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Ruby bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"

--- a/bindings/ruby/lib/regorus/version.rb
+++ b/bindings/ruby/lib/regorus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Regorus
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/bindings/wasm/Cargo.lock
+++ b/bindings/wasm/Cargo.lock
@@ -883,7 +883,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "regorus"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "regorusjs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regorusjs"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/wasm"
 description = "WASM bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"

--- a/xtask/src/tasks/bindings/all.rs
+++ b/xtask/src/tasks/bindings/all.rs
@@ -135,6 +135,9 @@ impl TestAllBindingsCommand {
             enforce_artifacts: false,
             force_nuget: false,
             nuget_dir: None,
+            test_filter: None,
+            skip_apps: false,
+            console_logger: false,
         }
         .run()?;
 


### PR DESCRIPTION
- Add SafeHandleWrapper gating with 30s dispose timeout to prevent native leaks; keep handle types internal.
- Remove IsClosed checks inside SafeHandle.ReleaseHandle (SafeHandle sets IsClosed before invoking ReleaseHandle), so native drops are not skipped.
- Add memory growth tests (using/finalizer paths) with GC cadence, limits, and clearer output.
- Extend xtask C# runner (filtering, console logger, skip apps) and defaults.
- Centralize result handling, pooled marshalling utilities, IReadOnlyList overloads, readonly PolicyModule; tighten MemoryLimits checks.
- Tweak registry helpers/enums; format C# code; bump versions and changelog.


fixes #570
closes #554 