### PR TITLE
Handle `i32::MIN` in `Number::two_pow` and `Number::ten_pow`

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -791,7 +791,8 @@ impl Number {
         if e >= 0 {
             Ok(ten_pow_positive(e as u32))
         } else {
-            let denom = ten_pow_positive((-e) as u32);
+            // Must cast to i64 before negating in case it's i32::MIN
+            let denom = ten_pow_positive((-(e as i64)) as u32);
             Number::from(1u64).divide(&denom)
         }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -781,7 +781,8 @@ impl Number {
         if e >= 0 {
             Ok(two_pow_positive(e as u32))
         } else {
-            let denom = two_pow_positive((-e) as u32);
+            // Must cast to i64 before negating in case it's i32::MIN
+            let denom = two_pow_positive((-(e as i64)) as u32);
             Number::from(1u64).divide(&denom)
         }
     }


### PR DESCRIPTION
When proving functions in `Number` correct with Verus, GPT-5.6 Sol discovered it couldn't prove `two_pow` because of a bug. When the `e` parameter is exactly `i32::MIN`, it's not correct to directly negate it, since this wouldn't fit in an `i32`. Its fix is to first cast it to an `i64`.

This PR fixes that, as well as the equivalent issue in `ten_pow`.
