### PR TITLE
fix(rvm): support nested partial object rule yields

### DIFF
--- a/src/languages/rego/compiler/comprehensions.rs
+++ b/src/languages/rego/compiler/comprehensions.rs
@@ -7,6 +7,7 @@ use crate::ast::{ExprRef, Query};
 use crate::lexer::Span;
 use crate::rvm::instructions::{ComprehensionBeginParams, ComprehensionMode};
 use crate::rvm::Instruction;
+use alloc::vec::Vec;
 
 impl<'a> Compiler<'a> {
     fn compile_comprehension(
@@ -42,6 +43,8 @@ impl<'a> Compiler<'a> {
             context_type: ContextType::Comprehension(context_type),
             dest_register: result_reg,
             key_expr: key_expr.cloned(),
+            extra_key_exprs: Vec::new(),
+            multi_value: false,
             value_expr: value_expr.cloned(),
             span: span.clone(),
             key_value_loops_hoisted: false,

--- a/src/languages/rego/compiler/loops.rs
+++ b/src/languages/rego/compiler/loops.rs
@@ -156,6 +156,8 @@ impl<'a> Compiler<'a> {
             context_type: ContextType::Every,
             dest_register: result_reg,
             key_expr: None,
+            extra_key_exprs: Vec::new(),
+            multi_value: false,
             value_expr: None,
             span: span.clone(),
             key_value_loops_hoisted: false,

--- a/src/languages/rego/compiler/mod.rs
+++ b/src/languages/rego/compiler/mod.rs
@@ -59,6 +59,11 @@ pub struct CompilationContext {
     pub(super) context_type: ContextType,
     pub(super) dest_register: Register,
     pub(super) key_expr: Option<ExprRef>,
+    /// Additional key expressions for multi-level partial objects (e.g., foo[a][b][c] := v).
+    /// When non-empty, all keys (key_expr + extra_key_exprs) form the full key path.
+    pub(super) extra_key_exprs: Vec<ExprRef>,
+    /// If true, the leaf is a set and values are inserted into it (contains rules).
+    pub(super) multi_value: bool,
     pub(super) value_expr: Option<ExprRef>,
     pub(super) span: Span,
     pub(super) key_value_loops_hoisted: bool,

--- a/src/languages/rego/compiler/queries.rs
+++ b/src/languages/rego/compiler/queries.rs
@@ -96,20 +96,34 @@ impl<'a> Compiler<'a> {
             }
         }
 
-        let (key_expr, value_expr) = match self.context_stack.last_mut() {
-            Some(context) => {
-                if context.key_value_loops_hoisted {
-                    return self.emit_context_yield();
+        let (key_expr, _extra_key_exprs, value_expr, is_partial_object_rule) =
+            match self.context_stack.last_mut() {
+                Some(context) => {
+                    if context.key_value_loops_hoisted {
+                        return self.emit_context_yield();
+                    }
+                    let is_po = matches!(
+                        context.context_type,
+                        ContextType::Rule(RuleType::PartialObject)
+                    );
+                    (
+                        context.key_expr.clone(),
+                        context.extra_key_exprs.clone(),
+                        context.value_expr.clone(),
+                        is_po,
+                    )
                 }
-                (context.key_expr.clone(), context.value_expr.clone())
-            }
-            None => return Ok(()),
-        };
+                None => return Ok(()),
+            };
 
         let mut key_value_loops = Vec::new();
 
-        if let Some(expr) = key_expr.as_ref() {
-            key_value_loops.extend(self.get_expr_loops(expr)?);
+        // Key expressions from rule head ref chains (partial object rules) are NOT hoisted.
+        // They reference variables bound in the body and are compiled directly in emit_context_yield.
+        if !is_partial_object_rule {
+            if let Some(expr) = key_expr.as_ref() {
+                key_value_loops.extend(self.get_expr_loops(expr)?);
+            }
         }
 
         if let Some(expr) = value_expr.as_ref() {
@@ -188,14 +202,37 @@ impl<'a> Compiler<'a> {
                     );
                 }
                 ContextType::Rule(RuleType::PartialObject) => {
-                    self.emit_instruction(
-                        Instruction::ObjectSet {
+                    // Check if we need ObjectDeepSet (multi-key or multi-value)
+                    if !context.extra_key_exprs.is_empty() || context.multi_value {
+                        let mut key_registers = Vec::new();
+                        // First key is already compiled as key_register
+                        key_registers.push(key_register);
+                        // Compile additional key expressions
+                        for extra_key_expr in &context.extra_key_exprs {
+                            let extra_reg = self.compile_rego_expr(extra_key_expr)?;
+                            key_registers.push(extra_reg);
+                        }
+                        let params = crate::rvm::instructions::ObjectDeepSetParams {
                             obj: dest_register,
-                            key: key_register,
+                            keys: key_registers,
                             value: value_register,
-                        },
-                        span,
-                    );
+                            multi_value: context.multi_value,
+                        };
+                        let params_index = self
+                            .program
+                            .instruction_data
+                            .add_object_deep_set_params(params);
+                        self.emit_instruction(Instruction::ObjectDeepSet { params_index }, span);
+                    } else {
+                        self.emit_instruction(
+                            Instruction::ObjectSet {
+                                obj: dest_register,
+                                key: key_register,
+                                value: value_register,
+                            },
+                            span,
+                        );
+                    }
                 }
                 ContextType::Rule(RuleType::Complete) => {
                     self.emit_instruction(

--- a/src/languages/rego/compiler/rules.rs
+++ b/src/languages/rego/compiler/rules.rs
@@ -58,8 +58,8 @@ impl<'a> Compiler<'a> {
                 Expr::RefDot {
                     refr: inner, field, ..
                 } => {
-                    // RefDot field is (Span, Value) — wrap as a literal Expr
-                    let field_expr = ExprRef::new(Expr::Var {
+                    // RefDot field is (Span, Value) — wrap as a string literal Expr
+                    let field_expr = ExprRef::new(Expr::String {
                         span: field.0.clone(),
                         value: field.1.clone(),
                         eidx: 0,

--- a/src/languages/rego/compiler/rules.rs
+++ b/src/languages/rego/compiler/rules.rs
@@ -36,6 +36,44 @@ impl<'a> Compiler<'a> {
         }
     }
 
+    /// Check whether a ref expression contains any RefBrack or RefDot nesting
+    /// (i.e., it's a partial rule reference like `foo[a]` or `foo[a].b`).
+    fn refr_has_bracket_or_dot(refr: &Expr) -> bool {
+        matches!(refr, Expr::RefBrack { .. } | Expr::RefDot { .. })
+    }
+
+    /// Extract key expressions from a nested ref chain (e.g., `foo[a][b].c`)
+    /// Returns them in order: [a, b, "c"]
+    fn extract_ref_key_exprs(refr: &Expr) -> Vec<ExprRef> {
+        let mut keys = Vec::new();
+        let mut current = refr;
+        loop {
+            match current {
+                Expr::RefBrack {
+                    refr: inner, index, ..
+                } => {
+                    keys.push(index.clone());
+                    current = inner.as_ref();
+                }
+                Expr::RefDot {
+                    refr: inner, field, ..
+                } => {
+                    // RefDot field is (Span, Value) — wrap as a literal Expr
+                    let field_expr = ExprRef::new(Expr::Var {
+                        span: field.0.clone(),
+                        value: field.1.clone(),
+                        eidx: 0,
+                    });
+                    keys.push(field_expr);
+                    current = inner.as_ref();
+                }
+                _ => break,
+            }
+        }
+        keys.reverse(); // We collected innermost-first, reverse to get outermost-first
+        keys
+    }
+
     pub(super) fn compute_rule_type(&self, rule_path: &str) -> Result<RuleType> {
         let Some(definitions) = self.policy.inner.rules.get(rule_path) else {
             // Default-only rules (e.g., `default deny := true`) have no regular definitions
@@ -54,7 +92,15 @@ impl<'a> Compiler<'a> {
             .map(|def| {
                 if let Rule::Spec { head, .. } = def.as_ref() {
                     match head {
-                        RuleHead::Set { .. } => RuleType::PartialSet,
+                        RuleHead::Set { refr, .. } => {
+                            // `foo[a] contains v` or `foo[a][b] contains v` → PartialObject
+                            // `foo contains v` → PartialSet
+                            if Self::refr_has_bracket_or_dot(refr.as_ref()) {
+                                RuleType::PartialObject
+                            } else {
+                                RuleType::PartialSet
+                            }
+                        }
                         RuleHead::Compr { refr, assign, .. } => match refr.as_ref() {
                             crate::ast::Expr::RefBrack { .. } if assign.is_some() => {
                                 RuleType::PartialObject
@@ -343,25 +389,38 @@ impl<'a> Compiler<'a> {
 
                     self.current_module_index = self.find_module_index_for_rule(rule_ref)?;
 
-                    let (key_expr, value_expr) = match head {
+                    let (key_expr, extra_key_exprs, multi_value, value_expr) = match head {
                         RuleHead::Compr { refr, assign, .. } => {
                             self.rule_definition_function_params[rule_index as usize].push(None);
                             self.rule_definition_destructuring_patterns[rule_index as usize]
                                 .push(None);
 
                             let output_expr = assign.as_ref().map(|assign| assign.value.clone());
-                            let key_expr = match refr.as_ref() {
-                                Expr::RefBrack { index, .. } => Some(index.clone()),
-                                _ => None,
+                            let all_keys = Self::extract_ref_key_exprs(refr.as_ref());
+                            let (first_key, rest_keys) = if all_keys.is_empty() {
+                                (None, Vec::new())
+                            } else {
+                                let mut keys = all_keys;
+                                let first = keys.remove(0);
+                                (Some(first), keys)
                             };
-                            (key_expr, output_expr)
+                            (first_key, rest_keys, false, output_expr)
                         }
-                        RuleHead::Set { key, .. } => {
+                        RuleHead::Set { refr, key, .. } => {
                             self.rule_definition_function_params[rule_index as usize].push(None);
                             self.rule_definition_destructuring_patterns[rule_index as usize]
                                 .push(None);
 
-                            (None, key.clone())
+                            let all_keys = Self::extract_ref_key_exprs(refr.as_ref());
+                            if all_keys.is_empty() {
+                                // Simple set: `foo contains v`
+                                (None, Vec::new(), false, key.clone())
+                            } else {
+                                // Multi-value partial object: `foo[a] contains v`
+                                let mut keys = all_keys;
+                                let first = keys.remove(0);
+                                (Some(first), keys, true, key.clone())
+                            }
                         }
                         RuleHead::Func { assign, args, .. } => {
                             let mut param_names = Vec::new();
@@ -442,8 +501,10 @@ impl<'a> Compiler<'a> {
                             }
 
                             match assign {
-                                Some(assignment) => (None, Some(assignment.value.clone())),
-                                None => (None, None),
+                                Some(assignment) => {
+                                    (None, Vec::new(), false, Some(assignment.value.clone()))
+                                }
+                                None => (None, Vec::new(), false, None),
                             }
                         }
                     };
@@ -458,6 +519,8 @@ impl<'a> Compiler<'a> {
                         dest_register: result_register,
                         context_type: ContextType::Rule(rule_type.clone()),
                         key_expr,
+                        extra_key_exprs,
+                        multi_value,
                         value_expr,
                         span,
                         key_value_loops_hoisted: false,

--- a/src/rvm/instructions/display.rs
+++ b/src/rvm/instructions/display.rs
@@ -201,6 +201,9 @@ impl core::fmt::Display for Instruction {
             Instruction::ObjectSet { obj, key, value } => {
                 format!("OBJECT_SET R({}) R({}) R({})", obj, key, value)
             }
+            Instruction::ObjectDeepSet { params_index } => {
+                format!("OBJECT_DEEP_SET P({})", params_index)
+            }
             Instruction::ObjectCreate { params_index } => {
                 format!("OBJECT_CREATE P({})", params_index)
             }

--- a/src/rvm/instructions/mod.rs
+++ b/src/rvm/instructions/mod.rs
@@ -7,8 +7,8 @@ mod types;
 
 pub use params::{
     ArrayCreateParams, BuiltinCallParams, ChainedIndexParams, ComprehensionBeginParams,
-    FunctionCallParams, InstructionData, LoopStartParams, ObjectCreateParams, SetCreateParams,
-    VirtualDataDocumentLookupParams,
+    FunctionCallParams, InstructionData, LoopStartParams, ObjectCreateParams, ObjectDeepSetParams,
+    SetCreateParams, VirtualDataDocumentLookupParams,
 };
 pub use types::{
     ComprehensionMode, GuardMode, LiteralOrRegister, LogicalBlockMode, LoopMode, PolicyOp,
@@ -179,6 +179,13 @@ pub enum Instruction {
         obj: u8,
         key: u8,
         value: u8,
+    },
+
+    /// Deep set into nested object with optional multi-value (set) leaf.
+    /// Handles patterns like `foo[a][b] := c` and `foo[a][b] contains v`.
+    ObjectDeepSet {
+        /// Index into program's instruction_data.object_deep_set_params table
+        params_index: u16,
     },
 
     /// Create object with optimized field setting - uses parameter table

--- a/src/rvm/instructions/params.rs
+++ b/src/rvm/instructions/params.rs
@@ -205,6 +205,29 @@ impl VirtualDataDocumentLookupParams {
     }
 }
 
+/// Deep object set parameters for multi-key partial object/set rules.
+/// Handles patterns like `foo[a][b] := c` and `foo[a] contains v`.
+#[repr(C)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectDeepSetParams {
+    /// Root object register
+    pub obj: u8,
+    /// Key registers in order (one per nesting level)
+    pub keys: Vec<u8>,
+    /// Value register to insert/assign at the leaf
+    pub value: u8,
+    /// If true, the leaf is a set and value is inserted into it.
+    /// If false, the leaf is a plain value that is overwritten.
+    pub multi_value: bool,
+}
+
+impl ObjectDeepSetParams {
+    /// Get the depth (number of key levels)
+    pub const fn depth(&self) -> usize {
+        self.keys.len()
+    }
+}
+
 /// Chained index parameters for multi-level object access (input, locals, non-rule data paths)
 #[repr(C)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -295,6 +318,8 @@ pub struct InstructionData {
     pub chained_index_params: Vec<ChainedIndexParams>,
     /// Comprehension parameter table for ComprehensionBegin instructions
     pub comprehension_begin_params: Vec<ComprehensionBeginParams>,
+    /// Object deep set parameter table for ObjectDeepSet instructions
+    pub object_deep_set_params: Vec<ObjectDeepSetParams>,
 }
 
 impl InstructionData {
@@ -315,6 +340,7 @@ impl InstructionData {
             virtual_data_document_lookup_params: Vec::new(),
             chained_index_params: Vec::new(),
             comprehension_begin_params: Vec::new(),
+            object_deep_set_params: Vec::new(),
         }
     }
 
@@ -444,6 +470,18 @@ impl InstructionData {
         index: u16,
     ) -> Option<&mut ComprehensionBeginParams> {
         self.comprehension_begin_params.get_mut(usize::from(index))
+    }
+
+    /// Add object deep set parameters and return the index
+    pub fn add_object_deep_set_params(&mut self, params: ObjectDeepSetParams) -> u16 {
+        let index = Self::ensure_u16_index(self.object_deep_set_params.len());
+        self.object_deep_set_params.push(params);
+        index
+    }
+
+    /// Get object deep set parameters by index
+    pub fn get_object_deep_set_params(&self, index: u16) -> Option<&ObjectDeepSetParams> {
+        self.object_deep_set_params.get(usize::from(index))
     }
 }
 

--- a/src/rvm/program/listing.rs
+++ b/src/rvm/program/listing.rs
@@ -507,6 +507,29 @@ fn format_instruction_readable(
             let comment = format!("Set field r{}[r{}] = r{}", obj, key, value);
             align_comment(&base, &comment, config.comment_column)
         }
+        Instruction::ObjectDeepSet { params_index } => {
+            let params = program
+                .instruction_data
+                .get_object_deep_set_params(params_index);
+            params.map_or_else(
+                || format!("{}ObjDeepSet   P({})", indent, params_index),
+                |p| {
+                    let keys_str: alloc::string::String =
+                        p.keys.iter().map(|k| alloc::format!("[r{}]", k)).collect();
+                    let mode = if p.multi_value { "∪=" } else { "←" };
+                    let base = format!(
+                        "{}ObjDeepSet   r{}{} {} r{}",
+                        indent, p.obj, keys_str, mode, p.value
+                    );
+                    let comment = if p.multi_value {
+                        alloc::format!("Deep set-add r{}{}.insert(r{})", p.obj, keys_str, p.value)
+                    } else {
+                        alloc::format!("Deep set r{}{} = r{}", p.obj, keys_str, p.value)
+                    };
+                    align_comment(&base, &comment, config.comment_column)
+                },
+            )
+        }
         Instruction::ObjectCreate { params_index } => {
             let params = program
                 .instruction_data
@@ -1022,6 +1045,7 @@ const fn get_instruction_name(instruction: &Instruction) -> &'static str {
         Instruction::HostAwait { .. } => "HOST_AWAIT",
         Instruction::Return { .. } => "RETURN",
         Instruction::ObjectSet { .. } => "OBJ_SET",
+        Instruction::ObjectDeepSet { .. } => "OBJ_DEEP_SET",
         Instruction::ObjectCreate { .. } => "OBJ_CREATE",
         Instruction::Index { .. } => "INDEX",
         Instruction::IndexLiteral { .. } => "INDEX_LIT",

--- a/src/rvm/tests/instruction_parser.rs
+++ b/src/rvm/tests/instruction_parser.rs
@@ -53,6 +53,7 @@ pub fn parse_instruction(text: &str) -> Result<Instruction> {
             "RuleReturn" => parse_rule_return(params_text),
             "DestructuringSuccess" => parse_destructuring_success(params_text),
             "ObjectSet" => parse_object_set(params_text),
+            "ObjectDeepSet" => parse_object_deep_set(params_text),
             "ObjectCreate" => parse_object_create(params_text),
             "Index" => parse_index(params_text),
             "IndexLiteral" => parse_index_literal(params_text),
@@ -398,6 +399,12 @@ fn parse_object_set(params_text: &str) -> Result<Instruction> {
         key: key.try_into().unwrap(),
         value: value.try_into().unwrap(),
     })
+}
+
+fn parse_object_deep_set(params_text: &str) -> Result<Instruction> {
+    let params = parse_params(params_text)?;
+    let params_index = get_param_u16(&params, "params_index")?;
+    Ok(Instruction::ObjectDeepSet { params_index })
 }
 
 fn parse_object_create(params_text: &str) -> Result<Instruction> {

--- a/src/rvm/vm/dispatch.rs
+++ b/src/rvm/vm/dispatch.rs
@@ -467,6 +467,36 @@ impl RegoVM {
                 }
                 Ok(InstructionOutcome::Continue)
             }
+            ObjectDeepSet { params_index } => {
+                let params = program
+                    .instruction_data
+                    .get_object_deep_set_params(params_index)
+                    .ok_or(VmError::InvalidObjectCreateParams {
+                        index: params_index,
+                        pc: self.pc,
+                        available: program.instruction_data.object_deep_set_params.len(),
+                    })?
+                    .clone();
+
+                // Read all key values and the leaf value upfront
+                let key_values: alloc::vec::Vec<Value> = params
+                    .keys
+                    .iter()
+                    .map(|&k| self.get_register(k).cloned())
+                    .collect::<core::result::Result<_, _>>()?;
+                let leaf_value = self.get_register(params.value)?.clone();
+
+                let mut root = self.take_register(params.obj)?;
+                self.object_deep_set(
+                    &mut root,
+                    &key_values,
+                    leaf_value,
+                    params.multi_value,
+                    params.obj,
+                )?;
+                self.set_register(params.obj, root)?;
+                Ok(InstructionOutcome::Continue)
+            }
             ObjectCreate { params_index } => {
                 let params = program
                     .instruction_data
@@ -1174,5 +1204,67 @@ impl RegoVM {
                 pc: self.pc,
             }),
         }
+    }
+
+    fn object_deep_set(
+        &self,
+        current: &mut Value,
+        key_values: &[Value],
+        leaf_value: Value,
+        multi_value: bool,
+        obj_register: u8,
+    ) -> Result<()> {
+        let Some((first_key, remaining_keys)) = key_values.split_first() else {
+            return Ok(());
+        };
+
+        let offending = current.clone();
+        let object = current
+            .as_object_mut()
+            .map_err(|_| VmError::RegisterNotObject {
+                register: obj_register,
+                value: offending,
+                pc: self.pc,
+            })?;
+
+        if remaining_keys.is_empty() {
+            if multi_value {
+                let leaf = match object.entry(first_key.clone()) {
+                    alloc::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
+                    alloc::collections::btree_map::Entry::Vacant(entry) => {
+                        entry.insert(Value::new_set())
+                    }
+                };
+
+                let leaf_snapshot = leaf.clone();
+                let set = leaf.as_set_mut().map_err(|_| VmError::RegisterNotSet {
+                    register: obj_register,
+                    value: leaf_snapshot,
+                    pc: self.pc,
+                })?;
+                set.insert(leaf_value);
+            } else {
+                object.insert(first_key.clone(), leaf_value);
+            }
+
+            return Ok(());
+        }
+
+        let child = match object.entry(first_key.clone()) {
+            alloc::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
+            alloc::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(Value::new_object())
+            }
+        };
+
+        if !matches!(child, Value::Object(_)) {
+            return Err(VmError::RegisterNotObject {
+                register: obj_register,
+                value: child.clone(),
+                pc: self.pc,
+            });
+        }
+
+        self.object_deep_set(child, remaining_keys, leaf_value, multi_value, obj_register)
     }
 }

--- a/src/rvm/vm/dispatch.rs
+++ b/src/rvm/vm/dispatch.rs
@@ -471,12 +471,11 @@ impl RegoVM {
                 let params = program
                     .instruction_data
                     .get_object_deep_set_params(params_index)
-                    .ok_or(VmError::InvalidObjectCreateParams {
+                    .ok_or(VmError::InvalidObjectDeepSetParams {
                         index: params_index,
                         pc: self.pc,
                         available: program.instruction_data.object_deep_set_params.len(),
-                    })?
-                    .clone();
+                    })?;
 
                 // Read all key values and the leaf value upfront
                 let key_values: alloc::vec::Vec<Value> = params
@@ -485,16 +484,12 @@ impl RegoVM {
                     .map(|&k| self.get_register(k).cloned())
                     .collect::<core::result::Result<_, _>>()?;
                 let leaf_value = self.get_register(params.value)?.clone();
+                let multi_value = params.multi_value;
+                let obj = params.obj;
 
-                let mut root = self.take_register(params.obj)?;
-                self.object_deep_set(
-                    &mut root,
-                    &key_values,
-                    leaf_value,
-                    params.multi_value,
-                    params.obj,
-                )?;
-                self.set_register(params.obj, root)?;
+                let mut root = self.take_register(obj)?;
+                self.object_deep_set(&mut root, &key_values, leaf_value, multi_value, obj)?;
+                self.set_register(obj, root)?;
                 Ok(InstructionOutcome::Continue)
             }
             ObjectCreate { params_index } => {
@@ -1215,17 +1210,22 @@ impl RegoVM {
         obj_register: u8,
     ) -> Result<()> {
         let Some((first_key, remaining_keys)) = key_values.split_first() else {
-            return Ok(());
+            return Err(VmError::Internal {
+                message: alloc::string::String::from("ObjectDeepSet requires a non-empty key path"),
+                pc: self.pc,
+            });
         };
 
-        let offending = current.clone();
-        let object = current
-            .as_object_mut()
-            .map_err(|_| VmError::RegisterNotObject {
-                register: obj_register,
-                value: offending,
-                pc: self.pc,
-            })?;
+        let object = match current.as_object_mut() {
+            Ok(obj) => obj,
+            Err(_) => {
+                return Err(VmError::RegisterNotObject {
+                    register: obj_register,
+                    value: current.clone(),
+                    pc: self.pc,
+                });
+            }
+        };
 
         if remaining_keys.is_empty() {
             if multi_value {

--- a/src/rvm/vm/errors.rs
+++ b/src/rvm/vm/errors.rs
@@ -83,6 +83,13 @@ pub enum VmError {
         available: usize,
     },
 
+    #[error("Invalid object deep set params index: {index} (pc={pc}, available={available})")]
+    InvalidObjectDeepSetParams {
+        index: u16,
+        pc: usize,
+        available: usize,
+    },
+
     #[error("Invalid template literal index: {index} (pc={pc}, available={available})")]
     InvalidTemplateLiteralIndex {
         index: u16,

--- a/tests/rvm/rego/cases/partial_object_multivalue.yaml
+++ b/tests/rvm/rego/cases/partial_object_multivalue.yaml
@@ -148,3 +148,352 @@ cases:
     query: data.test.items
     want_result:
       set!: [1, 2, 3]
+
+  # ── Multi-value with non-scalar leaf values ──
+
+  - note: multivalue_with_object_values
+    data: {}
+    modules:
+      - |
+        package test
+
+        records := [
+          {"category": "A", "item": {"id": 1, "name": "one"}},
+          {"category": "A", "item": {"id": 2, "name": "two"}},
+          {"category": "B", "item": {"id": 3, "name": "three"}}
+        ]
+
+        by_category[cat] contains item if {
+          some rec in records
+          cat := rec.category
+          item := rec.item
+        }
+    query: data.test.by_category
+    want_result:
+      A:
+        set!:
+          - {"id": 1, "name": "one"}
+          - {"id": 2, "name": "two"}
+      B:
+        set!:
+          - {"id": 3, "name": "three"}
+
+  - note: multivalue_with_array_values
+    data: {}
+    modules:
+      - |
+        package test
+
+        data_map := {"k1": [[1,2],[3,4]], "k2": [[5,6]]}
+
+        grouped[key] contains arr if {
+          some key, arrs in data_map
+          some arr in arrs
+        }
+    query: data.test.grouped
+    want_result:
+      k1:
+        set!: [[1,2], [3,4]]
+      k2:
+        set!: [[5,6]]
+
+  # ── Numeric key types ──
+
+  - note: multivalue_with_numeric_keys
+    data: {}
+    modules:
+      - |
+        package test
+
+        buckets := {0: ["a", "b"], 1: ["c"]}
+
+        items[k] contains v if {
+          some k, vals in buckets
+          some v in vals
+        }
+    query: data.test.items
+    want_result:
+      0:
+        set!: ["a", "b"]
+      1:
+        set!: ["c"]
+
+  # ── Empty body / no matches ──
+
+  - note: multivalue_empty_result
+    data: {}
+    modules:
+      - |
+        package test
+
+        items[k] contains v if {
+          some k, vals in {}
+          some v in vals
+        }
+    query: data.test.items
+    # The interpreter returns Undefined when no iteration fires; the RVM
+    # initializes the result register to an empty object and returns {}.
+    # Mark the interpreter result as an acceptable divergence.
+    allow_interpreter_incorrect_behavior: true
+    want_result: {}
+
+  # ── Consuming multivalue result in another rule ──
+
+  - note: multivalue_consumed_by_another_rule
+    data: {}
+    modules:
+      - |
+        package test
+
+        sources := {"web": [80, 443], "ssh": [22]}
+
+        ports[svc] contains p if {
+          some svc, ps in sources
+          some p in ps
+        }
+
+        web_ports := ports.web
+    query: data.test.web_ports
+    want_result:
+      set!: [80, 443]
+
+  - note: multivalue_count_in_another_rule
+    data: {}
+    modules:
+      - |
+        package test
+
+        sources := {"a": [1,2,3], "b": [4,5]}
+
+        items[k] contains v if {
+          some k, vals in sources
+          some v in vals
+        }
+
+        sizes[k] := count(items[k]) if {
+          some k, _ in sources
+        }
+    query: data.test.sizes
+    want_result:
+      a: 3
+      b: 2
+
+  # ── Single-element edge cases ──
+
+  - note: multivalue_single_key_single_value
+    data: {}
+    modules:
+      - |
+        package test
+
+        items[k] contains v if {
+          k := "only"
+          v := "one"
+        }
+    query: data.test.items
+    want_result:
+      only:
+        set!: ["one"]
+
+  # ── Multiple rule definitions with different keys ──
+
+  - note: multivalue_multiple_definitions_different_keys
+    data: {}
+    modules:
+      - |
+        package test
+
+        tags[category] contains tag if {
+          some tag in ["critical", "high"]
+          category := "severity"
+        }
+
+        tags[category] contains tag if {
+          some tag in ["network", "storage"]
+          category := "type"
+        }
+    query: data.test.tags
+    want_result:
+      severity:
+        set!: ["critical", "high"]
+      type:
+        set!: ["network", "storage"]
+
+  # ── Multivalue with body conditions and filtering ──
+
+  - note: multivalue_with_condition_filtering
+    data: {}
+    modules:
+      - |
+        package test
+
+        entries := {
+          "team1": [
+            {"name": "alice", "active": true},
+            {"name": "bob", "active": false},
+            {"name": "carol", "active": true}
+          ],
+          "team2": [
+            {"name": "dave", "active": false}
+          ]
+        }
+
+        active_members[team] contains member.name if {
+          some team, members in entries
+          some member in members
+          member.active == true
+        }
+    query: data.test.active_members
+    want_result:
+      team1:
+        set!: ["alice", "carol"]
+
+  # ── Multivalue from input data ──
+
+  - note: multivalue_from_nested_input
+    data: {}
+    input:
+      departments:
+        engineering:
+          members: ["alice", "bob"]
+        marketing:
+          members: ["carol"]
+    modules:
+      - |
+        package test
+
+        dept_members[dept] contains member if {
+          some dept, info in input.departments
+          some member in info.members
+        }
+    query: data.test.dept_members
+    want_result:
+      engineering:
+        set!: ["alice", "bob"]
+      marketing:
+        set!: ["carol"]
+
+  # ── Multiple definitions accumulating into same key ──
+
+  - note: multivalue_multiple_definitions_same_key
+    data: {}
+    modules:
+      - |
+        package test
+
+        items[k] contains v if {
+          some v in ["a", "b"]
+          k := "shared"
+        }
+
+        items[k] contains v if {
+          some v in ["b", "c"]
+          k := "shared"
+        }
+    query: data.test.items
+    want_result:
+      shared:
+        set!: ["a", "b", "c"]
+
+  # ── Boolean value in multivalue set ──
+
+  - note: multivalue_with_boolean_values
+    data: {}
+    modules:
+      - |
+        package test
+
+        checks := {"auth": [true, false], "ssl": [true]}
+
+        results[name] contains val if {
+          some name, vals in checks
+          some val in vals
+        }
+    query: data.test.results
+    want_result:
+      auth:
+        set!: [false, true]
+      ssl:
+        set!: [true]
+
+  # ── Multivalue with string key derived from computation ──
+
+  - note: multivalue_computed_keys
+    data: {}
+    modules:
+      - |
+        package test
+
+        raw := [
+          {"region": "us-east", "svc": "web"},
+          {"region": "us-east", "svc": "api"},
+          {"region": "eu-west", "svc": "web"}
+        ]
+
+        services[region] contains svc if {
+          some entry in raw
+          region := entry.region
+          svc := entry.svc
+        }
+    query: data.test.services
+    want_result:
+      us-east:
+        set!: ["api", "web"]
+      eu-west:
+        set!: ["web"]
+
+  # ── Large number of values per key ──
+
+  - note: multivalue_many_values_per_key
+    data: {}
+    modules:
+      - |
+        package test
+
+        numbers[bucket] contains n if {
+          some n in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+          bucket := "all"
+        }
+    query: data.test.numbers
+    want_result:
+      all:
+        set!: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+  # ── Multivalue alongside regular complete rule ──
+
+  - note: multivalue_alongside_complete_rule
+    data: {}
+    modules:
+      - |
+        package test
+
+        sources := {"x": [1, 2], "y": [3]}
+
+        items[k] contains v if {
+          some k, vs in sources
+          some v in vs
+        }
+
+        total := count(items)
+    query: data.test.total
+    want_result: 2
+
+  # ── Query the full package with both complete and multivalue rules ──
+
+  - note: multivalue_with_data_document_lookup
+    data: {}
+    modules:
+      - |
+        package test
+
+        sources := {"a": ["x", "y"]}
+
+        grouped[k] contains v if {
+          some k, vs in sources
+          some v in vs
+        }
+
+        first_group := grouped.a
+    query: data.test.first_group
+    want_result:
+      set!: ["x", "y"]

--- a/tests/rvm/rego/cases/partial_object_multivalue.yaml
+++ b/tests/rvm/rego/cases/partial_object_multivalue.yaml
@@ -100,25 +100,24 @@ cases:
       - |
         package test
 
-        tags[category] contains tag if {
-          some category, tag in {
-            "colors": "red",
-            "colors": "blue",
-          }
-        }
+        tag_pairs := [
+          ["colors", "red"],
+          ["colors", "blue"],
+          ["sizes", "small"],
+          ["sizes", "large"],
+        ]
 
         tags[category] contains tag if {
-          some category, tag in {
-            "sizes": "small",
-            "sizes": "large",
-          }
+          some pair in tag_pairs
+          category := pair[0]
+          tag := pair[1]
         }
     query: data.test.tags
     want_result:
       colors:
-        set!: ["blue"]
+        set!: ["red", "blue"]
       sizes:
-        set!: ["large"]
+        set!: ["small", "large"]
 
   - note: regular_partial_object_still_works
     data: {}
@@ -497,3 +496,125 @@ cases:
     query: data.test.first_group
     want_result:
       set!: ["x", "y"]
+
+  # ── Multi-bracket rule heads (tested via wrapper rules) ──
+
+  - note: multi_bracket_two_key_assign
+    data: {}
+    modules:
+      - |
+        package test
+
+        settings[svc][field] := v if {
+          some svc, fields in {"web": {"port": 80, "tls": true}, "ssh": {"port": 22}}
+          some field, v in fields
+        }
+
+        result := settings
+    query: data.test.result
+    want_result:
+      web:
+        port: 80
+        tls: true
+      ssh:
+        port: 22
+
+  - note: multi_bracket_two_key_contains
+    data: {}
+    modules:
+      - |
+        package test
+
+        perms[role] contains action if {
+          some role, actions in {"admin": ["read", "write"], "viewer": ["read"]}
+          some action in actions
+        }
+
+        result := perms
+    query: data.test.result
+    want_result:
+      admin:
+        set!: ["read", "write"]
+      viewer:
+        set!: ["read"]
+
+  - note: multi_bracket_three_key_nesting
+    data: {}
+    modules:
+      - |
+        package test
+
+        config[env][svc][key] := val if {
+          entries := [
+            {"env": "prod", "svc": "web", "key": "port", "val": 443},
+            {"env": "prod", "svc": "api", "key": "port", "val": 8080},
+            {"env": "dev", "svc": "web", "key": "port", "val": 8000}
+          ]
+          some entry in entries
+          env := entry.env
+          svc := entry.svc
+          key := entry.key
+          val := entry.val
+        }
+
+        result := config
+    query: data.test.result
+    want_result:
+      prod:
+        web:
+          port: 443
+        api:
+          port: 8080
+      dev:
+        web:
+          port: 8000
+
+  - note: multi_bracket_merge_across_definitions
+    data: {}
+    modules:
+      - |
+        package test
+
+        access[group][perm] := true if {
+          some group in ["admin", "ops"]
+          perm := "read"
+        }
+
+        access[group][perm] := true if {
+          group := "admin"
+          perm := "write"
+        }
+
+        result := access
+    query: data.test.result
+    want_result:
+      admin:
+        read: true
+        write: true
+      ops:
+        read: true
+
+  - note: multi_bracket_contains_accumulation
+    data: {}
+    modules:
+      - |
+        package test
+
+        tags[category] contains item if {
+          pairs := [
+            ["color", "red"],
+            ["color", "blue"],
+            ["size", "large"]
+          ]
+          some pair in pairs
+          category := pair[0]
+          item := pair[1]
+        }
+
+        result := tags
+    query: data.test.result
+    want_result:
+      color:
+        set!: ["blue", "red"]
+      size:
+        set!: ["large"]

--- a/tests/rvm/rego/cases/partial_object_multivalue.yaml
+++ b/tests/rvm/rego/cases/partial_object_multivalue.yaml
@@ -1,0 +1,150 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Partial Object Multi-Value Rules Test Suite
+# Tests `foo[key] contains value` patterns that produce objects with set values
+# Previously these were incorrectly compiled as flat partial sets.
+
+cases:
+  - note: simple_multivalue_partial_object
+    data: {}
+    modules:
+      - |
+        package test
+
+        servers := {"s1": ["p1", "p2"], "s2": ["p3"]}
+
+        ports[server] contains port if {
+          some server, port_list in servers
+          some port in port_list
+        }
+    query: data.test.ports
+    want_result:
+      s1:
+        set!: ["p1", "p2"]
+      s2:
+        set!: ["p3"]
+
+  - note: multivalue_partial_object_with_input
+    data: {}
+    input:
+      hosts:
+        web1:
+          ports: [80, 443]
+        web2:
+          ports: [80, 8080]
+        db1:
+          ports: [5432]
+    modules:
+      - |
+        package test
+
+        host_ports[host] contains port if {
+          some host, info in input.hosts
+          some port in info.ports
+        }
+    query: data.test.host_ports
+    want_result:
+      web1:
+        set!: [80, 443]
+      web2:
+        set!: [80, 8080]
+      db1:
+        set!: [5432]
+
+  - note: multivalue_partial_object_single_element_sets
+    data: {}
+    modules:
+      - |
+        package test
+
+        groups := {"a": ["x"], "b": ["y"]}
+
+        items[g] contains v if {
+          some g, vals in groups
+          some v in vals
+        }
+    query: data.test.items
+    want_result:
+      a:
+        set!: ["x"]
+      b:
+        set!: ["y"]
+
+  - note: multivalue_partial_object_with_filter
+    data: {}
+    modules:
+      - |
+        package test
+
+        data_map := {
+          "alice": [1, 2, 3, 4, 5],
+          "bob": [2, 4, 6, 8, 10]
+        }
+
+        even_values[name] contains v if {
+          some name, values in data_map
+          some v in values
+          v % 2 == 0
+        }
+    query: data.test.even_values
+    want_result:
+      alice:
+        set!: [2, 4]
+      bob:
+        set!: [2, 4, 6, 8, 10]
+
+  - note: multivalue_partial_object_overlapping_values
+    data: {}
+    modules:
+      - |
+        package test
+
+        tags[category] contains tag if {
+          some category, tag in {
+            "colors": "red",
+            "colors": "blue",
+          }
+        }
+
+        tags[category] contains tag if {
+          some category, tag in {
+            "sizes": "small",
+            "sizes": "large",
+          }
+        }
+    query: data.test.tags
+    want_result:
+      colors:
+        set!: ["blue"]
+      sizes:
+        set!: ["large"]
+
+  - note: regular_partial_object_still_works
+    data: {}
+    modules:
+      - |
+        package test
+
+        info[name] := count if {
+          counts := {"a": 1, "b": 2, "c": 3}
+          some name, count in counts
+        }
+    query: data.test.info
+    want_result:
+      a: 1
+      b: 2
+      c: 3
+
+  - note: simple_partial_set_still_works
+    data: {}
+    modules:
+      - |
+        package test
+
+        items contains x if {
+          some x in [1, 2, 3]
+        }
+    query: data.test.items
+    want_result:
+      set!: [1, 2, 3]


### PR DESCRIPTION
Partial object rules like foo[a] contains v were being compiled and executed like flat sets in the RVM path, which dropped the object key and caused real policies to return empty or incorrect results.

This changes the compiler and VM to treat bracketed and dotted rule heads as partial-object writes, adds an ObjectDeepSet instruction for nested object updates and multi-value leaves, and wires that through the listing, parser, and static provenance handling.

It also adds regression coverage for multi-value partial objects so cases like foo[a] contains v keep working in the RVM engine.