### PR TITLE
rvm: switch binary serialization to postcard

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -49,9 +49,9 @@ jobs:
 
       - name: Run rust-clippy
         run: cargo xtask clippy --sarif rust-clippy-results.sarif
-        continue-on-error: true
 
       - name: Upload analysis results to GitHub
+        if: ${{ hashFiles('rust-clippy-results.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v3.29.11
         with:
           sarif_file: rust-clippy-results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Azure RBAC condition interpreter with builtin evaluation coverage and YAML test suite, including quantifier (ForAnyOfAnyValues/ForAllOfAllValues), datetime (DateTimeEquals), IP (IpInRange), GUID (GuidEquals), list (ListContains), and string (StringEquals) semantics.
 - FFI surface for Azure RBAC condition evaluation (see bindings changelog for language-specific wrappers).
 
+### Changed
+- [**breaking**] Switch RVM binary serialization to postcard, bump the format to v4, and mark v1-3 loads as partial (recompile required).
+
 ## [0.9.1](https://github.com/microsoft/regorus/compare/regorus-v0.9.0...regorus-v0.9.1) - 2026-02-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,16 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +431,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "ensure_no_std"
@@ -1036,6 +1047,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,7 +1253,6 @@ name = "regorus"
 version = "0.9.1"
 dependencies = [
  "anyhow",
- "bincode",
  "cfg-if",
  "chrono",
  "chrono-tz",
@@ -1247,6 +1269,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "num_cpus",
+ "postcard",
  "prettydiff",
  "rand",
  "regex",
@@ -1534,12 +1557,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ net = ["dep:ipnet"]
 no_std = ["lazy_static/spin_no_std"]
 opa-runtime = []
 regex = ["dep:regex"]
-rvm = ["dep:bincode", "dep:indexmap"]
+rvm = ["dep:postcard", "dep:indexmap"]
 semver = ["dep:semver"]
 allocator-memory-limits = ["std", "mimalloc", "mimalloc/allocator-memory-limits"]
 std = ["rand/std", "rand/std_rng", "serde_json/std", "msvc_spectre_libs" ]
@@ -128,7 +128,7 @@ mimalloc = { package = "regorus-mimalloc", path = "mimalloc", version = "2.2.6",
 
 # rvm related deps
 indexmap = { version = "2.12.1", default-features = false, features = ["serde"], optional = true }
-bincode = { version = "2.0.1", default-features = false, features = ["alloc", "serde"], optional = true }
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.45"

--- a/bindings/ffi/Cargo.lock
+++ b/bindings/ffi/Cargo.lock
@@ -103,16 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +302,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -806,6 +817,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,7 +976,6 @@ name = "regorus"
 version = "0.9.1"
 dependencies = [
  "anyhow",
- "bincode",
  "chrono",
  "chrono-tz",
  "dashmap",
@@ -966,6 +988,7 @@ dependencies = [
  "msvc_spectre_libs",
  "num-bigint",
  "num-traits",
+ "postcard",
  "rand",
  "regex",
  "regorus-mimalloc",
@@ -1257,12 +1280,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/bindings/java/Cargo.lock
+++ b/bindings/java/Cargo.lock
@@ -53,16 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +202,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -682,6 +693,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +852,6 @@ name = "regorus"
 version = "0.9.1"
 dependencies = [
  "anyhow",
- "bincode",
  "chrono",
  "chrono-tz",
  "data-encoding",
@@ -841,6 +863,7 @@ dependencies = [
  "msvc_spectre_libs",
  "num-bigint",
  "num-traits",
+ "postcard",
  "rand",
  "regex",
  "regorus-mimalloc",
@@ -1080,12 +1103,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -53,16 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +180,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -677,6 +688,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,7 +911,6 @@ name = "regorus"
 version = "0.9.1"
 dependencies = [
  "anyhow",
- "bincode",
  "chrono",
  "chrono-tz",
  "data-encoding",
@@ -900,6 +922,7 @@ dependencies = [
  "msvc_spectre_libs",
  "num-bigint",
  "num-traits",
+ "postcard",
  "rand",
  "regex",
  "regorus-mimalloc",
@@ -1123,12 +1146,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/bindings/wasm/Cargo.lock
+++ b/bindings/wasm/Cargo.lock
@@ -64,16 +64,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +197,18 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -739,6 +750,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,7 +909,6 @@ name = "regorus"
 version = "0.9.1"
 dependencies = [
  "anyhow",
- "bincode",
  "chrono",
  "chrono-tz",
  "data-encoding",
@@ -898,6 +920,7 @@ dependencies = [
  "msvc_spectre_libs",
  "num-bigint",
  "num-traits",
+ "postcard",
  "rand",
  "regex",
  "semver",
@@ -1112,12 +1135,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/docs/rvm/architecture.md
+++ b/docs/rvm/architecture.md
@@ -90,11 +90,11 @@ version:
   `3`).
 2. **Section manifest**: four little-endian `u32` lengths for entry points,
   sources, literals, and the rule tree, plus a single-byte `rego_v0` flag.
-3. **Preamble payloads**: each section is encoded with `bincode` using helper
+3. **Preamble payloads**: each section is encoded with `postcard` using helper
   wrappers (`BinaryValueSlice`, `BinaryValueRef`) to stream complex `Value`
   graphs without cloning.
 4. **Program core**: the remaining `Program` struct is serialized once more via
-  `bincode`; fields skipped by serde (entry points, literals, sources,
+  `postcard`; fields skipped by serde (entry points, literals, sources,
   rule_tree, resolved builtins) are re-inserted from the preamble when the
   program is reconstructed.
 

--- a/src/rvm/program/core.rs
+++ b/src/rvm/program/core.rs
@@ -85,7 +85,7 @@ pub struct Program {
 
 impl Program {
     /// Current serialization format version
-    pub const SERIALIZATION_VERSION: u32 = 3;
+    pub const SERIALIZATION_VERSION: u32 = 4;
     /// Magic bytes to identify Regorus program files
     pub const MAGIC: [u8; 4] = *b"REGO";
     /// Maximum instructions supported (matches u16 jump targets)

--- a/src/rvm/program/serialization/binary.rs
+++ b/src/rvm/program/serialization/binary.rs
@@ -4,8 +4,7 @@
 use alloc::format;
 use alloc::string::{String, ToString as _};
 use alloc::vec::Vec;
-use bincode::config::standard;
-use bincode::serde::{decode_from_slice, encode_to_vec};
+use postcard::{from_bytes, to_allocvec};
 
 use super::{DeserializationResult, Program};
 use crate::value::Value;
@@ -70,7 +69,7 @@ impl Program {
     }
 
     /// Serialize program to binary format.
-    /// Uses pure bincode for all sections now that `Value` supports serde.
+    /// Uses postcard for all sections now that `Value` supports serde.
     pub fn serialize_binary(&self) -> Result<Vec<u8>, String> {
         self.validate_limits()?;
 
@@ -79,19 +78,19 @@ impl Program {
         buffer.extend_from_slice(&Self::MAGIC);
         buffer.extend_from_slice(&Self::SERIALIZATION_VERSION.to_le_bytes());
 
-        let entry_points_bin = encode_to_vec(&self.entry_points, standard())
-            .map_err(|e| format!("Entry points bincode serialization failed: {}", e))?;
+        let entry_points_bin = to_allocvec(&self.entry_points)
+            .map_err(|e| format!("Entry points postcard serialization failed: {}", e))?;
 
-        let sources_bin = encode_to_vec(&self.sources, standard())
-            .map_err(|e| format!("Sources bincode serialization failed: {}", e))?;
+        let sources_bin = to_allocvec(&self.sources)
+            .map_err(|e| format!("Sources postcard serialization failed: {}", e))?;
 
-        let literals_bin = encode_to_vec(BinaryValueSlice(self.literals.as_slice()), standard())
-            .map_err(|e| format!("Literals bincode serialization failed: {}", e))?;
+        let literals_bin = to_allocvec(&BinaryValueSlice(self.literals.as_slice()))
+            .map_err(|e| format!("Literals postcard serialization failed: {}", e))?;
 
-        let rule_tree_bin = encode_to_vec(BinaryValueRef(&self.rule_tree), standard())
-            .map_err(|e| format!("Rule tree bincode serialization failed: {}", e))?;
+        let rule_tree_bin = to_allocvec(&BinaryValueRef(&self.rule_tree))
+            .map_err(|e| format!("Rule tree postcard serialization failed: {}", e))?;
 
-        let binary_data = encode_to_vec(self, standard())
+        let binary_data = to_allocvec(self)
             .map_err(|e| format!("Program structure binary serialization failed: {}", e))?;
 
         buffer.extend_from_slice(
@@ -152,128 +151,13 @@ impl Program {
         }
 
         match version {
-            1 => {
-                if data.len() < 25 {
-                    return Err("Data too short for header".to_string());
-                }
-
-                let entry_points_len = Self::read_u32_as_usize(data, 8)?;
-                let sources_len = Self::read_u32_as_usize(data, 12)?;
-                let rego_v0 = Self::read_byte(data, 16)? != 0;
-
-                let mut offset = OffsetTracker::new(17);
-                let entry_points_start = offset.advance(entry_points_len)?;
-                let sources_start = offset.advance(sources_len)?;
-                let binary_len_start = offset.current();
-
-                if data.len() < binary_len_start.checked_add(4).ok_or("Offset overflow")? {
-                    return Err("Data too short for binary length".to_string());
-                }
-
-                let binary_len = Self::read_u32_as_usize(data, binary_len_start)?;
-
-                let mut binary_offset = OffsetTracker::new(binary_len_start);
-                binary_offset.advance(4)?; // Skip the binary_len u32
-                let binary_start = binary_offset.advance(binary_len)?;
-                let json_start = binary_offset.current();
-
-                if data.len() < json_start.checked_add(4).ok_or("Offset overflow")? {
-                    return Err("Data too short for JSON length".to_string());
-                }
-
-                let json_len = Self::read_u32_as_usize(data, json_start)?;
-
-                let total_expected = json_start
-                    .checked_add(4)
-                    .and_then(|v| v.checked_add(json_len))
-                    .ok_or("Offset overflow")?;
-                if data.len() < total_expected {
-                    return Err("Data truncated".to_string());
-                }
-
-                let json_end = json_start
-                    .checked_add(4)
-                    .and_then(|v| v.checked_add(json_len))
-                    .ok_or("Offset overflow")?;
-
-                let entry_points = decode_from_slice(
-                    Self::get_slice(data, entry_points_start, sources_start)?,
-                    standard(),
-                )
-                .map(|(value, _)| value)
-                .map_err(|e| format!("Entry points deserialization failed: {}", e))?;
-
-                let sources = decode_from_slice(
-                    Self::get_slice(data, sources_start, binary_len_start)?,
-                    standard(),
-                )
-                .map(|(value, _)| value)
-                .map_err(|e| format!("Sources deserialization failed: {}", e))?;
-
-                let mut needs_recompilation = false;
-
-                let mut program = match decode_from_slice::<Program, _>(
-                    Self::get_slice(data, binary_start, json_start)?,
-                    standard(),
-                ) {
-                    Ok((prog, _)) => prog,
-                    Err(_e) => {
-                        needs_recompilation = true;
-                        Program::new()
-                    }
-                };
-
-                let (literals, rule_tree) =
-                    match serde_json::from_slice::<serde_json::Value>(Self::get_slice(
-                        data,
-                        json_start.checked_add(4).ok_or("Offset overflow")?,
-                        json_end,
-                    )?) {
-                        Ok(combined) => {
-                            let literals = combined
-                                .get("literals")
-                                .and_then(|v| serde_json::from_value::<Vec<Value>>(v.clone()).ok())
-                                .unwrap_or_else(|| {
-                                    needs_recompilation = true;
-                                    Vec::new()
-                                });
-
-                            let rule_tree = combined
-                                .get("rule_tree")
-                                .and_then(|v| serde_json::from_value::<Value>(v.clone()).ok())
-                                .unwrap_or_else(|| {
-                                    needs_recompilation = true;
-                                    Value::new_object()
-                                });
-
-                            (literals, rule_tree)
-                        }
-                        Err(_e) => {
-                            needs_recompilation = true;
-                            (Vec::new(), Value::new_object())
-                        }
-                    };
-
-                program.entry_points = entry_points;
-                program.sources = sources;
-                program.literals = literals;
-                program.rule_tree = rule_tree;
-                program.rego_v0 = rego_v0;
-                program.needs_recompilation = needs_recompilation;
-
-                if !program.builtin_info_table.is_empty() {
-                    if let Err(_e) = program.initialize_resolved_builtins() {
-                        program.needs_recompilation = true;
-                    }
-                }
-
-                if program.needs_recompilation {
-                    Ok(DeserializationResult::Partial(program))
-                } else {
-                    Ok(DeserializationResult::Complete(program))
-                }
+            1..=3 => {
+                let mut program = Program::new();
+                program.needs_recompilation = true;
+                program.rego_v0 = Self::legacy_rego_v0(data, version).unwrap_or(false);
+                Ok(DeserializationResult::Partial(program))
             }
-            2 | 3 => {
+            4 => {
                 if data.len() < 29 {
                     return Err("Data too short for header".to_string());
                 }
@@ -306,27 +190,21 @@ impl Program {
                     return Err("Data truncated".to_string());
                 }
 
-                let entry_points = decode_from_slice(
-                    Self::get_slice(data, entry_points_start, sources_start)?,
-                    standard(),
-                )
-                .map(|(value, _)| value)
-                .map_err(|e| format!("Entry points deserialization failed: {}", e))?;
+                let entry_points =
+                    from_bytes(Self::get_slice(data, entry_points_start, sources_start)?)
+                        .map_err(|e| format!("Entry points deserialization failed: {}", e))?;
 
-                let sources = decode_from_slice(
-                    Self::get_slice(data, sources_start, literals_start)?,
-                    standard(),
-                )
-                .map(|(value, _)| value)
-                .map_err(|e| format!("Sources deserialization failed: {}", e))?;
+                let sources = from_bytes(Self::get_slice(data, sources_start, literals_start)?)
+                    .map_err(|e| format!("Sources deserialization failed: {}", e))?;
 
                 let mut needs_recompilation = false;
 
-                let literals = match decode_from_slice::<Vec<BinaryValue>, _>(
-                    Self::get_slice(data, literals_start, rule_tree_start)?,
-                    standard(),
-                ) {
-                    Ok((binary_literals, _)) => match binaries_to_values(binary_literals) {
+                let literals = match from_bytes::<Vec<BinaryValue>>(Self::get_slice(
+                    data,
+                    literals_start,
+                    rule_tree_start,
+                )?) {
+                    Ok(binary_literals) => match binaries_to_values(binary_literals) {
                         Ok(values) => values,
                         Err(_e) => {
                             needs_recompilation = true;
@@ -339,11 +217,12 @@ impl Program {
                     }
                 };
 
-                let rule_tree = match decode_from_slice::<BinaryValue, _>(
-                    Self::get_slice(data, rule_tree_start, binary_len_start)?,
-                    standard(),
-                ) {
-                    Ok((binary_tree, _)) => match binary_to_value(binary_tree) {
+                let rule_tree = match from_bytes::<BinaryValue>(Self::get_slice(
+                    data,
+                    rule_tree_start,
+                    binary_len_start,
+                )?) {
+                    Ok(binary_tree) => match binary_to_value(binary_tree) {
                         Ok(value) => value,
                         Err(_e) => {
                             needs_recompilation = true;
@@ -356,16 +235,14 @@ impl Program {
                     }
                 };
 
-                let mut program = match decode_from_slice::<Program, _>(
-                    Self::get_slice(data, binary_start, binary_end)?,
-                    standard(),
-                ) {
-                    Ok((prog, _)) => prog,
-                    Err(_e) => {
-                        needs_recompilation = true;
-                        Program::new()
-                    }
-                };
+                let mut program =
+                    match from_bytes::<Program>(Self::get_slice(data, binary_start, binary_end)?) {
+                        Ok(prog) => prog,
+                        Err(_e) => {
+                            needs_recompilation = true;
+                            Program::new()
+                        }
+                    };
 
                 program.entry_points = entry_points;
                 program.sources = sources;
@@ -404,8 +281,16 @@ impl Program {
         let version = Self::read_u32(data, 4).ok();
 
         match version {
-            Some(1..=3) => Ok(true),
+            Some(1..=4) => Ok(true),
             _ => Ok(false),
+        }
+    }
+
+    fn legacy_rego_v0(data: &[u8], version: u32) -> Option<bool> {
+        match version {
+            1 => data.get(16).map(|value| *value != 0),
+            2 | 3 => data.get(24).map(|value| *value != 0),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Move RVM binary encoding from bincode to postcard and bump the format version. Update test helpers, docs, changelog, and refresh lockfiles after the swap.

Closes #575