### PR TITLE
feat(xtask): add missing flags for CI-friendly Python and FFI builds

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -37,7 +37,7 @@ jobs:
         run: cargo fetch --locked
 
       - name: Fetch Python crate dependencies
-        run: cargo fetch --locked --manifest-path bindings/python/Cargo.toml --target ${{ matrix.host.target }}
+        run: cargo fetch --locked --manifest-path bindings/python/Cargo.toml
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/xtask/src/tasks/bindings/all.rs
+++ b/xtask/src/tasks/bindings/all.rs
@@ -27,7 +27,7 @@ impl BuildAllBindingsCommand {
         let release = self.release;
 
         let targets = ffi::resolve_targets(Vec::new())?;
-        ffi::build_targets(&workspace, &targets, release)?;
+        ffi::build_targets(&workspace, &targets, release, false)?;
 
         let ffi_dir = workspace.join("bindings/ffi/target");
         let nuget_result = build_nuget_package(&BuildNugetConfig {
@@ -53,7 +53,9 @@ impl BuildAllBindingsCommand {
             release,
             target: None,
             target_dir: None,
+            out: None,
             frozen: false,
+            strip: false,
         }
         .run()?;
         BuildWasmCommand {
@@ -114,6 +116,7 @@ impl TestAllBindingsCommand {
             release: self.release,
             target: None,
             python: self.python.clone(),
+            frozen: false,
         }
         .run()?;
 

--- a/xtask/src/tasks/bindings/csharp.rs
+++ b/xtask/src/tasks/bindings/csharp.rs
@@ -77,7 +77,7 @@ pub fn build_nuget_package(config: &BuildNugetConfig) -> Result<BuildNugetResult
         dir.clone()
     } else {
         let targets = ffi::resolve_targets(config.targets.clone())?;
-        ffi::build_targets(&workspace_root, &targets, config.release)?;
+        ffi::build_targets(&workspace_root, &targets, config.release, false)?;
 
         workspace_root.join("bindings/ffi/target")
     };

--- a/xtask/src/tasks/bindings/ffi.rs
+++ b/xtask/src/tasks/bindings/ffi.rs
@@ -20,6 +20,10 @@ pub struct BuildFfiCommand {
     /// Build in release mode instead of debug.
     #[arg(long)]
     release: bool,
+
+    /// Pass --frozen to all cargo invocations.
+    #[arg(long)]
+    frozen: bool,
 }
 
 impl BuildFfiCommand {
@@ -28,7 +32,7 @@ impl BuildFfiCommand {
         let targets = resolve_targets(self.targets.clone())?;
         let profile = profile_dir(self.release);
 
-        build_targets(&workspace_root, &targets, self.release)?;
+        build_targets(&workspace_root, &targets, self.release, self.frozen)?;
 
         let base = workspace_root.join("bindings/ffi/target");
         if targets.len() == 1 {
@@ -62,9 +66,9 @@ pub fn resolve_targets(mut targets: Vec<String>) -> Result<Vec<String>> {
 }
 
 /// Compiles the FFI crate for the supplied target triples.
-pub fn build_targets(root: &Path, targets: &[String], release: bool) -> Result<()> {
+pub fn build_targets(root: &Path, targets: &[String], release: bool, frozen: bool) -> Result<()> {
     for target in targets {
-        cargo_build(root, target, release)?;
+        cargo_build(root, target, release, frozen)?;
     }
     Ok(())
 }
@@ -101,7 +105,7 @@ pub fn detect_host_triple() -> Result<String> {
     Err(anyhow!("failed to detect host target triple"))
 }
 
-fn cargo_build(root: &Path, target: &str, release: bool) -> Result<()> {
+fn cargo_build(root: &Path, target: &str, release: bool, frozen: bool) -> Result<()> {
     let dir = root.join("bindings/ffi");
     let mut args = vec![
         OsString::from("build"),
@@ -111,6 +115,9 @@ fn cargo_build(root: &Path, target: &str, release: bool) -> Result<()> {
     ];
     if release {
         args.push(OsString::from("--release"));
+    }
+    if frozen {
+        args.push(OsString::from("--frozen"));
     }
 
     let title = format!("cargo build (ffi:{target})");

--- a/xtask/src/tasks/bindings/python.rs
+++ b/xtask/src/tasks/bindings/python.rs
@@ -24,12 +24,20 @@ pub struct BuildPythonCommand {
     pub target: Option<String>,
 
     /// Override the directory that receives built wheel files.
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", conflicts_with = "out")]
     pub target_dir: Option<PathBuf>,
 
-    /// Propagate --frozen to cargo invocations prior to packaging.
+    /// Place built wheel files directly into this directory.
+    #[arg(long, value_name = "PATH", conflicts_with = "target_dir")]
+    pub out: Option<PathBuf>,
+
+    /// Propagate --frozen to cargo and maturin invocations.
     #[arg(long)]
     pub frozen: bool,
+
+    /// Strip debug symbols from the built wheel.
+    #[arg(long)]
+    pub strip: bool,
 }
 
 impl BuildPythonCommand {
@@ -65,8 +73,19 @@ impl BuildPythonCommand {
             maturin.arg("--target");
             maturin.arg(target);
         }
-        maturin.arg("--target-dir");
-        maturin.arg(&wheel_dir);
+        if self.frozen {
+            maturin.arg("--frozen");
+        }
+        if self.strip {
+            maturin.arg("--strip");
+        }
+        if let Some(out) = &self.out {
+            maturin.arg("--out");
+            maturin.arg(out);
+        } else {
+            maturin.arg("--target-dir");
+            maturin.arg(&wheel_dir);
+        }
         run_command(maturin, "maturin build (bindings/python)")
     }
 }
@@ -84,6 +103,10 @@ pub struct TestPythonCommand {
     /// Python interpreter used to run the sample and tests.
     #[arg(long, value_name = "EXE", default_value = "python3")]
     pub python: String,
+
+    /// Pass --frozen to all cargo and maturin invocations.
+    #[arg(long)]
+    pub frozen: bool,
 }
 
 impl TestPythonCommand {
@@ -95,7 +118,13 @@ impl TestPythonCommand {
 
         install_testing_dependencies(&venv_python)?;
 
-        install_local_package(&python_dir, self.release, self.target.as_deref(), &venv_dir)?;
+        install_local_package(
+            &python_dir,
+            self.release,
+            self.target.as_deref(),
+            self.frozen,
+            &venv_dir,
+        )?;
 
         let mut sample = Command::new(&venv_python);
         sample.current_dir(&python_dir);
@@ -133,6 +162,7 @@ fn install_local_package(
     python_dir: &Path,
     release: bool,
     target: Option<&str>,
+    frozen: bool,
     venv_dir: &Path,
 ) -> Result<()> {
     let mut maturin = Command::new("maturin");
@@ -144,6 +174,9 @@ fn install_local_package(
     if let Some(target) = target {
         maturin.arg("--target");
         maturin.arg(target);
+    }
+    if frozen {
+        maturin.arg("--frozen");
     }
     maturin.env("VIRTUAL_ENV", venv_dir);
     let bin_dir = venv_bin_dir(venv_dir);


### PR DESCRIPTION
Pass --frozen through to maturin so that build-python works in network-isolated containers (e.g. OneBranch CFS).  Previously the flag only reached the preliminary cargo build but not maturin itself, causing cargo metadata to fail when it tried to fetch the index.

Also add --out and --strip to build-python so the pipeline can place wheels in a flat output directory and strip debug symbols without calling maturin directly.

Add --frozen to test-python (propagated to maturin develop) and build-ffi (propagated to cargo build) for parity with test-ffi which already supported it.