### PR TITLE
tests/opa: normalize path separators in folder filter on Windows

### DIFF
--- a/tests/opa.rs
+++ b/tests/opa.rs
@@ -380,7 +380,11 @@ fn run_opa_tests(opa_tests_dir: String, folders: &[String]) -> Result<()> {
         }
         let path = Path::new(&path_str);
         let path_dir = path.strip_prefix(tests_path)?.parent().unwrap();
-        let path_dir_str = path_dir.to_string_lossy().to_string();
+        // Normalize to forward slashes so the folder filter at the
+        // `folders.iter().any(|f| &path_dir_str == f)` check below matches
+        // CLI arguments like `v0/aggregates` on Windows, where
+        // `to_string_lossy` yields backslash separators by default.
+        let path_dir_str = path_dir.to_string_lossy().replace('\\', "/");
         let folder_name = folder_name_from_path(path_dir);
         let skip_rvm_for_folder = folder_name
             .as_deref()


### PR DESCRIPTION
## Summary

On Windows, `cargo xtask pre-push` fails immediately at the OPA testsuite stage with `Error: no matching tests found.`, even though the testsuite is present and every other check passes. The cause is a path-separator mismatch in the folder filter in `tests/opa.rs`.

## Root cause

`run_opa_tests` builds `path_dir_str` from `Path::to_string_lossy()`, which on Windows yields backslash separators (e.g. `v0\aggregates`). The folder filter then does an exact-string comparison against the CLI arguments:

```rust
let path_dir_str = path_dir.to_string_lossy().to_string();
// ...
let run_test = folders.is_empty()
    || folders.iter().any(|f| &path_dir_str == f);
```

CLI arguments — including the ones the `cargo xtask pre-push` hook passes — use forward slashes (`v0/aggregates`). On Windows the equality check never matches, no folders are selected, `npass == 0 && nfail == 0`, and the function bails. The neighboring `is_rego_v0_test` check already accounts for the separator difference (`starts_with("v0/") || path_dir.starts_with("v0\\")`), but the filter comparison was missed.

## Reproduction

On Windows, against `main` at `11940dd`:

```pwsh
cargo test --features opa-testutil,serde_json/arbitrary_precision,rego-extensions \
  --test opa -- v1/aggregates
```

Output:
```
OPA TESTSUITE STATUS
    FOLDER                                    PASS FAIL

Error: no matching tests found.
```
Exit code `1`. The same failure blocks `cargo xtask pre-push` for any change on this platform.

## Fix

Normalize `path_dir_str` to forward slashes at construction time:

```diff
-        let path_dir_str = path_dir.to_string_lossy().to_string();
+        // Normalize to forward slashes so the folder filter at the
+        // `folders.iter().any(|f| &path_dir_str == f)` check below matches
+        // CLI arguments like `v0/aggregates` on Windows, where
+        // `to_string_lossy` yields backslash separators by default.
+        let path_dir_str = path_dir.to_string_lossy().replace('\\', "/");
```

Single line of logic. No behavior change on Unix-like platforms (no backslashes to replace).

## Validation

After the fix, on the same Windows machine:

| Command | Before | After |
|---|---|---|
| `cargo test ... --test opa -- v1/aggregates` | exit 1, `no matching tests found` | exit 0, **72 / 0** |
| `cargo test ... --test opa -- <all 188 v0/* and v1/* folders>` *(the pre-push hook command)* | exit 1, `no matching tests found` | exit 0, **TOTAL: 2861 / 0** |
| `cargo xtask pre-commit` | passes | passes (unaffected) |

## Notes

- The duplicate platform branch at `path_dir.starts_with("v0\\")` becomes redundant after this change but is left intact to keep the diff minimal — happy to remove it in a follow-up if preferred.
- This is a test-only change; no library or RVM code is touched.
