### PR TITLE
fix(builtins): guard against exponent-too-large in units.parse/parse_bytes

### DIFF
--- a/src/builtins/units.rs
+++ b/src/builtins/units.rs
@@ -95,6 +95,10 @@ fn parse(span: &Span, params: &[Ref<Expr>], args: &[Value], _strict: bool) -> Re
     // a stable representation that includes an explicit leading digit.
     let canonical_part = canonicalize_number_part(number_part);
 
+    if exponent_too_large(canonical_part.as_ref()) {
+        bail!(params[0].span().error("units.parse: exponent too large"));
+    }
+
     if let Some(e) = ten_exp(suffix) {
         let combined = combine_decimal_exponent(canonical_part.as_ref(), e)
             .ok_or_else(|| params[0].span().error("could not parse number"))?;
@@ -168,6 +172,12 @@ fn parse_bytes(span: &Span, params: &[Ref<Expr>], args: &[Value], strict: bool) 
     // Canonicalize quirky literals (e.g. ".5", "-.1") so downstream parsing always sees
     // a stable representation that includes an explicit leading digit.
     let canonical_part = canonicalize_number_part(number_part);
+
+    if exponent_too_large(canonical_part.as_ref()) {
+        bail!(params[0]
+            .span()
+            .error("units.parse_bytes: exponent too large"));
+    }
 
     if let Some(e) = twob_exp(suffix) {
         let mut number = match Number::from_str(canonical_part.as_ref()) {
@@ -244,4 +254,12 @@ fn split_decimal_exponent(number: &str) -> Option<(&str, i32)> {
     }
     let exponent = exp_part.parse::<i32>().ok()?;
     Some((mantissa, exponent))
+}
+
+fn exponent_too_large(number: &str) -> bool {
+    number
+        .find(['e', 'E'])
+        .and_then(|idx| number.get(idx + 1..))
+        .map(|exponent| exponent.strip_prefix(['+', '-']).unwrap_or(exponent))
+        .is_some_and(|digits| digits.len() > 6)
 }

--- a/tests/interpreter/cases/builtins/units/exponent.yaml
+++ b/tests/interpreter/cases/builtins/units/exponent.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+cases:
+  - note: parse-exponent-too-large
+    data: {}
+    modules:
+      - |
+        package test
+        x = units.parse("1e9999999K")
+    query: data.test.x
+    error: "units.parse: exponent too large"
+
+  - note: parse-bytes-exponent-too-large
+    data: {}
+    modules:
+      - |
+        package test
+        x = units.parse_bytes("1e9999999Ki")
+    query: data.test.x
+    error: "units.parse_bytes: exponent too large"
+
+  - note: parse-normal-exponent-ok
+    data: {}
+    modules:
+      - |
+        package test
+        x = units.parse("1e6K")
+    query: data.test.x
+    want_result: 1e9


### PR DESCRIPTION
Inputs like `"1e9999999K"` caused downstream numeric overflow because Number::from_str was called with a string containing an enormous exponent. Guard against this by rejecting any number whose exponent field exceeds 6 digits before dispatching to the SI/binary-prefix matching logic.

### Changes

- New `exponent_too_large(number: &str) -> bool` helper: finds the `e`/`E` position, strips an optional sign, and returns `true` when the digit count exceeds 6
- Call it in `parse()` (units.parse) immediately after canonicalization, before `ten_exp`/`two_exp` dispatch
- Call it in `parse_bytes()` (units.parse_bytes) before `twob_exp`/`tenb_exp` dispatch
- Both sites emit a clear error message rather than propagating through Number arithmetic

### Tests

New `tests/interpreter/cases/builtins/units/exponent.yaml` covering:
- `units.parse("1e9999999K")` errors with "exponent too large"
- `units.parse_bytes("1e9999999Ki")` errors with "exponent too large"
- `units.parse("1e6K")` succeeds (1e9) — boundary case that must still work

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>