### PR TITLE
chore: bump version to 0.10.0 across all bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-05
+
 ### Added
+
+- *(copilot)* add multi-agent code review skills (#707)
+- *(azure_policy)* test runner, compiler fixes, and example program (#700)
+- *(azure-policy)* implement effect compilation and metadata population (#691)
+- *(azure-policy)* implement count/count.where compilation (#688)
+- *(azure-policy)* implement condition, expression, field, and template dispatch compilation (#686)
+- *(azure-policy)* add compiler skeleton with core types and stubs (#674)
+- *(rvm)* implement Azure Policy condition evaluation (#661)
+- *(rvm)* new instructions and loop semantics for Azure Policy support (#659)
+- *(azure-policy)* add policy rule and policy definition parsers (#660)
+- add Azure Policy constraint parser (#658)
+- *(rvm)* extend program metadata and bump serialization to v6 (#654)
+- add Azure Policy core JSON parser and expression parser (#655)
+- add Azure Policy AST types (#653)
+- *(azure-policy)* add alias normalization and denormalization (#635)
+- add Azure Policy builtins with YAML test suite (#630)
+- make policy length limits configurable per engine (#624)
+- implement add_extension in Python binding (#596)
+- *(rbac)* [**breaking**] add Azure RBAC engine, FFI API, and cross-language tests (#577)
 - Azure RBAC condition interpreter with builtin evaluation coverage and YAML test suite, including quantifier (ForAnyOfAnyValues/ForAllOfAllValues), datetime (DateTimeEquals), IP (IpInRange), GUID (GuidEquals), list (ListContains), and string (StringEquals) semantics.
 - FFI surface for Azure RBAC condition evaluation (see bindings changelog for language-specific wrappers).
+
+### Fixed
+
+- harden regex builtins with compiled-size limit (#705)
+- *(ci)* skip mimalloc FFI and disable isolation for Miri (#621)
+
+### Other
+
+- bump version to 0.10.0 across all bindings
+- *(deps)* update all Rust dependencies and fix lockfile refresh workflow (#704)
+- *(deps)* bump com.google.code.gson:gson (#702)
+- *(deps)* bump the github-actions group across 1 directory with 5 updates (#690)
+- *(deps)* bump the per-dependency group across 1 directory with 5 updates (#703)
+- Make `git rev-parse` in `build.rs` optional with graceful fallback (#701)
+- *(azure_policy)* add foundation test cases (#698)
+- *(azure_policy)* add end-to-end policy test cases (#699)
+- fix rand advisory and harden python CI caching (#675)
+- azure-policy parser: allow overriding the column-width limit (#673)
+- *(deps)* bump the rust-dependencies group across 5 directories with 6 updates (#671)
+- *(deps)* bump ruby/setup-ruby in the github-actions group (#670)
+- *(csharp)* prepare NuGet package for nuget.org publishing (#668)
+- Fix RVM evaluation of default-only rules (#664)
+- *(deps)* bump minitest in /bindings/ruby in the per-dependency group (#656)
+- *(deps)* bump the rust-dependencies group across 2 directories with 3 updates (#657)
+- consolidate RVM instruction variants and clean up VM internals (#651)
+- *(deps)* bump wasm-bindgen-test (#650)
+- *(deps)* bump rb_sys in /bindings/ruby in the per-dependency group (#649)
+- *(deps)* bump the rust-dependencies group across 3 directories with 4 updates (#647)
+- *(deps)* bump the github-actions group across 1 directory with 3 updates (#646)
+- *(dependabot)* restore cargo dependency grouping (#645)
+- Fix build break (#634)
+- *(deps)* bump the rust-dependencies group across 5 directories with 16 updates (#633)
+- *(dependabot)* fix cargo config quoting (#632)
+- *(dependabot)* fix cargo workspace updates and refresh lockfiles (#629)
+- *(deps)* bump rubocop in /bindings/ruby in the per-dependency group (#622)
+- *(deps)* bump the github-actions group with 11 updates (#628)
+- Consolidate Dependabot, fix #595 (mimalloc + indexmap), add feature-matrix CI (#627)
+- RVM compiler & runtime optimizations: caching, instruction fusion, constant hoisting, and correctness fixes (#626)
+- Rvm optimizations (#620)
+- *(deps)* bump rubocop in /bindings/ruby in the per-dependency group (#618)
+- *(ci)* add miri workflow (#581)
+- *(ci)* add cargo audit and deny (#580)
+- switch binary serialization to postcard (#582)
+- *(deps-dev)* bump org.apache.maven.plugins:maven-surefire-plugin (#605)
+- *(deps)* bump bytes (#569)
+- *(deps)* bump the per-dependency group with 2 updates (#603)
+- *(deps)* bump the per-dependency group across 1 directory with 3 updates (#607)
+- boolean mapping (#612)
+- Bump the per-dependency group with 1 update (#587)
+- *(deps)* bump the per-dependency group (#585)
+- *(deps)* bump the per-dependency group (#586)
+- *(deps-dev)* bump the per-dependency group (#583)
+- *(deps)* bump the per-dependency group with 12 updates (#593)
+- *(dependabot)* expand coverage and pin workflows (#579)
 
 ### Changed
 - [**breaking**] Switch RVM binary serialization to postcard, bump the format to v4, and mark v1-3 loads as partial (recompile required).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [package]
 name = "regorus"
 description = "A fast, lightweight Rego (OPA policy language) interpreter"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 repository = "https://github.com/microsoft/regorus"

--- a/bindings/csharp/Benchmarks/Benchmarks.csproj
+++ b/bindings/csharp/Benchmarks/Benchmarks.csproj
@@ -6,8 +6,6 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <!-- If the environment variable is set (such as in a Github Action run), append the suffix to the version number -->
-    <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
     <UsePackageReference Condition="'$(UsePackageReference)' == ''">false</UsePackageReference>
   </PropertyGroup>
 

--- a/bindings/csharp/Directory.Packages.props
+++ b/bindings/csharp/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <RegorusPackageVersion>0.9.1</RegorusPackageVersion>
+    <RegorusPackageVersion>0.10.0</RegorusPackageVersion>
     <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
   </PropertyGroup>
 

--- a/bindings/csharp/Regorus.Tests/Regorus.Tests.csproj
+++ b/bindings/csharp/Regorus.Tests/Regorus.Tests.csproj
@@ -10,8 +10,6 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <!-- If the environment variable is set (such as in a Github Action run), append the suffix to the version number -->
-    <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
     <UsePackageReference Condition="'$(UsePackageReference)' == ''">false</UsePackageReference>
   </PropertyGroup>
 

--- a/bindings/csharp/Regorus/Regorus.csproj
+++ b/bindings/csharp/Regorus/Regorus.csproj
@@ -9,7 +9,7 @@
        <LangVersion>10.0</LangVersion>
 
         <!-- See https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-pack -->
-        <VersionPrefix>0.9.1</VersionPrefix>
+        <VersionPrefix>$(RegorusPackageVersion)</VersionPrefix>
         <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT AND Apache-2.0 AND BSD-3-Clause</PackageLicenseExpression>

--- a/bindings/csharp/TargetExampleApp/TargetExampleApp.csproj
+++ b/bindings/csharp/TargetExampleApp/TargetExampleApp.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- If the environment variable is set (such as in a Github Action run), append the suffix to the version number -->
-    <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
     <UsePackageReference Condition="'$(UsePackageReference)' == ''">false</UsePackageReference>
   </PropertyGroup>
 

--- a/bindings/csharp/TestApp/TestApp.csproj
+++ b/bindings/csharp/TestApp/TestApp.csproj
@@ -11,8 +11,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Allow CI to append the version suffix for locally built packages -->
-    <RegorusPackageVersionSuffix Condition="'$(VersionSuffix)' != ''">-$(VersionSuffix)</RegorusPackageVersionSuffix>
     <UsePackageReference Condition="'$(UsePackageReference)' == ''">false</UsePackageReference>
   </PropertyGroup>
 

--- a/bindings/ffi/Cargo.lock
+++ b/bindings/ffi/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "regorus-ffi"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "cbindgen",

--- a/bindings/ffi/Cargo.toml
+++ b/bindings/ffi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regorus-ffi"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 

--- a/bindings/java/Cargo.lock
+++ b/bindings/java/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "regorus-java"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "jni",

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regorus-java"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/java"
 description = "Java bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.microsoft.regorus</groupId>
   <artifactId>regorus-java</artifactId>
-  <version>0.9.1</version>
+  <version>0.10.0</version>
 
   <name>Regorus Java</name>
   <description>Java bindings for Regorus - a fast, lightweight Rego interpreter written in Rust</description>

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -1001,7 +1001,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "regoruspy"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "ordered-float",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regoruspy"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/python"
 description = "Python bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"

--- a/bindings/ruby/Cargo.lock
+++ b/bindings/ruby/Cargo.lock
@@ -1032,7 +1032,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "regorusrb"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "magnus",
  "regorus",

--- a/bindings/ruby/ext/regorusrb/Cargo.toml
+++ b/bindings/ruby/ext/regorusrb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regorusrb"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 description = "Ruby bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"

--- a/bindings/ruby/lib/regorus/version.rb
+++ b/bindings/ruby/lib/regorus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Regorus
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end

--- a/bindings/wasm/Cargo.lock
+++ b/bindings/wasm/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "regorusjs"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "regorusjs"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/microsoft/regorus/bindings/wasm"
 description = "WASM bindings for Regorus - a fast, lightweight Rego interpreter written in Rust"

--- a/xtask/src/tasks/bindings/version.rs
+++ b/xtask/src/tasks/bindings/version.rs
@@ -124,7 +124,7 @@ struct Binding {
     manifest: Option<&'static str>,
     ruby_version: Option<&'static str>,
     pom_xml: Option<&'static str>,
-    csharp_project: Option<&'static str>,
+    csharp_version_file: Option<&'static str>,
     csharp_dependents: &'static [&'static str],
 }
 
@@ -139,7 +139,7 @@ const BINDINGS: &[Binding] = &[
         manifest: Some("bindings/ffi/Cargo.toml"),
         ruby_version: None,
         pom_xml: None,
-        csharp_project: None,
+        csharp_version_file: None,
         csharp_dependents: EMPTY,
     },
     Binding {
@@ -148,7 +148,7 @@ const BINDINGS: &[Binding] = &[
         manifest: Some("bindings/java/Cargo.toml"),
         ruby_version: None,
         pom_xml: Some("bindings/java/pom.xml"),
-        csharp_project: None,
+        csharp_version_file: None,
         csharp_dependents: EMPTY,
     },
     Binding {
@@ -157,7 +157,7 @@ const BINDINGS: &[Binding] = &[
         manifest: Some("bindings/python/Cargo.toml"),
         ruby_version: None,
         pom_xml: None,
-        csharp_project: None,
+        csharp_version_file: None,
         csharp_dependents: EMPTY,
     },
     Binding {
@@ -166,7 +166,7 @@ const BINDINGS: &[Binding] = &[
         manifest: Some("bindings/wasm/Cargo.toml"),
         ruby_version: None,
         pom_xml: None,
-        csharp_project: None,
+        csharp_version_file: None,
         csharp_dependents: EMPTY,
     },
     Binding {
@@ -175,7 +175,7 @@ const BINDINGS: &[Binding] = &[
         manifest: Some("bindings/ruby/ext/regorusrb/Cargo.toml"),
         ruby_version: Some("bindings/ruby/lib/regorus/version.rb"),
         pom_xml: None,
-        csharp_project: None,
+        csharp_version_file: None,
         csharp_dependents: EMPTY,
     },
     Binding {
@@ -184,14 +184,8 @@ const BINDINGS: &[Binding] = &[
         manifest: None,
         ruby_version: None,
         pom_xml: None,
-        csharp_project: Some("bindings/csharp/Regorus/Regorus.csproj"),
-        csharp_dependents: &[
-            "bindings/csharp/Directory.Packages.props",
-            "bindings/csharp/Regorus.Tests/Regorus.Tests.csproj",
-            "bindings/csharp/Benchmarks/Benchmarks.csproj",
-            "bindings/csharp/TargetExampleApp/TargetExampleApp.csproj",
-            "bindings/csharp/TestApp/TestApp.csproj",
-        ],
+        csharp_version_file: Some("bindings/csharp/Directory.Packages.props"),
+        csharp_dependents: EMPTY,
     },
 ];
 
@@ -335,7 +329,7 @@ fn read_binding_version(root: &Path, binding: &Binding) -> Result<Version> {
     if let Some(manifest) = binding.manifest {
         return read_manifest_version(&root.join(manifest));
     }
-    if let Some(project) = binding.csharp_project {
+    if let Some(project) = binding.csharp_version_file {
         return read_csharp_version(root.join(project));
     }
     bail!("binding '{}' missing version source", binding.name)
@@ -357,13 +351,18 @@ fn read_manifest_version(path: &Path) -> Result<Version> {
 fn read_csharp_version(path: PathBuf) -> Result<Version> {
     let contents =
         fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
-    let re = Regex::new(r#"(?s)<VersionPrefix>(?P<value>[^<]+)</VersionPrefix>"#)?;
+    let re = Regex::new(r#"(?s)<RegorusPackageVersion>(?P<value>[^<]+)</RegorusPackageVersion>"#)?;
     let caps = re
         .captures(&contents)
-        .ok_or_else(|| anyhow!("{} missing <VersionPrefix> entry", path.display()))?;
-    let version = caps.name("value").unwrap().as_str();
-    Version::parse(version)
-        .with_context(|| format!("invalid VersionPrefix '{}' in {}", version, path.display()))
+        .ok_or_else(|| anyhow!("{} missing <RegorusPackageVersion> entry", path.display()))?;
+    let version = caps.name("value").unwrap().as_str().trim();
+    Version::parse(version).with_context(|| {
+        format!(
+            "invalid RegorusPackageVersion '{}' in {}",
+            version,
+            path.display()
+        )
+    })
 }
 
 /// Calculates the version to write, bumping the minor release when the binding
@@ -420,8 +419,8 @@ fn apply_binding_version(
         }
     }
 
-    if let Some(project) = binding.csharp_project {
-        touched.extend(update_csharp_projects(
+    if let Some(project) = binding.csharp_version_file {
+        touched.extend(update_csharp_version_files(
             root,
             project,
             binding.csharp_dependents,
@@ -502,59 +501,54 @@ fn update_java_pom(root: &Path, pom_path: &str, version: &str, check: bool) -> R
 }
 
 /// Updates the NuGet packaging project and any sample/test consumers.
-fn update_csharp_projects(
+fn update_csharp_version_files(
     root: &Path,
-    package_project: &str,
+    version_file: &str,
     dependent_projects: &[&str],
     version: &str,
     check: bool,
 ) -> Result<Vec<String>> {
     let mut touched = Vec::new();
-    let version_prefix = Regex::new(
-        r#"(?s)(?P<prefix><VersionPrefix>)(?P<value>[^<]+)(?P<suffix></VersionPrefix>)"#,
-    )?;
-    let pkg_ref = Regex::new(
-        r#"(?i)(?P<prefix><Package(?:Reference|Version)[^>]*Include="microsoft\.regorus"[^>]*Version=")(?P<value>\d+\.\d+\.\d+)(?P<suffix>[^\"]*")"#,
+    let version_prop = Regex::new(
+        r#"(?s)(?P<prefix><RegorusPackageVersion>)(?P<value>[^<]+)(?P<suffix></RegorusPackageVersion>)"#,
     )?;
 
-    let package_path = root.join(package_project);
+    let package_path = root.join(version_file);
+    if !version_prop.is_match(
+        &fs::read_to_string(&package_path)
+            .with_context(|| format!("failed to read {}", package_path.display()))?,
+    ) {
+        anyhow::bail!(
+            "{} missing <RegorusPackageVersion> entry",
+            package_path.display()
+        );
+    }
     if edit_file(&package_path, check, |contents| {
         let mut changed = false;
-        let mut new_contents = contents.to_owned();
+        let new_contents = version_prop
+            .replace(contents, |caps: &regex::Captures| {
+                let current = caps.name("value").unwrap().as_str().trim();
+                if current == version {
+                    caps[0].to_string()
+                } else {
+                    changed = true;
+                    format!("{}{}{}", &caps["prefix"], version, &caps["suffix"])
+                }
+            })
+            .into_owned();
 
-        if version_prefix.is_match(&new_contents) {
-            new_contents = version_prefix
-                .replace(&new_contents, |caps: &regex::Captures| {
-                    let current = caps.name("value").unwrap().as_str();
-                    if current == version {
-                        caps[0].to_string()
-                    } else {
-                        changed = true;
-                        format!("{}{}{}", &caps["prefix"], version, &caps["suffix"])
-                    }
-                })
-                .into_owned();
-        }
-
-        let replaced = pkg_ref.replace_all(&new_contents, |caps: &regex::Captures| {
-            let current = caps.name("value").unwrap().as_str();
-            if current == version {
-                caps[0].to_string()
-            } else {
-                changed = true;
-                format!("{}{}{}", &caps["prefix"], version, &caps["suffix"])
-            }
-        });
-        let final_contents = replaced.into_owned();
-
-        if changed && final_contents != *contents {
-            Ok(Some(final_contents))
+        if changed && new_contents != *contents {
+            Ok(Some(new_contents))
         } else {
             Ok(None)
         }
     })? {
-        touched.push(package_project.to_string());
+        touched.push(version_file.to_string());
     }
+
+    let pkg_ref = Regex::new(
+        r#"(?i)(?P<prefix><Package(?:Reference|Version)[^>]*Include="microsoft\.regorus"[^>]*Version=")(?P<value>\d+\.\d+\.\d+)(?P<suffix>[^\"]*")"#,
+    )?;
 
     for rel_path in dependent_projects {
         let path = root.join(rel_path);


### PR DESCRIPTION
Update regorus core crate and all language bindings (ffi, java, python, wasm, ruby, csharp) to version 0.10.0.

- Centralize C# package version via Directory.Packages.props
- Remove redundant version suffix properties from C# project files
- Regenerate all binding Cargo.lock files including Ruby
- Fix xtask to read/write RegorusPackageVersion from Directory.Packages.props
  instead of parsing VersionPrefix from the csproj (which now uses an MSBuild
  property indirection)

Supersedes #677.