### PR TITLE
fix(builtins): add d/w/y duration units to time.parse_duration_ns

### DIFF
--- a/src/builtins/azure_policy/template_functions_encoding.rs
+++ b/src/builtins/azure_policy/template_functions_encoding.rs
@@ -174,12 +174,12 @@ fn percent_encode(s: &str) -> String {
             // always returns Some for radix 16.
             result.push('%');
             result.push(
-                core::char::from_digit(u32::from(b >> 4), 16)
+                char::from_digit(u32::from(b >> 4), 16)
                     .unwrap_or('0')
                     .to_ascii_uppercase(),
             );
             result.push(
-                core::char::from_digit(u32::from(b & 0x0F), 16)
+                char::from_digit(u32::from(b & 0x0F), 16)
                     .unwrap_or('0')
                     .to_ascii_uppercase(),
             );

--- a/src/builtins/time/compat.rs
+++ b/src/builtins/time/compat.rs
@@ -53,6 +53,9 @@ const MILLISECOND: u64 = 1000 * MICROSECOND;
 const SECOND: u64 = 1000 * MILLISECOND;
 const MINUTE: u64 = 60 * SECOND;
 const HOUR: u64 = 60 * MINUTE;
+const DAY: u64 = 24 * HOUR;
+const WEEK: u64 = 7 * DAY;
+const YEAR: u64 = 365 * DAY;
 
 #[derive(Debug)]
 pub enum ParseDurationError {
@@ -155,6 +158,9 @@ pub fn parse_duration(mut s: &str) -> Result<Duration, ParseDurationError> {
             "s" => SECOND,
             "m" => MINUTE,
             "h" => HOUR,
+            "d" => DAY,
+            "w" => WEEK,
+            "y" => YEAR,
             unkonwn => return Err(ParseDurationError::UnknownUnit(unkonwn.to_string())),
         };
 

--- a/src/builtins/time/compat.rs
+++ b/src/builtins/time/compat.rs
@@ -161,7 +161,7 @@ pub fn parse_duration(mut s: &str) -> Result<Duration, ParseDurationError> {
             "d" => DAY,
             "w" => WEEK,
             "y" => YEAR,
-            unkonwn => return Err(ParseDurationError::UnknownUnit(unkonwn.to_string())),
+            unknown => return Err(ParseDurationError::UnknownUnit(unknown.to_string())),
         };
 
         s = &s[idx + 1..];

--- a/src/tests/interpreter/mod.rs
+++ b/src/tests/interpreter/mod.rs
@@ -598,6 +598,7 @@ fn yaml_test_impl(file: &str) -> Result<()> {
             "globmatch.yaml",
             "now_ns.yaml",
             "parse_duration_ns.yaml",
+            "duration_units.yaml",
             "parse_ns.yaml",
             "parse_rfc3339_ns.yaml",
             "weekday.yaml",

--- a/tests/interpreter/cases/builtins/time/duration_units.yaml
+++ b/tests/interpreter/cases/builtins/time/duration_units.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: days-weeks-years
+    data: {}
+    modules:
+      - |
+        package test
+        one_day   = time.parse_duration_ns("1d")
+        one_week  = time.parse_duration_ns("1w")
+        one_year  = time.parse_duration_ns("1y")
+    query: data.test
+    want_result:
+      one_day:  86400000000000
+      one_week: 604800000000000
+      one_year: 31536000000000000
+
+  - note: mixed-units
+    data: {}
+    modules:
+      - |
+        package test
+        x = time.parse_duration_ns("1d12h")
+    query: data.test.x
+    want_result: 129600000000000


### PR DESCRIPTION
OPA supports `d` (day), `w` (week), and `y` (365-day year) as duration unit suffixes; Regorus previously returned an UnknownUnit error for those tokens.

### Changes

- Add constants `DAY = 24 * HOUR`, `WEEK = 7 * DAY`, `YEAR = 365 * DAY` in `src/builtins/time/compat.rs`
- Add `"d"`, `"w"`, `"y"` arms to the unit-matching block in `parse_duration()`

### Tests

New `tests/interpreter/cases/builtins/time/duration_units.yaml` covering:
- Individual units: 1d = 86400000000000 ns, 1w = 604800000000000 ns, 1y = 31536000000000000 ns
- Mixed compound: "1d12h" = 129600000000000 ns

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>