### PR TITLE
fix(builtins): prevent panic in strings.count on empty needle

### DIFF
--- a/src/builtins/strings.rs
+++ b/src/builtins/strings.rs
@@ -542,15 +542,15 @@ fn strings_count(
     ensure_args_count(span, name, params, args, 2)?;
 
     let search = ensure_string(name, &params[0], &args[0])?;
-    let substring = ensure_string(name, &params[0], &args[1])?;
+    let substring = ensure_string(name, &params[1], &args[1])?;
 
-    Ok(Value::from(
-        search
-            .as_bytes()
-            .windows(substring.len())
-            .filter(|&w| w == substring.as_bytes())
-            .count(),
-    ))
+    if substring.is_empty() {
+        // An empty needle matches between every character (and at both ends),
+        // consistent with Go's strings.Count and OPA semantics.
+        return Ok(Value::from(search.chars().count().saturating_add(1)));
+    }
+
+    Ok(Value::from(search.matches(substring.as_ref()).count()))
 }
 
 fn startswith(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Result<Value> {

--- a/tests/interpreter/cases/builtins/strings/strings_count.yaml
+++ b/tests/interpreter/cases/builtins/strings/strings_count.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: basic match
+    data: {}
+    modules: []
+    query: 'x := strings.count("cheese", "e")'
+    want_result:
+      x: 3
+
+  - note: no match
+    data: {}
+    modules: []
+    query: 'x := strings.count("dummy", "x")'
+    want_result:
+      x: 0
+
+  - note: multiple separate matches
+    data: {}
+    modules: []
+    query: 'x := strings.count("hello hello hello world", "hello")'
+    want_result:
+      x: 3
+
+  - note: empty needle returns char_count+1
+    data: {}
+    modules: []
+    query: 'x := strings.count("abc", "")'
+    want_result:
+      x: 4
+
+  - note: empty needle on empty string
+    data: {}
+    modules: []
+    query: 'x := strings.count("", "")'
+    want_result:
+      x: 1
+
+  - note: empty needle on single char
+    data: {}
+    modules: []
+    query: 'x := strings.count("a", "")'
+    want_result:
+      x: 2
+
+  - note: non-overlapping matches only
+    data: {}
+    modules: []
+    query: 'x := strings.count("aaaa", "aa")'
+    want_result:
+      x: 2
+
+  - note: multibyte utf8 string with empty needle
+    data: {}
+    modules: []
+    query: 'x := strings.count("\u4e16\u754c", "")'
+    want_result:
+      x: 3


### PR DESCRIPTION
## Summary

`strings.count` panicked at runtime when called with an empty needle string because `.windows(0)` is not valid in Rust. This PR fixes three tightly coupled issues in `strings_count`:

### Bugs fixed

| # | Bug | Impact |
|---|-----|--------|
| 1 | Wrong param index (`params[0]` used for `substring` error span instead of `params[1]`) | Misleading error messages |
| 2 | **Panic**: `.windows(needle.len())` panics when needle is empty (`len == 0`) | Process crash |
| 3 | **Semantics**: byte-level `.windows()` counted overlapping matches; OPA uses non-overlapping semantics (Go `strings.Count`) | Wrong results, e.g. `strings.count("aaaa", "aa")` returned 3 instead of 2 |

### Fix

```rust
// Before (bugs):
let substring = ensure_string(name, &params[0], &args[1])?;  // wrong index
Ok(Value::from(
    search.as_bytes().windows(substring.len())  // panics on empty
        .filter(|&w| w == substring.as_bytes()).count()  // overlapping
))

// After:
let substring = ensure_string(name, &params[1], &args[1])?;
if substring.is_empty() {
    // Empty needle: matches between every character and at both ends
    // consistent with Go strings.Count and OPA semantics
    return Ok(Value::from(search.chars().count().saturating_add(1)));
}
Ok(Value::from(search.matches(substring.as_ref()).count()))
```

### Tests

A YAML regression test is added at `tests/interpreter/cases/builtins/strings/strings_count.yaml` covering:
- Basic match, no-match, multi-match
- **Empty needle on non-empty string** (was panic, now returns `char_count + 1`)
- **Empty needle on empty string** (returns 1)
- **Non-overlapping semantics** (`strings.count("aaaa", "aa") = 2`, not 3)
- Multi-byte UTF-8 string with empty needle

