### PR TITLE
fix: feature-matrix CI failures for minimal and rvm test combos

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -30,7 +30,7 @@ jobs:
           # Common library usage pattern (issue #595): consumer enables
           # std + arc + rvm and relies on indexmap/std propagation.
           - name: library (std + arc + rvm)
-            features: std,arc,rvm
+            features: std,arc,rvm,test-utils
 
           # New default after removing mimalloc from full-opa.
           # Ensures all builtins compile without the allocator.
@@ -45,12 +45,12 @@ jobs:
           # Selective builtins without full-opa: validates that popular
           # features can be cherry-picked independently.
           - name: cherry-picked builtins
-            features: std,arc,rvm,regex,time,semver,cache
+            features: std,arc,rvm,regex,time,semver,cache,test-utils
 
           # Observability features only: coverage + cache without the
           # heavier builtins (regex, time, etc.).
           - name: observability
-            features: std,arc,rvm,coverage,cache
+            features: std,arc,rvm,coverage,cache,test-utils
 
           # Azure Policy adds jsonschema + dashmap; test it compiles
           # and runs on top of full-opa.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ time = ["dep:chrono", "dep:chrono-tz"]
 uuid = ["dep:uuid"]
 urlquery = ["dep:url"]
 yaml = ["serde_yaml"]
+test-utils = []
 full-opa = [
     "base64",
     "base64url",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ mod scheduler;
 mod schema;
 #[cfg(feature = "azure_policy")]
 pub mod target;
-#[cfg(any(test, all(feature = "yaml", feature = "std")))]
+#[cfg(any(test, feature = "test-utils", all(feature = "yaml", feature = "std")))]
 pub mod test_utils;
 pub mod utils;
 mod value;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -93,9 +93,9 @@ pub fn process_value(v: &Value) -> Result<Value> {
 /// Diff-friendly equality helper used by multiple YAML suites.
 pub fn match_values(computed: &Value, expected: &Value) -> Result<()> {
     if computed != expected {
-        let expected_yaml = serde_yaml::to_string(expected)?;
-        let computed_yaml = serde_yaml::to_string(computed)?;
-        bail!("expected:\n{}computed:\n{}", expected_yaml, computed_yaml);
+        let expected_str = serde_json::to_string_pretty(expected)?;
+        let computed_str = serde_json::to_string_pretty(computed)?;
+        bail!("expected:\n{expected_str}\ncomputed:\n{computed_str}");
     }
     Ok(())
 }

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -611,6 +611,61 @@ fn yaml_test_impl(file: &str) -> Result<()> {
             }
         }
     }
+    #[cfg(not(feature = "time"))]
+    {
+        let skip = [
+            "add_date.yaml",
+            "date.yaml",
+            "clock.yaml",
+            "diff.yaml",
+            "format.yaml",
+            "now_ns.yaml",
+            "parse_duration_ns.yaml",
+            "parse_ns.yaml",
+            "parse_rfc3339_ns.yaml",
+            "weekday.yaml",
+        ];
+        for s in skip {
+            if file.contains(s) {
+                std::println!("skipped {file} without time feature.");
+                return Ok(());
+            }
+        }
+    }
+    #[cfg(not(feature = "semver"))]
+    {
+        let skip = ["semver/compare.yaml", "semver/is_valid.yaml"];
+        for s in skip {
+            if file.contains(s) {
+                std::println!("skipped {file} without semver feature.");
+                return Ok(());
+            }
+        }
+    }
+    #[cfg(not(feature = "glob"))]
+    {
+        if file.contains("globmatch.yaml") {
+            std::println!("skipped {file} without glob feature.");
+            return Ok(());
+        }
+    }
+    #[cfg(not(feature = "uuid"))]
+    {
+        let skip = ["uuid/generate.yaml", "uuid/parse.yaml"];
+        for s in skip {
+            if file.contains(s) {
+                std::println!("skipped {file} without uuid feature.");
+                return Ok(());
+            }
+        }
+    }
+    #[cfg(not(feature = "regex"))]
+    {
+        if file.contains("regex/") {
+            std::println!("skipped {file} without regex feature.");
+            return Ok(());
+        }
+    }
     #[cfg(not(feature = "graph"))]
     {
         // Skip tests that depend on graph builtin that need graph feature.


### PR DESCRIPTION
Fixes the failures in the `tests/feature-matrix` weekly CI run ([run #25244035824](https://github.com/microsoft/regorus/actions/runs/25244035824)).

## Root Causes

**1. Missing per-feature skip logic in interpreter tests ("minimal" job)**

Tests for `time`, `semver`, `glob`, `uuid`, and `regex` builtins ran even when those features weren't enabled. The existing skip logic only handled the `no_std` case.

**2. `test_utils` module unavailable to integration tests ("library", "observability", "cherry-picked builtins" jobs)**

`test_utils` was gated behind `cfg(any(test, all(feature = "yaml", feature = "std")))`. Since `cfg(test)` doesn't apply to the library when compiled for integration tests, it required the `yaml` product feature. Integration tests with `rvm` but without `yaml` couldn't access the module.

## Fix

- Add per-feature `#[cfg(not(feature = "..."))]` skip blocks for time, semver, glob, uuid, and regex builtin tests.
- Introduce a zero-dep `test-utils` feature that exposes `test_utils` without requiring `yaml`.
- Replace `serde_yaml` usage in `test_utils::match_values` with `serde_json` (always available) so the module has no optional-dep requirements.
- Update the feature-matrix workflow to add `test-utils` to rvm-based jobs.