### PR TITLE
Fix potential underflow in `bigint_to_scientific`

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -912,7 +912,7 @@ fn bigint_to_scientific(value: &BigInt) -> String {
         return format!("{}{}e0", sign, digits);
     }
 
-    let exponent = digits.len() as i32 - 1;
+    let exponent = digits.len() - 1;
     format!("{}{}.{}e{}", sign, &digits[0..1], &digits[1..], exponent)
 }
 


### PR DESCRIPTION
Now that Verus has some support for `format!`, I was able to start checking functions that use it, including `bigint_to_scientific`. This uncovered a potential panic in that function. If `usize` is 64 bits (as it is on many platforms), then `digits.len()` can be 2^31 or greater. If it's equal to 2^31, or congruent to 2^31 modulo 2^32, then casting to an `i32` will produce `i32::MIN`, and then subtracting 1 will panic due to underflow. This PR prevents that in a pretty straightforward way: It just doesn't bother casting to an `i32`.