### PR TITLE
build: fix rand advisory and harden python CI caching

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -18,7 +18,7 @@ jobs:
         host:
           - name: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - name: windows-latest
+          - name: windows-2022
             target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.host.name }}
     steps:
@@ -32,7 +32,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: ${{ runner.os }}-regorus
+          shared-key: ${{ runner.os }}-${{ matrix.host.name }}-regorus
       - name: Fetch dependencies
         run: cargo fetch --locked
 
@@ -60,9 +60,12 @@ jobs:
     needs: build
     strategy:
       matrix:
-        host: [ubuntu-24.04, ubuntu-22.04, windows-latest]
+        host:
+          - name: ubuntu-24.04
+          - name: ubuntu-22.04
+          - name: windows-2022
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-    runs-on: ${{ matrix.host }}
+    runs-on: ${{ matrix.host.name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,7 +75,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: ${{ runner.os }}-regorus
+          shared-key: ${{ runner.os }}-${{ matrix.host.name }}-regorus
       - name: Fetch dependencies
         run: cargo fetch --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",


### PR DESCRIPTION
## Summary
This change does two small things that are related by one CI symptom: the Python workflow was intermittently picking up incompatible cached build artifacts, and cargo-deny started failing on a new rand advisory.

First, it updates Cargo.lock to use rand 0.10.1 so the all-features cargo-deny run no longer trips over RUSTSEC-2026-0097.

Second, it tightens the Python workflow cache boundaries. The rust-cache key is now scoped to the specific runner image, the test matrix uses the same host object shape as the build matrix, and the Windows jobs are pinned to windows-2022 instead of windows-latest. That keeps Ubuntu 22.04, Ubuntu 24.04, and Windows caches from silently sharing host binaries across image changes.

## Why this helps
The intermittent Python CI failure was happening in a restored host build-script binary, not in the wheel output itself. If a cache created on a newer runner image is restored on an older one, the host executable can fail to start because the system C library no longer matches. Separating the caches by pinned runner image removes that class of failure.

## Validation
- cargo deny --log-level warn --manifest-path Cargo.toml --all-features check advisories bans
- repository pre-commit hook run during commit, including build, fmt, and clippy