### PR TITLE
fix: RVM evaluation of default-only rules

### DIFF
--- a/src/languages/rego/compiler/rules.rs
+++ b/src/languages/rego/compiler/rules.rs
@@ -38,6 +38,11 @@ impl<'a> Compiler<'a> {
 
     pub(super) fn compute_rule_type(&self, rule_path: &str) -> Result<RuleType> {
         let Some(definitions) = self.policy.inner.rules.get(rule_path) else {
+            // Default-only rules (e.g., `default deny := true`) have no regular definitions
+            // in the `rules` map — they only exist in `default_rules`. Treat them as Complete.
+            if self.policy.inner.default_rules.contains_key(rule_path) {
+                return Ok(RuleType::Complete);
+            }
             return Err(CompilerError::General {
                 message: format!("no definitions found for rule path '{}'", rule_path),
             }
@@ -603,6 +608,31 @@ impl<'a> Compiler<'a> {
             self.rule_function_param_count[rule_index as usize] = rule_param_count;
 
             if rule_param_count.is_none() {
+                let rule_path_parts: Vec<&str> = rule_path.split('.').collect();
+                if let Some((rule_name, package_parts)) = rule_path_parts.split_last() {
+                    let package_path: Vec<String> =
+                        package_parts.iter().map(|s| s.to_string()).collect();
+
+                    let _ = self.program.add_rule_to_tree(
+                        &package_path,
+                        rule_name,
+                        rule_index as usize,
+                    );
+                }
+            }
+
+            self.register_counter = saved_register_counter;
+            self.current_package = saved_package;
+            self.current_module_index = saved_module_index;
+        } else {
+            // Default-only rule — no body definitions to compile.
+            // Ensure rule_num_registers is sized so finish() won't panic.
+            if let Some(&rule_index) = self.rule_index_map.get(rule_path) {
+                while self.rule_num_registers.len() <= rule_index as usize {
+                    self.rule_num_registers.push(0);
+                }
+
+                // Add the rule to the data tree so it is discoverable.
                 let rule_path_parts: Vec<&str> = rule_path.split('.').collect();
                 if let Some((rule_name, package_parts)) = rule_path_parts.split_last() {
                     let package_path: Vec<String> =

--- a/src/rvm/vm/rules.rs
+++ b/src/rvm/vm/rules.rs
@@ -192,7 +192,13 @@ impl RegoVM {
         let rule_definitions = rule_info.definitions.clone();
 
         if rule_definitions.is_empty() {
-            let result = Value::Undefined;
+            // No compiled definitions — check for a default value before returning Undefined.
+            // Default-only rules (e.g., `default deny := true`) have no body definitions
+            // but their default value was evaluated at compile time and stored as a literal.
+            let result = rule_info
+                .default_literal_index
+                .and_then(|idx| self.program.literals.get(usize::from(idx)).cloned())
+                .unwrap_or(Value::Undefined);
             if !is_function_rule {
                 let available = self.rule_cache.len();
                 let entry =
@@ -336,7 +342,11 @@ impl RegoVM {
         }
 
         if rule_info.definitions.is_empty() {
-            let result = Value::Undefined;
+            // No compiled definitions — check for a default value before returning Undefined.
+            let result = rule_info
+                .default_literal_index
+                .and_then(|idx| self.program.literals.get(usize::from(idx)).cloned())
+                .unwrap_or(Value::Undefined);
             if !is_function_rule {
                 let available = self.rule_cache.len();
                 let entry =

--- a/tests/interpreter/cases/default/basic.yaml
+++ b/tests/interpreter/cases/default/basic.yaml
@@ -321,6 +321,37 @@ cases:
     skip: true
     want_result: [5]
 
+  - note: default_only_rule_bool
+    data: {}
+    modules:
+      - |
+        package test
+        default deny := true
+    query: data.test.deny
+    want_result: true
+
+  - note: default_only_rule_object
+    data: {}
+    modules:
+      - |
+        package test
+        default deny := {"result": false, "reasons": []}
+    query: data.test.deny
+    want_result:
+      result: false
+      reasons: []
+
+  - note: default_only_rule_with_package_query
+    data: {}
+    modules:
+      - |
+        package graph.mypolicy
+        default deny := {"result": false, "reasons": []}
+    query: data.graph.mypolicy.deny
+    want_result:
+      result: false
+      reasons: []
+
   - note: valid-var-in-some-in-value
     data: {}
     modules:

--- a/tests/rvm/rego/cases/default_rules.yaml
+++ b/tests/rvm/rego/cases/default_rules.yaml
@@ -154,6 +154,39 @@ cases:
     query: data.test.auth.allow
     want_result: false
 
+  - note: default_only_rule_bool
+    data: {}
+    modules:
+      - |
+        package test
+        default deny := true
+    query: data.test.deny
+    want_result: true
+
+  - note: default_only_rule_object
+    data: {}
+    modules:
+      - |
+        package test
+        default deny := {"result": false, "reasons": []}
+    query: data.test.deny
+    want_result:
+      result: false
+      reasons: []
+
+  - note: default_only_rule_with_entry_point
+    data: {}
+    modules:
+      - |
+        package graph.mypolicy
+        default deny := {"result": false, "reasons": []}
+    entry_points:
+      - data.graph.mypolicy.deny
+    query: data.graph.mypolicy.deny
+    want_result:
+      result: false
+      reasons: []
+
   - note: multiple_default_rules_different_names
     skip: true
     data: {}


### PR DESCRIPTION
### Problem

Rego rules that have only a `default` declaration with no conditional body (e.g., `default deny := {"result": false}`) return `Undefined` in the RVM instead of the default value. The interpreter handles this correctly — the bug is RVM-only.

### Root cause

Two gaps in the RVM compiler and VM:

1. **Compiler (`compute_rule_type`)**: When a rule path exists only in the `default_rules` map (no entries in `rules`), the compiler errors with "no definitions found for rule path" instead of recognizing it as a `Complete` rule.

2. **Compiler (`compile_worklist_rule`)**: The `else` branch (no definitions to compile) was a no-op — it didn't allocate register slots or add the rule to the data tree, so `finish()` would panic or the rule was undiscoverable at eval time.

3. **VM (`execute_call_rule_common` / `execute_call_rule_suspendable`)**: When `rule_definitions` is empty, both functions immediately returned `Undefined` without checking the `default_literal_index` for a pre-compiled default value.

### Fix

- `compute_rule_type`: return `Complete` when the rule path exists in `default_rules` but not `rules`
- `compile_worklist_rule` else branch: size `rule_num_registers`, add the rule to the program's data tree
- `execute_call_rule_common` + `execute_call_rule_suspendable`: look up `default_literal_index` and return the stored literal before falling back to `Undefined`

### Tests

- 3 new RVM test cases in `default_rules.yaml`: `default_only_rule_bool`, `default_only_rule_object`, `default_only_rule_with_entry_point`
- 3 matching interpreter test cases in `default/basic.yaml` (confirming the interpreter already handles these correctly)